### PR TITLE
fix: Replace asyncio.timeout with async_timeout for Python 3.10 compatibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 from typing import Optional, List
 
+from async_timeout import timeout
 from google.genai import types
 from google.adk.models.google_llm import Gemini
 from google.adk.runners import Runner
@@ -241,11 +242,11 @@ async def create_itinerary(
     event_count = 0  # Track events for timeout error reporting
 
     try:
-        # WHY ASYNCIO.TIMEOUT: Wraps all 3 workflow phases in a single timeout context.
+        # WHY TIMEOUT: Wraps all 3 workflow phases in a single timeout context.
         # If total execution exceeds workflow_timeout seconds, raises TimeoutError with
         # diagnostic info (how many events processed before timeout).
         # This is a safety mechanism - workflows should complete in <2 minutes typically.
-        async with asyncio.timeout(workflow_timeout):
+        async with timeout(workflow_timeout):
             # Phase 1: Extract book metadata
             logger.info("phase_1_start", phase="metadata_extraction")
             print("Phase 1: Extracting book metadata...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "ipykernel>=6.25.0",
     "ipywidgets>=8.1.0",
     "streamlit>=1.28.0",
+    "async-timeout>=4.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Fixes #1 - Replace `asyncio.timeout()` with `async_timeout` package for Python 3.10 compatibility.

## Changes

- Replace `asyncio.timeout()` with `async_timeout.timeout()` in main.py
- Add `async-timeout>=4.0.0` dependency to pyproject.toml
- Update imports to use async_timeout

## Testing

The code now supports Python 3.10+ environments. Please test on a Python 3.10 environment to verify compatibility.

---

Generated with [Claude Code](https://claude.ai/code)