### PR TITLE
Cache book-to-regions discovery results to speed up and cut the cost of repeat searches

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,9 @@ ENABLE_ADK_DEBUG=false
 LANGFUSE_SECRET_KEY=sk-lf-xxx
 LANGFUSE_PUBLIC_KEY=pk-lf-xxx
 LANGFUSE_HOST=https://cloud.langfuse.com
+
+# Result Cache (in-process; caches the Discovery book->regions chain)
+# Default OFF — when false, discover() behavior is byte-for-byte unchanged.
+ENABLE_RESULT_CACHE=false
+CACHE_TTL_SECONDS=86400
+CACHE_MAX_ENTRIES=500

--- a/README.md
+++ b/README.md
@@ -334,10 +334,11 @@ Agent prompts include reliability improvements:
 ## Testing
 
 ```bash
-make test                # Unit tests (362 tests)
-make test-integration    # Integration tests with VCR cassettes
-make test-all            # Both
-make test-cov            # With coverage
+make test                  # Unit tests (376 tests)
+make test-integration      # Integration tests with VCR cassettes (excludes real_api)
+make test-integration-live # Live tests that hit real APIs (real_api marker; uses quota)
+make test-all              # Both
+make test-cov              # With coverage
 ```
 
 | Module | Tests | Description |
@@ -347,10 +348,24 @@ make test-cov            # With coverage
 | `test_agents.py` | 49 | Agent factory functions (incl. book recommendation pipeline) |
 | `test_services.py` | 10 | Session service |
 | `test_llm_scorer.py` | 23 | LLM scoring models and prompts |
+| `test_cache.py` | 14 | Discovery result cache (TTL/LRU, key normalization, cache-hit short-circuit) |
 | `test_core.py` | 89 | Events, session state, extraction, regions, prompts (incl. book recs) |
 | `test_api.py` | 108 | API models, endpoints, SSE streaming (incl. book recommendations) |
 
 Integration tests use [VCR.py](https://vcrpy.readthedocs.io/) to record/replay HTTP interactions. For quality evaluation, see [evaluation/README.md](evaluation/README.md).
+
+### Live cache verification (`real_api`)
+
+`tests/integration/test_cache_real_api.py` is the live counterpart to the mocked
+cache-hit unit test. With `ENABLE_RESULT_CACHE` on, it calls `discover()` twice
+with an identical book/author and meters `Gemini.generate_content_async`
+directly (call count + summed `usage_metadata.total_token_count`) to prove the
+**second call is a cache hit that makes zero new Gemini calls and consumes zero
+new Gemini tokens** while returning the same regions. It is marked `real_api`, so
+it is excluded from the default `make test-integration` run and only fires via
+`make test-integration-live`. It hits the live API (no VCR — recorded responses
+would defeat token counting), so it needs `GOOGLE_API_KEY` and uses a small
+amount of quota; it skips when the key is absent.
 
 ## Troubleshooting
 

--- a/common/config.py
+++ b/common/config.py
@@ -32,6 +32,11 @@ class Config:
     langfuse_host: Optional[str]
     environment: str
     internal_api_secret: str
+    # Result cache (opportunity: cache expensive recommendation calls).
+    # Defaults keep the cache OFF so existing deploys are byte-for-byte unchanged.
+    enable_result_cache: bool
+    cache_ttl_seconds: int
+    cache_max_entries: int
 
 
 def _require_env(key: str) -> str:
@@ -50,6 +55,22 @@ def _require_env_int(key: str) -> int:
 def _require_env_bool(key: str) -> bool:
     """Get required boolean environment variable."""
     return _require_env(key).lower() == "true"
+
+
+def _env_bool(key: str, default: bool) -> bool:
+    """Get optional boolean environment variable with a default."""
+    value = os.getenv(key)
+    if value is None:
+        return default
+    return value.lower() == "true"
+
+
+def _env_int(key: str, default: int) -> int:
+    """Get optional integer environment variable with a default."""
+    value = os.getenv(key)
+    if value is None:
+        return default
+    return int(value)
 
 
 def load_config() -> Config:
@@ -98,6 +119,9 @@ def load_config() -> Config:
         langfuse_host=os.getenv("LANGFUSE_HOST"),
         environment=os.getenv("ENVIRONMENT", "local"),
         internal_api_secret=os.getenv("INTERNAL_API_SECRET", ""),
+        enable_result_cache=_env_bool("ENABLE_RESULT_CACHE", False),
+        cache_ttl_seconds=_env_int("CACHE_TTL_SECONDS", 86400),
+        cache_max_entries=_env_int("CACHE_MAX_ENTRIES", 500),
     )
 
 

--- a/core/cache.py
+++ b/core/cache.py
@@ -1,0 +1,91 @@
+"""
+Tiny in-process TTL + LRU cache for expensive recommendation results.
+
+Scope (G1, opportunity "Cache expensive Gemini / Google Books recommendation
+calls"): an in-memory, per-process cache with no external dependencies. It is
+used to short-circuit the most-repeated, highest-cost chain (Discovery:
+book -> regions) when the same book/author/preferences are requested again.
+
+Design notes:
+- Monotonic-clock expiry (immune to wall-clock changes).
+- ``max_entries`` cap with oldest-first ("LRU-ish": insertion/refresh order)
+  eviction.
+- An ``asyncio.Lock`` guards all mutations so concurrent requests are safe.
+- Values are returned as-is; callers cache only already-validated data, so a
+  hit can never introduce a *new* fabrication. Staleness is bounded by the TTL.
+
+This cache is intentionally simple. A shared/persistent cache (Redis/KV) is an
+explicit follow-up and would add infrastructure (G4), so it is out of scope.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import OrderedDict
+from typing import Any, Optional
+
+
+class TTLCache:
+    """An async-safe, bounded TTL cache with oldest-first eviction.
+
+    Args:
+        ttl_seconds: Time-to-live for each entry, in seconds. Entries older
+            than this are treated as misses and dropped on access.
+        max_entries: Maximum number of live entries. When exceeded, the
+            oldest entry is evicted.
+        clock: Monotonic time source (override for tests). Defaults to
+            ``time.monotonic``.
+    """
+
+    def __init__(
+        self,
+        ttl_seconds: int,
+        max_entries: int,
+        clock=time.monotonic,
+    ) -> None:
+        if ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be positive")
+        if max_entries <= 0:
+            raise ValueError("max_entries must be positive")
+        self._ttl = ttl_seconds
+        self._max = max_entries
+        self._clock = clock
+        self._lock = asyncio.Lock()
+        # key -> (expires_at, value); ordered oldest-first for eviction.
+        self._store: "OrderedDict[str, tuple[float, Any]]" = OrderedDict()
+
+    async def get(self, key: str) -> Optional[Any]:
+        """Return the cached value for ``key`` or ``None`` on miss/expiry."""
+        async with self._lock:
+            entry = self._store.get(key)
+            if entry is None:
+                return None
+            expires_at, value = entry
+            if self._clock() >= expires_at:
+                # Expired: drop and report a miss.
+                self._store.pop(key, None)
+                return None
+            # Refresh recency so frequently used entries survive eviction.
+            self._store.move_to_end(key)
+            return value
+
+    async def set(self, key: str, value: Any) -> None:
+        """Store ``value`` under ``key``, evicting the oldest if over capacity."""
+        async with self._lock:
+            expires_at = self._clock() + self._ttl
+            if key in self._store:
+                self._store.pop(key, None)
+            self._store[key] = (expires_at, value)
+            self._store.move_to_end(key)
+            while len(self._store) > self._max:
+                # Evict oldest (FIFO/LRU-ish).
+                self._store.popitem(last=False)
+
+    async def clear(self) -> None:
+        """Drop all entries (used by tests and the rollback path)."""
+        async with self._lock:
+            self._store.clear()
+
+    def __len__(self) -> int:
+        return len(self._store)

--- a/core/executor.py
+++ b/core/executor.py
@@ -23,6 +23,7 @@ Usage (HTTP adapter):
 """
 
 import asyncio
+import hashlib
 import uuid
 from typing import AsyncGenerator, List, Optional
 
@@ -70,6 +71,7 @@ from .prompts import (
     build_composition_prompt,
     build_local_atmosphere_prompt,
 )
+from .cache import TTLCache
 from .regions import get_valid_region_ids, validate_region_selection
 from .session_state import SessionStateAccessor, SessionStateKeys
 from .types import ExecutorConfig
@@ -148,6 +150,17 @@ class WorkflowExecutor:
             use_database=config.use_database,
         )
         self._model = model or self._create_model()
+        # Optional in-process result cache for the Discovery chain.
+        # Disabled unless ENABLE_RESULT_CACHE is set, so default behavior
+        # is byte-for-byte unchanged.
+        self._discovery_cache = (
+            TTLCache(
+                ttl_seconds=config.cache_ttl_seconds,
+                max_entries=config.cache_max_entries,
+            )
+            if getattr(config, "enable_result_cache", False)
+            else None
+        )
 
     @property
     def session_service(self):
@@ -179,6 +192,68 @@ class WorkflowExecutor:
             public_key=self._config.langfuse_public_key,
             host=self._config.langfuse_host,
         )
+
+    async def _emit_cached_discovery(
+        self,
+        job_id: str,
+        user_id: str,
+        book_title: str,
+        author: str,
+        region_analysis: dict,
+    ) -> AsyncGenerator[DomainEvent, None]:
+        """Replay a cached discovery result without invoking Gemini.
+
+        The session already exists (created by ``discover`` before the cache
+        lookup). This writes the confirmed book metadata and the cached
+        region analysis into session state via ``append_event`` so the
+        downstream discover->compose handoff (which reads ``state.regions``)
+        behaves identically to a fresh run.
+        """
+        book_metadata = BookMetadata(
+            book_title=book_title,
+            author=author,
+            book_found=True,
+        )
+        yield MetadataReady(metadata=book_metadata.model_dump())
+
+        session = await self._session_service.get_session(
+            app_name=APP_NAME, user_id=user_id, session_id=job_id
+        )
+        cache_event = Event(
+            invocation_id="system",
+            author="system",
+            actions=EventActions(
+                state_delta={
+                    SessionStateKeys.BOOK_METADATA: book_metadata.model_dump(),
+                    SessionStateKeys.REGION_ANALYSIS: region_analysis,
+                }
+            ),
+        )
+        await self._session_service.append_event(session, cache_event)
+
+        yield RegionsReady(
+            job_id=job_id,
+            regions=region_analysis.get("regions", []),
+            analysis_note=region_analysis.get("analysis_note", ""),
+        )
+        yield WorkflowComplete(job_id=job_id)
+
+    @staticmethod
+    def _discovery_cache_key(
+        book_title: str, author: str, preferences: Optional[dict]
+    ) -> str:
+        """Build a normalized, versioned cache key for a discovery request.
+
+        Versioned prefix ('v1') lets a logic change invalidate cleanly.
+        """
+        norm_title = (book_title or "").strip().lower()
+        norm_author = (author or "").strip().lower()
+        # Stable hash of preferences regardless of key ordering.
+        pref_items = sorted((preferences or {}).items(), key=lambda kv: str(kv[0]))
+        pref_sig = hashlib.sha1(
+            repr(pref_items).encode("utf-8")
+        ).hexdigest()
+        return f"discover:v1:{norm_title}|{norm_author}|{pref_sig}"
 
     async def discover(
         self,
@@ -228,6 +303,26 @@ class WorkflowExecutor:
             return
 
         yield JobStarted(job_id=job_id)
+
+        # Cache fast-path: an identical book/author/preferences request reuses
+        # the previously computed (already validated) regions and makes ZERO
+        # Gemini calls. Only non-empty region sets are ever cached, so a hit
+        # cannot introduce a new fabrication; staleness is bounded by the TTL.
+        cache_key = None
+        if self._discovery_cache is not None:
+            cache_key = self._discovery_cache_key(book_title, author, preferences)
+            cached_region_analysis = await self._discovery_cache.get(cache_key)
+            if cached_region_analysis:
+                logger.info("discovery_cache_hit", job_id=job_id[:8])
+                async for ev in self._emit_cached_discovery(
+                    job_id=job_id,
+                    user_id=user_id,
+                    book_title=book_title,
+                    author=author,
+                    region_analysis=cached_region_analysis,
+                ):
+                    yield ev
+                return
 
         try:
             async with timeout(self._config.workflow_timeout):
@@ -301,6 +396,15 @@ class WorkflowExecutor:
                     job_id=job_id[:8],
                     num_regions=len(state.regions),
                 )
+
+                # Store on miss: cache only non-empty, schema-validated region
+                # sets so a future hit can safely short-circuit the chain.
+                if (
+                    self._discovery_cache is not None
+                    and cache_key is not None
+                    and state.regions
+                ):
+                    await self._discovery_cache.set(cache_key, state.region_analysis)
 
                 yield RegionsReady(
                     job_id=job_id,

--- a/core/types.py
+++ b/core/types.py
@@ -26,6 +26,10 @@ class ExecutorConfig:
     langfuse_public_key: Optional[str] = None
     langfuse_host: Optional[str] = None
     environment: str = "local"
+    # Result cache settings (carried through from common.config.Config).
+    enable_result_cache: bool = False
+    cache_ttl_seconds: int = 86400
+    cache_max_entries: int = 500
 
     @classmethod
     def from_config(cls, config) -> "ExecutorConfig":
@@ -40,4 +44,7 @@ class ExecutorConfig:
             langfuse_public_key=config.langfuse_public_key,
             langfuse_host=config.langfuse_host,
             environment=config.environment,
+            enable_result_cache=getattr(config, "enable_result_cache", False),
+            cache_ttl_seconds=getattr(config, "cache_ttl_seconds", 86400),
+            cache_max_entries=getattr(config, "cache_max_entries", 500),
         )

--- a/tests/integration/test_cache_real_api.py
+++ b/tests/integration/test_cache_real_api.py
@@ -1,0 +1,134 @@
+"""Real-API integration test for the Discovery result cache.
+
+Unlike ``tests/unit/test_cache.py`` (which mocks the discovery chain), this
+test exercises the cache against the *live* Gemini API:
+
+1. First ``discover()`` call is a cache MISS -> runs the real discovery chain,
+   makes one or more Gemini calls and consumes real tokens.
+2. Second ``discover()`` call with an identical book/author/preferences is a
+   cache HIT -> must make ZERO new Gemini calls and consume ZERO new Gemini
+   tokens, while returning the same previously-validated regions.
+
+"Gemini tokens" are measured at ground truth by metering
+``Gemini.generate_content_async`` directly (call count + summed
+``usage_metadata.total_token_count``), so the assertion does not depend on
+Langfuse being configured.
+
+Run with: ``make test-integration-real`` or
+``pytest tests/integration/test_cache_real_api.py -v -m real_api``.
+Requires ``GOOGLE_API_KEY``; skips otherwise.
+"""
+
+import os
+
+import pytest
+import google.adk.models.google_llm as google_llm
+
+from core.events import RegionsReady, WorkflowComplete, WorkflowError
+from core.executor import WorkflowExecutor
+from core.types import ExecutorConfig
+from services.session_service import create_session_service
+
+
+class _GeminiMeter:
+    """Counts live Gemini generation calls and the tokens they consume."""
+
+    def __init__(self):
+        self.calls = 0
+        self.total_tokens = 0
+
+
+def _install_gemini_meter(monkeypatch) -> _GeminiMeter:
+    """Wrap Gemini.generate_content_async to record real API usage.
+
+    Every discovery agent shares the Gemini class, so patching at the class
+    level captures all generation traffic the workflow produces.
+    """
+    meter = _GeminiMeter()
+    real_generate = google_llm.Gemini.generate_content_async
+
+    async def metered_generate(self, *args, **kwargs):
+        meter.calls += 1
+        async for response in real_generate(self, *args, **kwargs):
+            usage = getattr(response, "usage_metadata", None)
+            if usage is not None:
+                meter.total_tokens += getattr(usage, "total_token_count", 0) or 0
+            yield response
+
+    monkeypatch.setattr(
+        google_llm.Gemini, "generate_content_async", metered_generate
+    )
+    return meter
+
+
+def _first(events, event_type):
+    return next((e for e in events if isinstance(e, event_type)), None)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.real_api
+async def test_second_discover_is_cache_hit_with_zero_new_gemini_tokens(
+    real_api_key, monkeypatch
+):
+    """A repeated discover() must short-circuit with zero new Gemini tokens."""
+    meter = _install_gemini_meter(monkeypatch)
+
+    config = ExecutorConfig(
+        model_name=os.getenv("MODEL_NAME", "gemini-2.5-flash"),
+        google_api_key=real_api_key,
+        use_database=False,
+        enable_result_cache=True,
+        langfuse_secret_key=os.getenv("LANGFUSE_SECRET_KEY"),
+        langfuse_public_key=os.getenv("LANGFUSE_PUBLIC_KEY"),
+        langfuse_host=os.getenv("LANGFUSE_HOST", "https://cloud.langfuse.com"),
+    )
+    executor = WorkflowExecutor(
+        config=config,
+        session_service=create_session_service(use_database=False),
+    )
+    assert executor._discovery_cache is not None, "cache must be enabled"
+
+    request = {"book_title": "The Great Gatsby", "author": "F. Scott Fitzgerald"}
+
+    # --- Call 1: cache MISS, real discovery against live Gemini ---------------
+    first_events = [event async for event in executor.discover(**request)]
+
+    assert _first(first_events, WorkflowError) is None, "first discover errored"
+    first_regions = _first(first_events, RegionsReady)
+    assert first_regions is not None and first_regions.regions, (
+        "first discover must produce regions to populate the cache"
+    )
+    calls_after_first = meter.calls
+    tokens_after_first = meter.total_tokens
+    assert calls_after_first > 0, "miss should invoke Gemini at least once"
+    assert tokens_after_first > 0, "miss should consume real Gemini tokens"
+
+    # --- Call 2: identical request, expected cache HIT ------------------------
+    second_events = [event async for event in executor.discover(**request)]
+
+    assert _first(second_events, WorkflowError) is None, "second discover errored"
+    second_regions = _first(second_events, RegionsReady)
+    assert second_regions is not None, "second discover must return regions"
+
+    new_calls = meter.calls - calls_after_first
+    new_tokens = meter.total_tokens - tokens_after_first
+    assert new_calls == 0, (
+        f"cache hit must make zero Gemini calls, made {new_calls}"
+    )
+    assert new_tokens == 0, (
+        f"cache hit must consume zero new Gemini tokens, consumed {new_tokens}"
+    )
+
+    # The hit must serve the same previously-validated regions...
+    assert second_regions.regions == first_regions.regions
+    # ...and the cached fast-path reports no token usage at completion.
+    second_complete = _first(second_events, WorkflowComplete)
+    assert second_complete is not None
+    assert second_complete.token_usage is None
+
+    print(
+        f"\n✅ cache hit verified: call 1 = {calls_after_first} Gemini call(s) / "
+        f"{tokens_after_first} tokens; call 2 = +{new_calls} calls / "
+        f"+{new_tokens} tokens"
+    )

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,0 +1,176 @@
+"""Unit tests for the in-process TTL + LRU cache (core/cache.py)."""
+
+import pytest
+
+from core.cache import TTLCache
+from core.types import ExecutorConfig
+
+
+class _FakeClock:
+    """Controllable monotonic clock for deterministic TTL tests."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class TestTTLCacheBasics:
+    async def test_set_then_get_hit(self):
+        cache = TTLCache(ttl_seconds=100, max_entries=10)
+        await cache.set("k", {"regions": [1, 2]})
+        assert await cache.get("k") == {"regions": [1, 2]}
+
+    async def test_missing_key_returns_none(self):
+        cache = TTLCache(ttl_seconds=100, max_entries=10)
+        assert await cache.get("absent") is None
+
+    async def test_rejects_nonpositive_config(self):
+        with pytest.raises(ValueError):
+            TTLCache(ttl_seconds=0, max_entries=10)
+        with pytest.raises(ValueError):
+            TTLCache(ttl_seconds=10, max_entries=0)
+
+
+class TestTTLCacheExpiry:
+    async def test_entry_expires_after_ttl(self):
+        clock = _FakeClock()
+        cache = TTLCache(ttl_seconds=60, max_entries=10, clock=clock)
+        await cache.set("k", "v")
+        clock.advance(59)
+        assert await cache.get("k") == "v"  # still live
+        clock.advance(1)  # now at ttl boundary
+        assert await cache.get("k") is None  # expired
+        assert len(cache) == 0  # expired entry dropped on access
+
+
+class TestTTLCacheEviction:
+    async def test_oldest_evicted_when_over_capacity(self):
+        cache = TTLCache(ttl_seconds=100, max_entries=2)
+        await cache.set("a", 1)
+        await cache.set("b", 2)
+        await cache.set("c", 3)  # should evict "a"
+        assert await cache.get("a") is None
+        assert await cache.get("b") == 2
+        assert await cache.get("c") == 3
+        assert len(cache) == 2
+
+    async def test_get_refreshes_recency(self):
+        cache = TTLCache(ttl_seconds=100, max_entries=2)
+        await cache.set("a", 1)
+        await cache.set("b", 2)
+        await cache.get("a")  # refresh "a" so "b" is now oldest
+        await cache.set("c", 3)  # should evict "b", not "a"
+        assert await cache.get("a") == 1
+        assert await cache.get("b") is None
+        assert await cache.get("c") == 3
+
+    async def test_clear_empties_cache(self):
+        cache = TTLCache(ttl_seconds=100, max_entries=10)
+        await cache.set("a", 1)
+        await cache.clear()
+        assert await cache.get("a") is None
+        assert len(cache) == 0
+
+
+class TestDiscoveryCacheKey:
+    """The key builder lives on WorkflowExecutor; verify normalization."""
+
+    def _key(self, title, author, prefs):
+        from core.executor import WorkflowExecutor
+
+        return WorkflowExecutor._discovery_cache_key(title, author, prefs)
+
+    def test_normalizes_case_and_whitespace(self):
+        assert self._key("  1984 ", "George ORWELL", None) == self._key(
+            "1984", "george orwell", None
+        )
+
+    def test_preferences_order_independent(self):
+        k1 = self._key("Dune", "Herbert", {"pace": "slow", "mood": "epic"})
+        k2 = self._key("Dune", "Herbert", {"mood": "epic", "pace": "slow"})
+        assert k1 == k2
+
+    def test_different_preferences_differ(self):
+        k1 = self._key("Dune", "Herbert", {"mood": "epic"})
+        k2 = self._key("Dune", "Herbert", {"mood": "cozy"})
+        assert k1 != k2
+
+    def test_versioned_prefix(self):
+        assert self._key("Dune", "Herbert", None).startswith("discover:v1:")
+
+
+class TestExecutorConfigCacheDefaults:
+    def test_cache_off_by_default(self):
+        config = ExecutorConfig(
+            model_name="gemini-2.0-flash", google_api_key="test-key"
+        )
+        assert config.enable_result_cache is False
+        assert config.cache_ttl_seconds == 86400
+        assert config.cache_max_entries == 500
+
+
+class TestExecutorCacheHit:
+    """End-to-end: a primed cache short-circuits discover() with zero LLM work."""
+
+    async def test_cache_hit_skips_discovery_chain(self, monkeypatch):
+        import core.executor as ex
+        from core.executor import WorkflowExecutor, APP_NAME
+        from core.events import RegionsReady, WorkflowComplete
+        from services.session_service import create_session_service
+
+        # Any attempt to build/run the Gemini discovery chain must fail the test.
+        def _boom(*args, **kwargs):
+            raise AssertionError("discovery chain invoked on a cache hit")
+
+        monkeypatch.setattr(ex, "create_discovery_workflow", _boom)
+        monkeypatch.setattr(ex, "Runner", _boom)
+
+        config = ExecutorConfig(
+            model_name="gemini-2.0-flash",
+            google_api_key="test-key",
+            enable_result_cache=True,
+        )
+        executor = WorkflowExecutor(
+            config=config,
+            session_service=create_session_service(use_database=False),
+            model=object(),  # never used on a hit; bypass real Gemini construction
+        )
+
+        cached = {
+            "regions": [{"region_id": 1, "name": "Atlanta, United States"}],
+            "analysis_note": "cached note",
+        }
+        key = WorkflowExecutor._discovery_cache_key("1984", "George Orwell", None)
+        await executor._discovery_cache.set(key, cached)
+
+        events = [
+            e
+            async for e in executor.discover(
+                book_title="1984", author="George Orwell"
+            )
+        ]
+
+        regions_events = [e for e in events if isinstance(e, RegionsReady)]
+        assert len(regions_events) == 1
+        assert regions_events[0].regions == cached["regions"]
+        assert regions_events[0].analysis_note == "cached note"
+        assert any(isinstance(e, WorkflowComplete) for e in events)
+
+    async def test_cache_disabled_has_no_cache(self):
+        from core.executor import WorkflowExecutor
+        from services.session_service import create_session_service
+
+        config = ExecutorConfig(
+            model_name="gemini-2.0-flash", google_api_key="test-key"
+        )
+        executor = WorkflowExecutor(
+            config=config,
+            session_service=create_session_service(use_database=False),
+            model=object(),
+        )
+        assert executor._discovery_cache is None


### PR DESCRIPTION
## What this does

Adds an optional in-memory cache for the most expensive, most-repeated step of a search: the Discovery step that turns a book into a set of travel regions. When the same book, author, and preferences are searched again, we return the saved result instantly and skip the Gemini call entirely.

This is the first, smallest slice of the approved "cache expensive recommendation calls" work (RICE 80, G1 greenlight).

## Why

Right now every search re-runs the full Gemini multi-agent chain with no caching, so a popular title like "1984" is recomputed from scratch on every request. That's slow for the reader and adds up in API cost. Caching the discovery result makes repeat searches near-instant and cheaper.

## How it works

- **New `core/cache.py`** — a small, dependency-free in-memory cache with a time limit (TTL) and a maximum size that drops the oldest entries first. Safe for concurrent requests.
- **`discover()` checks the cache first.** On a hit it replays the saved regions and returns right away (zero Gemini calls); on a miss it runs exactly as before and then saves the result.
- **Safe by design.** Only complete, validated results are ever stored, so a cached answer can never be "more wrong" than a fresh one, and entries expire automatically after the TTL.

## How to turn it off

- Off by default. Controlled by `ENABLE_RESULT_CACHE` (with `CACHE_TTL_SECONDS` and `CACHE_MAX_ENTRIES`).
- With the flag off, search behaves exactly as it does today.
- Instant rollback: set `ENABLE_RESULT_CACHE=false`, or revert this PR.

## Scope

- Caches the discovery step only. Caching the later compose/recommend steps and moving to a shared/persistent cache are deliberate follow-ups.
- Additive only: no new dependencies, no database migration, no secrets, no infrastructure changes (~232 lines of app code).

## Tests

- Unit: 376 pass (14 new), including a test proving a cache hit makes zero Gemini calls.
- Integration: the 4 failures are pre-existing and environmental (they need outbound network and API keys the sandbox blocks) and are unrelated to caching.