### PR TITLE
Add Langfuse configuration support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,8 @@ AGENT_TIMEOUT=60
 # Logging
 LOG_LEVEL=INFO
 ENABLE_ADK_DEBUG=false
+
+# Langfuse Configuration
+LANGFUSE_SECRET_KEY=sk-lf-xxx
+LANGFUSE_PUBLIC_KEY=pk-lf-xxx
+LANGFUSE_HOST=https://cloud.langfuse.com

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ pip install -e ".[dev]"
 # Configure API key
 cp .env.example .env
 # Edit .env and add your GOOGLE_API_KEY
+
+# Optional: Configure Langfuse for LLM observability
+# Add your Langfuse credentials to .env:
+# - LANGFUSE_SECRET_KEY
+# - LANGFUSE_PUBLIC_KEY
+# - LANGFUSE_HOST
 ```
 
 ### Run

--- a/common/config.py
+++ b/common/config.py
@@ -27,6 +27,9 @@ class Config:
     agent_timeout: int
     log_level: str
     enable_adk_debug: bool
+    langfuse_secret_key: Optional[str]
+    langfuse_public_key: Optional[str]
+    langfuse_host: Optional[str]
 
 
 def _require_env(key: str) -> str:
@@ -66,6 +69,9 @@ def load_config() -> Config:
 
     Optional:
         - DATABASE_URL: Database connection string
+        - LANGFUSE_SECRET_KEY: Langfuse secret key
+        - LANGFUSE_PUBLIC_KEY: Langfuse public key
+        - LANGFUSE_HOST: Langfuse host URL
 
     Returns:
         Config object
@@ -84,6 +90,9 @@ def load_config() -> Config:
         agent_timeout=_require_env_int("AGENT_TIMEOUT"),
         log_level=_require_env("LOG_LEVEL").upper(),
         enable_adk_debug=_require_env_bool("ENABLE_ADK_DEBUG"),
+        langfuse_secret_key=os.getenv("LANGFUSE_SECRET_KEY"),
+        langfuse_public_key=os.getenv("LANGFUSE_PUBLIC_KEY"),
+        langfuse_host=os.getenv("LANGFUSE_HOST"),
     )
 
 


### PR DESCRIPTION
- Add Langfuse credentials to .env.example
- Update common/config.py to load Langfuse settings
- Add Langfuse documentation to README