### PR TITLE
fix: handle None token counts from Gemini when model returns no content

### DIFF
--- a/plugins/langfuse_plugin.py
+++ b/plugins/langfuse_plugin.py
@@ -302,18 +302,18 @@ class LangfusePlugin(BasePlugin):
             if hasattr(response, 'usage_metadata'):
                 metadata = response.usage_metadata
                 return TokenUsage(
-                    input_tokens=getattr(metadata, 'prompt_token_count', 0),
-                    output_tokens=getattr(metadata, 'candidates_token_count', 0),
-                    total_tokens=getattr(metadata, 'total_token_count', 0),
+                    input_tokens=getattr(metadata, 'prompt_token_count', 0) or 0,
+                    output_tokens=getattr(metadata, 'candidates_token_count', 0) or 0,
+                    total_tokens=getattr(metadata, 'total_token_count', 0) or 0,
                 )
 
             # Alternative: Try dict-like access
             if isinstance(response, dict) and 'usage_metadata' in response:
                 metadata = response['usage_metadata']
                 return TokenUsage(
-                    input_tokens=metadata.get('prompt_token_count', 0),
-                    output_tokens=metadata.get('candidates_token_count', 0),
-                    total_tokens=metadata.get('total_token_count', 0),
+                    input_tokens=metadata.get('prompt_token_count') or 0,
+                    output_tokens=metadata.get('candidates_token_count') or 0,
+                    total_tokens=metadata.get('total_token_count') or 0,
                 )
 
             return None


### PR DESCRIPTION
## Summary

- `candidates_token_count` is `None` (not `0`) in Gemini responses when an agent produces only a function call with no text output (e.g. `reader_profile_agent`)
- `getattr(obj, attr, default)` returns `None` in this case because the attribute *exists* — the default only kicks in for missing attributes
- Added `or 0` fallback to all token count extractions in `_extract_token_usage()` to prevent `TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'`

## Test plan

- [x] 245 unit tests pass (`make test`)
- [x] 7 integration tests pass (`make test-integration`)
- [x] Confirmed the crash was observed in GitHub Actions after PR #145 merged; this commit fixes the root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)