### PR TITLE
feat(telemetry): server-side core-funnel events behind ANALYTICS_ENAB…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,8 @@ ENABLE_ADK_DEBUG=false
 LANGFUSE_SECRET_KEY=sk-lf-xxx
 LANGFUSE_PUBLIC_KEY=pk-lf-xxx
 LANGFUSE_HOST=https://cloud.langfuse.com
+
+# Analytics / Telemetry
+# Server-side core-funnel telemetry (search_submitted/result_shown/search_empty/search_failed).
+# Off by default; additive logging seam that complements frontend GA4.
+ANALYTICS_ENABLED=false

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -31,6 +31,23 @@ from core.events import (
     WorkflowComplete,
 )
 from core.executor import WorkflowExecutor
+from core.telemetry import (
+    FunnelTelemetry,
+    SearchEntry,
+    get_funnel_telemetry,
+    track_funnel,
+)
+from functools import lru_cache
+
+
+@lru_cache(maxsize=1)
+def _funnel_telemetry() -> FunnelTelemetry:
+    """Build funnel telemetry once from app config; disabled on any failure."""
+    try:
+        from common.config import get_config
+        return get_funnel_telemetry(get_config())
+    except Exception:
+        return FunnelTelemetry(enabled=False)
 
 
 def _sse(event_type: str, data: str) -> dict:
@@ -129,12 +146,20 @@ async def discover_stream(
     executor: WorkflowExecutor,
 ) -> AsyncGenerator[dict, None]:
     """Run phases 1-2 via executor and yield SSE events."""
-    async for event in executor.discover(
-        book_title=book_title,
-        author=author,
-        preferences=preferences,
+    tracked = track_funnel(
+        executor.discover(
+            book_title=book_title,
+            author=author,
+            preferences=preferences,
+            user_id=user_id,
+        ),
+        telemetry=_funnel_telemetry(),
+        entry=SearchEntry.BOOK,
         user_id=user_id,
-    ):
+        result_types=(RegionsReady,),
+        is_empty=lambda e: not getattr(e, "regions", None),
+    )
+    async for event in tracked:
         yield domain_event_to_sse(event)
 
 
@@ -165,16 +190,24 @@ async def local_atmosphere_stream(
     executor: WorkflowExecutor,
 ) -> AsyncGenerator[dict, None]:
     """Run the local-atmosphere flow via executor and yield SSE events."""
-    async for event in executor.local_atmosphere(
-        book_title=book_title,
-        author=author,
-        location_label=location_label,
-        lat=lat,
-        lng=lng,
-        radius_km=radius_km,
-        preferences=preferences,
+    tracked = track_funnel(
+        executor.local_atmosphere(
+            book_title=book_title,
+            author=author,
+            location_label=location_label,
+            lat=lat,
+            lng=lng,
+            radius_km=radius_km,
+            preferences=preferences,
+            user_id=user_id,
+        ),
+        telemetry=_funnel_telemetry(),
+        entry=SearchEntry.PLACE,
         user_id=user_id,
-    ):
+        result_types=(ItineraryReady,),
+        is_empty=lambda e: not getattr(e, "itinerary", None),
+    )
+    async for event in tracked:
         yield domain_event_to_sse(event)
 
 

--- a/common/config.py
+++ b/common/config.py
@@ -32,6 +32,7 @@ class Config:
     langfuse_host: Optional[str]
     environment: str
     internal_api_secret: str
+    analytics_enabled: bool
 
 
 def _require_env(key: str) -> str:
@@ -75,6 +76,7 @@ def load_config() -> Config:
         - LANGFUSE_PUBLIC_KEY: Langfuse public key
         - LANGFUSE_HOST: Langfuse host URL
         - ENVIRONMENT: deployment environment tag (default: "local")
+        - ANALYTICS_ENABLED: emit server-side funnel telemetry (default: "false")
 
     Returns:
         Config object
@@ -98,6 +100,9 @@ def load_config() -> Config:
         langfuse_host=os.getenv("LANGFUSE_HOST"),
         environment=os.getenv("ENVIRONMENT", "local"),
         internal_api_secret=os.getenv("INTERNAL_API_SECRET", ""),
+        # Optional, additive: server-side funnel telemetry. Off by default so
+        # wiring it in is a no-op until explicitly enabled.
+        analytics_enabled=os.getenv("ANALYTICS_ENABLED", "false").lower() == "true",
     )
 
 

--- a/core/telemetry.py
+++ b/core/telemetry.py
@@ -1,0 +1,128 @@
+"""
+Server-side core-funnel telemetry (additive, feature-flagged).
+
+Why this exists
+---------------
+GA4 already runs on the frontend, but client-side analytics is unreliable for
+exactly the signals the Product Analyst needs in the weekly review: failed
+searches, real backend latency, and the book-vs-place entry split. This module
+emits those funnel stages from the server, where they can always be observed.
+
+It is intentionally a thin logging seam. When ``ANALYTICS_ENABLED`` is false
+(the default) every call is a no-op, so wiring it in changes nothing in
+production until the flag is flipped. A later slice can forward these same
+events to the GA4 Measurement Protocol or PostHog without touching call sites.
+"""
+
+from __future__ import annotations
+
+import time
+from enum import Enum
+from typing import AsyncGenerator, Callable, Optional, Tuple, Type
+
+from common.logging import get_logger
+from core.events import DomainEvent, WorkflowError
+
+logger = get_logger("storyland.telemetry.funnel")
+
+
+class FunnelStage(str, Enum):
+    """Core funnel stages emitted from the backend."""
+
+    SEARCH_SUBMITTED = "search_submitted"
+    RESULT_SHOWN = "result_shown"
+    SEARCH_EMPTY = "search_empty"
+    SEARCH_FAILED = "search_failed"
+
+
+class SearchEntry(str, Enum):
+    """How the search was started -- the funnel's first dimension."""
+
+    BOOK = "book"  # discover flow: starts from a book
+    PLACE = "place"  # local-atmosphere flow: starts from a place/location
+
+
+class FunnelTelemetry:
+    """Emits structured funnel events. No-op unless explicitly enabled."""
+
+    def __init__(self, enabled: bool, environment: str = "local") -> None:
+        self._enabled = enabled
+        self._environment = environment
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def emit(
+        self,
+        stage: FunnelStage,
+        *,
+        entry: SearchEntry,
+        user_id: str,
+        latency_ms: Optional[int] = None,
+        **fields: object,
+    ) -> None:
+        """Record one funnel event. Silently does nothing when disabled."""
+        if not self._enabled:
+            return
+        extra = {k: v for k, v in fields.items() if v is not None}
+        logger.info(
+            "funnel_event",
+            stage=stage.value,
+            entry=entry.value,
+            user_id=user_id,
+            latency_ms=latency_ms,
+            environment=self._environment,
+            **extra,
+        )
+
+
+def get_funnel_telemetry(config: object) -> FunnelTelemetry:
+    """Build a FunnelTelemetry from app config (safe defaults if absent)."""
+    return FunnelTelemetry(
+        enabled=bool(getattr(config, "analytics_enabled", False)),
+        environment=str(getattr(config, "environment", "local")),
+    )
+
+
+async def track_funnel(
+    stream: AsyncGenerator[DomainEvent, None],
+    *,
+    telemetry: FunnelTelemetry,
+    entry: SearchEntry,
+    user_id: str,
+    result_types: Tuple[Type[DomainEvent], ...],
+    is_empty: Callable[[DomainEvent], bool],
+) -> AsyncGenerator[DomainEvent, None]:
+    """
+    Wrap a domain-event stream and emit funnel stages around it.
+
+    Emits ``search_submitted`` on entry, then exactly one terminal stage:
+    ``result_shown`` (a non-empty result event was seen), ``search_empty``
+    (the flow finished with no usable result), or ``search_failed`` (a
+    WorkflowError was emitted or an exception propagated). Events pass through
+    untouched, so this is transparent to consumers.
+    """
+    start = time.monotonic()
+    saw_result = False
+    saw_error = False
+    telemetry.emit(FunnelStage.SEARCH_SUBMITTED, entry=entry, user_id=user_id)
+    try:
+        async for event in stream:
+            if isinstance(event, result_types) and not is_empty(event):
+                saw_result = True
+            elif isinstance(event, WorkflowError):
+                saw_error = True
+            yield event
+    except Exception:
+        saw_error = True
+        raise
+    finally:
+        latency_ms = int((time.monotonic() - start) * 1000)
+        if saw_error:
+            stage = FunnelStage.SEARCH_FAILED
+        elif saw_result:
+            stage = FunnelStage.RESULT_SHOWN
+        else:
+            stage = FunnelStage.SEARCH_EMPTY
+        telemetry.emit(stage, entry=entry, user_id=user_id, latency_ms=latency_ms)

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1,0 +1,131 @@
+"""Unit tests for server-side funnel telemetry (core/telemetry.py)."""
+
+import pytest
+
+from core.events import RegionsReady, ItineraryReady, WorkflowError
+from core.telemetry import (
+    FunnelStage,
+    FunnelTelemetry,
+    SearchEntry,
+    get_funnel_telemetry,
+    track_funnel,
+)
+
+
+class _Recorder(FunnelTelemetry):
+    """Telemetry that records emitted stages instead of logging."""
+
+    def __init__(self):
+        super().__init__(enabled=True)
+        self.events = []
+
+    def emit(self, stage, *, entry, user_id, latency_ms=None, **fields):
+        self.events.append((stage, entry, user_id, latency_ms))
+
+
+async def _gen(events):
+    for e in events:
+        yield e
+
+
+@pytest.mark.asyncio
+async def test_disabled_telemetry_is_noop():
+    t = FunnelTelemetry(enabled=False)
+    # Should not raise and should record nothing observable.
+    t.emit(FunnelStage.SEARCH_SUBMITTED, entry=SearchEntry.BOOK, user_id="u")
+    assert t.enabled is False
+
+
+def test_get_funnel_telemetry_reads_config():
+    class Cfg:
+        analytics_enabled = True
+        environment = "prod"
+
+    t = get_funnel_telemetry(Cfg())
+    assert t.enabled is True
+
+
+def test_get_funnel_telemetry_defaults_when_missing():
+    t = get_funnel_telemetry(object())
+    assert t.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_result_shown_on_non_empty_regions():
+    rec = _Recorder()
+    regions = RegionsReady(job_id="j", regions=[{"id": 1}], analysis_note="n")
+    out = [
+        e
+        async for e in track_funnel(
+            _gen([regions]),
+            telemetry=rec,
+            entry=SearchEntry.BOOK,
+            user_id="u",
+            result_types=(RegionsReady,),
+            is_empty=lambda e: not getattr(e, "regions", None),
+        )
+    ]
+    assert out == [regions]  # passthrough preserved
+    stages = [e[0] for e in rec.events]
+    assert stages == [FunnelStage.SEARCH_SUBMITTED, FunnelStage.RESULT_SHOWN]
+
+
+@pytest.mark.asyncio
+async def test_search_empty_on_empty_regions():
+    rec = _Recorder()
+    empty = RegionsReady(job_id="j", regions=[], analysis_note="")
+    _ = [
+        e
+        async for e in track_funnel(
+            _gen([empty]),
+            telemetry=rec,
+            entry=SearchEntry.BOOK,
+            user_id="u",
+            result_types=(RegionsReady,),
+            is_empty=lambda e: not getattr(e, "regions", None),
+        )
+    ]
+    assert rec.events[-1][0] == FunnelStage.SEARCH_EMPTY
+
+
+@pytest.mark.asyncio
+async def test_search_failed_on_workflow_error():
+    rec = _Recorder()
+    err = WorkflowError(message="boom", error_type="X", phase=None)
+    _ = [
+        e
+        async for e in track_funnel(
+            _gen([err]),
+            telemetry=rec,
+            entry=SearchEntry.PLACE,
+            user_id="u",
+            result_types=(ItineraryReady,),
+            is_empty=lambda e: not getattr(e, "itinerary", None),
+        )
+    ]
+    assert rec.events[-1][0] == FunnelStage.SEARCH_FAILED
+    assert rec.events[-1][1] == SearchEntry.PLACE
+
+
+@pytest.mark.asyncio
+async def test_search_failed_on_exception_propagates():
+    rec = _Recorder()
+
+    async def _boom():
+        if False:
+            yield  # make it an async generator
+        raise RuntimeError("kaboom")
+
+    with pytest.raises(RuntimeError):
+        _ = [
+            e
+            async for e in track_funnel(
+                _boom(),
+                telemetry=rec,
+                entry=SearchEntry.BOOK,
+                user_id="u",
+                result_types=(RegionsReady,),
+                is_empty=lambda e: False,
+            )
+        ]
+    assert rec.events[-1][0] == FunnelStage.SEARCH_FAILED


### PR DESCRIPTION
…LED flag

Adds an additive, flag-guarded telemetry seam that emits core-funnel stages (search_submitted / result_shown / search_empty / search_failed) with backend latency and the book-vs-place entry split from the discover and local-atmosphere streams. No-op unless ANALYTICS_ENABLED=true. Complements frontend GA4 by covering the signals client analytics misses (failed searches, real latency).

Implements approved opportunity 'Wire Product Analyst to GA4 + verify core-funnel event coverage' (RICE 85, G1-approved 2026-06-16).