### PR TITLE
Fix SQLite async driver configuration for Google ADK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ GOOGLE_API_KEY=your-google-ai-api-key-here
 
 # Database Configuration
 USE_DATABASE=false
-DATABASE_URL=sqlite:///storyland_sessions.db
+DATABASE_URL=sqlite+aiosqlite:///storyland_sessions.db
 
 # Session Configuration
 SESSION_MAX_EVENTS=20

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -236,7 +236,7 @@ print(state.get('user:preferences'))
 
 - Default: `storyland_sessions.db` in current directory
 - Configured via: `DATABASE_URL` environment variable
-- Format: `sqlite:///path/to/database.db`
+- Format: `sqlite+aiosqlite:///path/to/database.db`
 
 ## Backup & Maintenance
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,7 @@ GOOGLE_API_KEY=your-google-ai-api-key-here
 
 # Database (optional)
 USE_DATABASE=false
-DATABASE_URL=sqlite:///storyland_sessions.db
+DATABASE_URL=sqlite+aiosqlite:///storyland_sessions.db
 
 # Session (optional)
 SESSION_MAX_EVENTS=20
@@ -43,7 +43,7 @@ ENABLE_ADK_DEBUG=false  # Enable DEBUG for ADK internal logs
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `USE_DATABASE` | Enable SQLite persistence | `false` |
-| `DATABASE_URL` | SQLite database path | `sqlite:///storyland_sessions.db` |
+| `DATABASE_URL` | SQLite database path | `sqlite+aiosqlite:///storyland_sessions.db` |
 
 ### Session Settings
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,7 +38,7 @@
 
    # Optional - Enable database persistence
    USE_DATABASE=false
-   DATABASE_URL=sqlite:///storyland_sessions.db
+   DATABASE_URL=sqlite+aiosqlite:///storyland_sessions.db
    ```
 
 ## Quick Start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "ipywidgets>=8.1.0",
     "streamlit>=1.28.0",
     "async-timeout>=4.0.0",
+    "aiosqlite>=0.19.0",
 ]
 
 [project.optional-dependencies]

--- a/services/session_service.py
+++ b/services/session_service.py
@@ -18,8 +18,8 @@ def create_session_service(
     Factory for creating the appropriate session service.
 
     Args:
-        connection_string: Optional database URL (e.g., "sqlite:///sessions.db")
-                          If not provided, defaults to "sqlite:///storyland_sessions.db"
+        connection_string: Optional database URL (e.g., "sqlite+aiosqlite:///sessions.db")
+                          If not provided, defaults to "sqlite+aiosqlite:///storyland_sessions.db"
                           Note: This is passed as 'db_url' to DatabaseSessionService
         use_database: If True, use DatabaseSessionService; otherwise InMemorySessionService
 
@@ -35,7 +35,7 @@ def create_session_service(
 
         # Custom SQLite database
         >>> session_service = create_session_service(
-        ...     connection_string="sqlite:///custom.db",
+        ...     connection_string="sqlite+aiosqlite:///custom.db",
         ...     use_database=True
         ... )
 
@@ -48,8 +48,8 @@ def create_session_service(
     if use_database:
         # Production: Database-backed session service
         if not connection_string:
-            # Default to SQLite in the current directory
-            connection_string = "sqlite:///storyland_sessions.db"
+            # Default to SQLite with async driver in the current directory
+            connection_string = "sqlite+aiosqlite:///storyland_sessions.db"
 
         print(f"Using DatabaseSessionService with: {connection_string}")
         return DatabaseSessionService(db_url=connection_string)
@@ -72,7 +72,7 @@ def create_session_service_from_env():
 
     Examples:
         # In .env file:
-        # DATABASE_URL=sqlite:///storyland_sessions.db
+        # DATABASE_URL=sqlite+aiosqlite:///storyland_sessions.db
         # USE_DATABASE=true
 
         >>> session_service = create_session_service_from_env()

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -37,7 +37,7 @@ class TestCreateSessionService:
     def test_create_database_service(self, tmp_path):
         """Test use_database=True creates DatabaseSessionService."""
         db_path = tmp_path / "test.db"
-        connection_string = f"sqlite:///{db_path}"
+        connection_string = f"sqlite+aiosqlite:///{db_path}"
 
         service = create_session_service(
             connection_string=connection_string,
@@ -55,7 +55,7 @@ class TestCreateSessionService:
     def test_create_session_service_ignores_connection_string_when_not_database(self):
         """Test connection_string is ignored when use_database=False."""
         service = create_session_service(
-            connection_string="sqlite:///should_be_ignored.db",
+            connection_string="sqlite+aiosqlite:///should_be_ignored.db",
             use_database=False
         )
 
@@ -92,7 +92,7 @@ class TestCreateSessionServiceFromEnv:
 
     @patch.dict(os.environ, {
         'USE_DATABASE': 'true',
-        'DATABASE_URL': 'sqlite:///custom_test.db'
+        'DATABASE_URL': 'sqlite+aiosqlite:///custom_test.db'
     })
     def test_from_env_with_custom_database_url(self):
         """Test uses DATABASE_URL from environment."""


### PR DESCRIPTION
## Problem
Google ADK now requires async database drivers. Current SQLite URL format (`sqlite:///`) fails.

## Solution
Updated DATABASE_URL format throughout the codebase to use `sqlite+aiosqlite:///` for async support.

## Changes
- Updated `.env.example` with correct URL format
- Added `aiosqlite>=0.19.0` dependency to `pyproject.toml`
- Updated all documentation files
- Updated default connection strings in `services/session_service.py`
- Updated test fixtures to use new format

Fixes #4

Generated with [Claude Code](https://claude.ai/code)