### PR TITLE
chore(cache): remove ENABLE_RESULT_CACHE flag, make Discovery cache always-on

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,6 @@ LANGFUSE_PUBLIC_KEY=pk-lf-xxx
 LANGFUSE_HOST=https://cloud.langfuse.com
 
 # Result Cache (in-process; caches the Discovery book->regions chain)
-# Default OFF — when false, discover() behavior is byte-for-byte unchanged.
-ENABLE_RESULT_CACHE=false
+# Always on. Tune the TTL / max entries below.
 CACHE_TTL_SECONDS=86400
 CACHE_MAX_ENTRIES=500

--- a/README.md
+++ b/README.md
@@ -357,8 +357,9 @@ Integration tests use [VCR.py](https://vcrpy.readthedocs.io/) to record/replay H
 ### Live cache verification (`real_api`)
 
 `tests/integration/test_cache_real_api.py` is the live counterpart to the mocked
-cache-hit unit test. With `ENABLE_RESULT_CACHE` on, it calls `discover()` twice
-with an identical book/author and meters `Gemini.generate_content_async`
+cache-hit unit test. The Discovery result cache is always on, so it calls
+`discover()` twice with an identical book/author and meters
+`Gemini.generate_content_async`
 directly (call count + summed `usage_metadata.total_token_count`) to prove the
 **second call is a cache hit that makes zero new Gemini calls and consumes zero
 new Gemini tokens** while returning the same regions. It is marked `real_api`, so

--- a/common/config.py
+++ b/common/config.py
@@ -32,9 +32,7 @@ class Config:
     langfuse_host: Optional[str]
     environment: str
     internal_api_secret: str
-    # Result cache (opportunity: cache expensive recommendation calls).
-    # Defaults keep the cache OFF so existing deploys are byte-for-byte unchanged.
-    enable_result_cache: bool
+    # Result cache for the Discovery chain (always on; validated in prod 2026-06-17).
     cache_ttl_seconds: int
     cache_max_entries: int
 
@@ -55,14 +53,6 @@ def _require_env_int(key: str) -> int:
 def _require_env_bool(key: str) -> bool:
     """Get required boolean environment variable."""
     return _require_env(key).lower() == "true"
-
-
-def _env_bool(key: str, default: bool) -> bool:
-    """Get optional boolean environment variable with a default."""
-    value = os.getenv(key)
-    if value is None:
-        return default
-    return value.lower() == "true"
 
 
 def _env_int(key: str, default: int) -> int:
@@ -119,7 +109,6 @@ def load_config() -> Config:
         langfuse_host=os.getenv("LANGFUSE_HOST"),
         environment=os.getenv("ENVIRONMENT", "local"),
         internal_api_secret=os.getenv("INTERNAL_API_SECRET", ""),
-        enable_result_cache=_env_bool("ENABLE_RESULT_CACHE", False),
         cache_ttl_seconds=_env_int("CACHE_TTL_SECONDS", 86400),
         cache_max_entries=_env_int("CACHE_MAX_ENTRIES", 500),
     )

--- a/core/executor.py
+++ b/core/executor.py
@@ -150,16 +150,12 @@ class WorkflowExecutor:
             use_database=config.use_database,
         )
         self._model = model or self._create_model()
-        # Optional in-process result cache for the Discovery chain.
-        # Disabled unless ENABLE_RESULT_CACHE is set, so default behavior
-        # is byte-for-byte unchanged.
-        self._discovery_cache = (
-            TTLCache(
-                ttl_seconds=config.cache_ttl_seconds,
-                max_entries=config.cache_max_entries,
-            )
-            if getattr(config, "enable_result_cache", False)
-            else None
+        # In-process result cache for the Discovery chain (always on;
+        # validated in prod 2026-06-17). Replays prior validated discovery
+        # results verbatim, so it cannot introduce new hallucinations.
+        self._discovery_cache = TTLCache(
+            ttl_seconds=config.cache_ttl_seconds,
+            max_entries=config.cache_max_entries,
         )
 
     @property
@@ -308,21 +304,19 @@ class WorkflowExecutor:
         # the previously computed (already validated) regions and makes ZERO
         # Gemini calls. Only non-empty region sets are ever cached, so a hit
         # cannot introduce a new fabrication; staleness is bounded by the TTL.
-        cache_key = None
-        if self._discovery_cache is not None:
-            cache_key = self._discovery_cache_key(book_title, author, preferences)
-            cached_region_analysis = await self._discovery_cache.get(cache_key)
-            if cached_region_analysis:
-                logger.info("discovery_cache_hit", job_id=job_id[:8])
-                async for ev in self._emit_cached_discovery(
-                    job_id=job_id,
-                    user_id=user_id,
-                    book_title=book_title,
-                    author=author,
-                    region_analysis=cached_region_analysis,
-                ):
-                    yield ev
-                return
+        cache_key = self._discovery_cache_key(book_title, author, preferences)
+        cached_region_analysis = await self._discovery_cache.get(cache_key)
+        if cached_region_analysis:
+            logger.info("discovery_cache_hit", job_id=job_id[:8])
+            async for ev in self._emit_cached_discovery(
+                job_id=job_id,
+                user_id=user_id,
+                book_title=book_title,
+                author=author,
+                region_analysis=cached_region_analysis,
+            ):
+                yield ev
+            return
 
         try:
             async with timeout(self._config.workflow_timeout):
@@ -399,11 +393,7 @@ class WorkflowExecutor:
 
                 # Store on miss: cache only non-empty, schema-validated region
                 # sets so a future hit can safely short-circuit the chain.
-                if (
-                    self._discovery_cache is not None
-                    and cache_key is not None
-                    and state.regions
-                ):
+                if state.regions:
                     await self._discovery_cache.set(cache_key, state.region_analysis)
 
                 yield RegionsReady(

--- a/core/types.py
+++ b/core/types.py
@@ -27,7 +27,6 @@ class ExecutorConfig:
     langfuse_host: Optional[str] = None
     environment: str = "local"
     # Result cache settings (carried through from common.config.Config).
-    enable_result_cache: bool = False
     cache_ttl_seconds: int = 86400
     cache_max_entries: int = 500
 
@@ -44,7 +43,6 @@ class ExecutorConfig:
             langfuse_public_key=config.langfuse_public_key,
             langfuse_host=config.langfuse_host,
             environment=config.environment,
-            enable_result_cache=getattr(config, "enable_result_cache", False),
             cache_ttl_seconds=getattr(config, "cache_ttl_seconds", 86400),
             cache_max_entries=getattr(config, "cache_max_entries", 500),
         )

--- a/tests/integration/test_cache_real_api.py
+++ b/tests/integration/test_cache_real_api.py
@@ -78,7 +78,6 @@ async def test_second_discover_is_cache_hit_with_zero_new_gemini_tokens(
         model_name=os.getenv("MODEL_NAME", "gemini-2.5-flash"),
         google_api_key=real_api_key,
         use_database=False,
-        enable_result_cache=True,
         langfuse_secret_key=os.getenv("LANGFUSE_SECRET_KEY"),
         langfuse_public_key=os.getenv("LANGFUSE_PUBLIC_KEY"),
         langfuse_host=os.getenv("LANGFUSE_HOST", "https://cloud.langfuse.com"),

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -105,11 +105,10 @@ class TestDiscoveryCacheKey:
 
 
 class TestExecutorConfigCacheDefaults:
-    def test_cache_off_by_default(self):
+    def test_cache_config_defaults(self):
         config = ExecutorConfig(
             model_name="gemini-2.0-flash", google_api_key="test-key"
         )
-        assert config.enable_result_cache is False
         assert config.cache_ttl_seconds == 86400
         assert config.cache_max_entries == 500
 
@@ -133,7 +132,6 @@ class TestExecutorCacheHit:
         config = ExecutorConfig(
             model_name="gemini-2.0-flash",
             google_api_key="test-key",
-            enable_result_cache=True,
         )
         executor = WorkflowExecutor(
             config=config,
@@ -161,7 +159,8 @@ class TestExecutorCacheHit:
         assert regions_events[0].analysis_note == "cached note"
         assert any(isinstance(e, WorkflowComplete) for e in events)
 
-    async def test_cache_disabled_has_no_cache(self):
+    async def test_cache_always_enabled(self):
+        from core.cache import TTLCache
         from core.executor import WorkflowExecutor
         from services.session_service import create_session_service
 
@@ -173,4 +172,4 @@ class TestExecutorCacheHit:
             session_service=create_session_service(use_database=False),
             model=object(),
         )
-        assert executor._discovery_cache is None
+        assert isinstance(executor._discovery_cache, TTLCache)


### PR DESCRIPTION
## What
Removes the `ENABLE_RESULT_CACHE` feature flag and makes the Discovery result-cache **always on**.

## Why
The cache shipped to prod on 2026-06-17 (PR #156) with the flag ON and is validated:
- Live `real_api` test confirms a repeat `discover()` is a cache hit with **zero new Gemini tokens**.
- Post-deploy eval (18 cases) showed no grounding regression (geo_accuracy 4.50/5, book_relevance 4.06/5).
- The cache only replays prior **validated** discovery results, so it cannot introduce new hallucinations by construction.

## Changes
- `common/config.py` — drop `enable_result_cache` field + env read; remove now-unused `_env_bool` helper. `CACHE_TTL_SECONDS` / `CACHE_MAX_ENTRIES` retained.
- `core/types.py` — drop `enable_result_cache` from `ExecutorConfig` and `from_config`.
- `core/executor.py` — always construct the `TTLCache`; simplify the now always-true `is not None` guards on the cache fast-path and store-on-miss.
- `tests/` — remove disabled-path test/assertions, add `test_cache_always_enabled`, drop `enable_result_cache=True` kwargs.
- `.env.example` + `README.md` — documented as always-on.

## Verification
- `make test` → 376 passed
- `make test-integration` → 7 passed
- `pytest -m real_api tests/integration/test_cache_real_api.py` → 1 passed (live, zero new tokens)

⚠️ Do not merge without **G2**. Removing the flag means the env-var rollback lever goes away; prod rollback would be code-revert + redeploy (**G5**).