### PR TITLE
fix(retry): bound Gemini retry backoff under workflow_timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,13 @@ MODEL_NAME=gemini-2.5-flash-lite
 WORKFLOW_TIMEOUT=300
 AGENT_TIMEOUT=60
 
+# Gemini retry backoff (bounded so worst-case retries finish well under
+# WORKFLOW_TIMEOUT). exp_base=2 + max_delay keeps the schedule interactive;
+# the previous exp_base=7 could blow the timeout budget under throttling.
+RETRY_EXP_BASE=2
+RETRY_MAX_DELAY=12
+RETRY_ATTEMPTS=4
+
 # Logging
 LOG_LEVEL=INFO
 ENABLE_ADK_DEBUG=false

--- a/common/config.py
+++ b/common/config.py
@@ -35,6 +35,10 @@ class Config:
     # Result cache for the Discovery chain (always on; validated in prod 2026-06-17).
     cache_ttl_seconds: int
     cache_max_entries: int
+    # Bounded Gemini retry backoff (keeps worst-case schedule < workflow_timeout).
+    retry_exp_base: float
+    retry_max_delay: float
+    retry_attempts: int
 
 
 def _require_env(key: str) -> str:
@@ -61,6 +65,14 @@ def _env_int(key: str, default: int) -> int:
     if value is None:
         return default
     return int(value)
+
+
+def _env_float(key: str, default: float) -> float:
+    """Get optional float environment variable with a default."""
+    value = os.getenv(key)
+    if value is None:
+        return default
+    return float(value)
 
 
 def load_config() -> Config:
@@ -111,6 +123,9 @@ def load_config() -> Config:
         internal_api_secret=os.getenv("INTERNAL_API_SECRET", ""),
         cache_ttl_seconds=_env_int("CACHE_TTL_SECONDS", 86400),
         cache_max_entries=_env_int("CACHE_MAX_ENTRIES", 500),
+        retry_exp_base=_env_float("RETRY_EXP_BASE", 2.0),
+        retry_max_delay=_env_float("RETRY_MAX_DELAY", 12.0),
+        retry_attempts=_env_int("RETRY_ATTEMPTS", 4),
     )
 
 

--- a/core/executor.py
+++ b/core/executor.py
@@ -29,6 +29,8 @@ from typing import AsyncGenerator, List, Optional
 
 from async_timeout import timeout
 from google.genai import types
+
+from core.retry import build_retry_options
 from google.adk.events import Event
 from google.adk.events.event_actions import EventActions
 from google.adk.models.google_llm import Gemini
@@ -169,11 +171,11 @@ class WorkflowExecutor:
         return self._config
 
     def _create_model(self) -> Gemini:
-        retry_config = types.HttpRetryOptions(
-            attempts=5,
-            exp_base=7,
+        retry_config = build_retry_options(
+            attempts=self._config.retry_attempts,
+            exp_base=self._config.retry_exp_base,
             initial_delay=1,
-            http_status_codes=[429, 500, 503, 504],
+            max_delay=self._config.retry_max_delay,
         )
         return Gemini(
             model=self._config.model_name,

--- a/core/retry.py
+++ b/core/retry.py
@@ -1,0 +1,63 @@
+"""Bounded HTTP retry configuration for the shared Gemini model.
+
+Centralizes retry-backoff construction so ``core.executor`` and the
+evaluation runner stay in parity (a single source of truth for the retry
+schedule).
+
+Background: the shared Gemini model previously used ``exp_base=7`` with
+``attempts=5``, which produces a worst-case backoff schedule of roughly
+1s, 7s, 49s, 343s -> ~400s. Because every workflow phase runs inside
+``workflow_timeout`` (300s by default), a 429/500/503 burst would sit in
+multi-minute blind backoff until the timeout wall fired, surfacing a
+"timed out" error to the user precisely when the API was throttling.
+
+Using ``exp_base=2`` with an explicit ``max_delay`` keeps the worst-case
+cumulative backoff far under ``workflow_timeout``, converting silent
+timeouts into either a fast success or a clean, fast error.
+"""
+
+from __future__ import annotations
+
+from google.genai import types
+
+# Transient server / rate-limit status codes we retry on (unchanged).
+RETRY_STATUS_CODES = [429, 500, 503, 504]
+
+
+def worst_case_backoff_seconds(
+    attempts: int,
+    exp_base: float,
+    initial_delay: float,
+    max_delay: float,
+) -> float:
+    """Return the worst-case cumulative delay spent waiting between retries.
+
+    Standard exponential backoff: the delay before retry ``i`` (0-indexed)
+    is ``initial_delay * exp_base ** i``, capped at ``max_delay``. A run of
+    ``attempts`` total attempts performs at most ``attempts - 1`` retries.
+    """
+    total = 0.0
+    for i in range(max(attempts - 1, 0)):
+        total += min(initial_delay * (exp_base ** i), max_delay)
+    return total
+
+
+def build_retry_options(
+    *,
+    attempts: int,
+    exp_base: float,
+    initial_delay: float,
+    max_delay: float,
+) -> "types.HttpRetryOptions":
+    """Build a genai ``HttpRetryOptions`` from bounded backoff parameters.
+
+    Single construction point shared by the executor and the eval runner so
+    their retry behaviour can never silently diverge.
+    """
+    return types.HttpRetryOptions(
+        attempts=attempts,
+        exp_base=exp_base,
+        initial_delay=initial_delay,
+        max_delay=max_delay,
+        http_status_codes=list(RETRY_STATUS_CODES),
+    )

--- a/core/types.py
+++ b/core/types.py
@@ -29,6 +29,10 @@ class ExecutorConfig:
     # Result cache settings (carried through from common.config.Config).
     cache_ttl_seconds: int = 86400
     cache_max_entries: int = 500
+    # Bounded Gemini retry backoff (parity with the eval runner).
+    retry_exp_base: float = 2.0
+    retry_max_delay: float = 12.0
+    retry_attempts: int = 4
 
     @classmethod
     def from_config(cls, config) -> "ExecutorConfig":
@@ -45,4 +49,7 @@ class ExecutorConfig:
             environment=config.environment,
             cache_ttl_seconds=getattr(config, "cache_ttl_seconds", 86400),
             cache_max_entries=getattr(config, "cache_max_entries", 500),
+            retry_exp_base=getattr(config, "retry_exp_base", 2.0),
+            retry_max_delay=getattr(config, "retry_max_delay", 12.0),
+            retry_attempts=getattr(config, "retry_attempts", 4),
         )

--- a/evaluation/tools/run_scheduled_eval.py
+++ b/evaluation/tools/run_scheduled_eval.py
@@ -19,6 +19,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from common.logging import get_logger, configure_logging
 from common.config import load_config
+from core.retry import build_retry_options
 from services.session_service import create_session_service
 from agents.orchestrator import (
     create_discovery_workflow,
@@ -394,11 +395,11 @@ async def _run_evaluation_case(
         )
 
         # Initialize model with retry config (same as main.py)
-        retry_config = types.HttpRetryOptions(
-            attempts=5,
-            exp_base=7,
+        retry_config = build_retry_options(
+            attempts=config.retry_attempts,
+            exp_base=config.retry_exp_base,
             initial_delay=1,
-            http_status_codes=[429, 500, 503, 504]
+            max_delay=config.retry_max_delay,
         )
         model = Gemini(
             model=config.model_name,

--- a/tests/unit/test_retry_backoff.py
+++ b/tests/unit/test_retry_backoff.py
@@ -1,0 +1,188 @@
+"""Unit tests for the bounded Gemini retry backoff (core/retry.py).
+
+Guards the fix for the pathological ``exp_base=7`` schedule: the shared model
+is used by every workflow phase, each wrapped in ``workflow_timeout`` (300s),
+so the worst-case retry schedule must finish well inside that budget.
+"""
+
+import os
+
+import pytest
+
+from common.config import _env_float, load_config
+from core.retry import (
+    RETRY_STATUS_CODES,
+    build_retry_options,
+    worst_case_backoff_seconds,
+)
+from core.types import ExecutorConfig
+
+WORKFLOW_TIMEOUT_DEFAULT = 300
+
+
+class TestWorstCaseBackoff:
+    def test_defaults_sum_well_under_workflow_timeout(self):
+        # Default bounded schedule: attempts=4, exp_base=2, initial=1, max=12.
+        total = worst_case_backoff_seconds(
+            attempts=4, exp_base=2.0, initial_delay=1.0, max_delay=12.0
+        )
+        # 1 + 2 + 4 = 7s over the 3 retries.
+        assert total == pytest.approx(7.0)
+        assert total < WORKFLOW_TIMEOUT_DEFAULT
+
+    def test_executor_config_defaults_are_bounded(self):
+        cfg = ExecutorConfig(model_name="m", google_api_key="k")
+        total = worst_case_backoff_seconds(
+            attempts=cfg.retry_attempts,
+            exp_base=cfg.retry_exp_base,
+            initial_delay=1.0,
+            max_delay=cfg.retry_max_delay,
+        )
+        # Far under the interactive budget (and the per-agent timeout of 60s).
+        assert total < cfg.workflow_timeout
+        assert total < 60
+
+    def test_max_delay_caps_the_schedule(self):
+        # Without a cap the 4th-ish delay explodes; the cap holds each term.
+        capped = worst_case_backoff_seconds(
+            attempts=6, exp_base=2.0, initial_delay=1.0, max_delay=12.0
+        )
+        # 1 + 2 + 4 + 8 + 12(capped from 16) = 27, not 1+2+4+8+16 = 31.
+        assert capped == pytest.approx(27.0)
+
+    def test_pathological_legacy_config_would_blow_the_budget(self):
+        # Regression documentation: the OLD config (exp_base=7, attempts=5,
+        # effectively no cap) exceeds workflow_timeout — which is the bug.
+        legacy = worst_case_backoff_seconds(
+            attempts=5, exp_base=7.0, initial_delay=1.0, max_delay=float("inf")
+        )
+        # 1 + 7 + 49 + 343 = 400s > 300s wall.
+        assert legacy == pytest.approx(400.0)
+        assert legacy > WORKFLOW_TIMEOUT_DEFAULT
+
+
+class TestBuildRetryOptions:
+    def test_builds_with_expected_fields(self):
+        opts = build_retry_options(
+            attempts=4, exp_base=2.0, initial_delay=1.0, max_delay=12.0
+        )
+        assert opts.attempts == 4
+        assert opts.exp_base == 2.0
+        assert opts.max_delay == 12.0
+        assert opts.initial_delay == 1.0
+        assert list(opts.http_status_codes) == [429, 500, 503, 504]
+
+    def test_status_codes_unchanged_from_legacy(self):
+        assert RETRY_STATUS_CODES == [429, 500, 503, 504]
+
+    def test_executor_and_eval_runner_use_identical_config(self):
+        """Parity: both call sites build options from the same defaults."""
+        cfg = ExecutorConfig(model_name="m", google_api_key="k")
+        executor_opts = build_retry_options(
+            attempts=cfg.retry_attempts,
+            exp_base=cfg.retry_exp_base,
+            initial_delay=1.0,
+            max_delay=cfg.retry_max_delay,
+        )
+        # The eval runner reads the same three values from common.config.Config,
+        # whose defaults match ExecutorConfig's.
+        eval_opts = build_retry_options(
+            attempts=cfg.retry_attempts,
+            exp_base=cfg.retry_exp_base,
+            initial_delay=1.0,
+            max_delay=cfg.retry_max_delay,
+        )
+        assert (executor_opts.attempts, executor_opts.exp_base, executor_opts.max_delay) == (
+            eval_opts.attempts,
+            eval_opts.exp_base,
+            eval_opts.max_delay,
+        )
+
+
+class TestEnvDrivenConfig:
+    def test_env_float_default_and_override(self, monkeypatch):
+        monkeypatch.delenv("RETRY_EXP_BASE", raising=False)
+        assert _env_float("RETRY_EXP_BASE", 2.0) == 2.0
+        monkeypatch.setenv("RETRY_EXP_BASE", "3.5")
+        assert _env_float("RETRY_EXP_BASE", 2.0) == 3.5
+
+    def test_load_config_reads_retry_overrides(self, monkeypatch):
+        base_env = {
+            "GOOGLE_API_KEY": "k",
+            "USE_DATABASE": "false",
+            "SESSION_MAX_EVENTS": "100",
+            "MAX_CONTEXT_TOKENS": "1000",
+            "MODEL_NAME": "gemini-2.5-flash-lite",
+            "WORKFLOW_TIMEOUT": "300",
+            "AGENT_TIMEOUT": "60",
+            "LOG_LEVEL": "INFO",
+            "ENABLE_ADK_DEBUG": "false",
+        }
+        for k, v in base_env.items():
+            monkeypatch.setenv(k, v)
+
+        # Defaults when unset.
+        for k in ("RETRY_EXP_BASE", "RETRY_MAX_DELAY", "RETRY_ATTEMPTS"):
+            monkeypatch.delenv(k, raising=False)
+        cfg = load_config()
+        assert cfg.retry_exp_base == 2.0
+        assert cfg.retry_max_delay == 12.0
+        assert cfg.retry_attempts == 4
+
+        # Overrides honored.
+        monkeypatch.setenv("RETRY_EXP_BASE", "2")
+        monkeypatch.setenv("RETRY_MAX_DELAY", "8")
+        monkeypatch.setenv("RETRY_ATTEMPTS", "3")
+        cfg2 = load_config()
+        assert cfg2.retry_exp_base == 2.0
+        assert cfg2.retry_max_delay == 8.0
+        assert cfg2.retry_attempts == 3
+        # Even the override schedule stays bounded.
+        assert worst_case_backoff_seconds(
+            attempts=cfg2.retry_attempts,
+            exp_base=cfg2.retry_exp_base,
+            initial_delay=1.0,
+            max_delay=cfg2.retry_max_delay,
+        ) < cfg2.workflow_timeout
+
+
+class TestExecutorConfigPlumbing:
+    def test_from_config_carries_retry_fields(self):
+        class _Cfg:
+            model_name = "m"
+            google_api_key = "k"
+            workflow_timeout = 300
+            database_url = None
+            use_database = False
+            langfuse_secret_key = None
+            langfuse_public_key = None
+            langfuse_host = None
+            environment = "local"
+            cache_ttl_seconds = 86400
+            cache_max_entries = 500
+            retry_exp_base = 2.0
+            retry_max_delay = 12.0
+            retry_attempts = 4
+
+        ec = ExecutorConfig.from_config(_Cfg())
+        assert ec.retry_exp_base == 2.0
+        assert ec.retry_max_delay == 12.0
+        assert ec.retry_attempts == 4
+
+    def test_from_config_falls_back_when_fields_absent(self):
+        class _OldCfg:
+            model_name = "m"
+            google_api_key = "k"
+            workflow_timeout = 300
+            database_url = None
+            use_database = False
+            langfuse_secret_key = None
+            langfuse_public_key = None
+            langfuse_host = None
+            environment = "local"
+            cache_ttl_seconds = 86400
+            cache_max_entries = 500
+
+        ec = ExecutorConfig.from_config(_OldCfg())
+        assert ec.retry_exp_base == 2.0
+        assert ec.retry_attempts == 4


### PR DESCRIPTION
# fix(retry): bound Gemini retry backoff under workflow_timeout

**Repo:** storyland-ai · **Base:** `main` ← **Head:** `feat/bounded-retry-backoff`
**Opportunity:** Fix pathological Gemini retry backoff (exp_base=7) — RICE 54, Approved (G1)
**Status target:** In PR (not merged — for Olga's G2 review)

## What
The shared Gemini model (`core/executor.py::_create_model()`) used
`HttpRetryOptions(attempts=5, exp_base=7, initial_delay=1)`. Base-7 backoff
explodes: ~1s, 7s, 49s, 343s → ~400s worst case. Every workflow phase runs
inside `workflow_timeout` (300s), so under a 429/500/503 burst the model sat in
multi-minute blind backoff and the 300s wall fired first — the user saw a
"timed out" error precisely when the API was throttling, wasting partial token
spend. The model is shared by every phase (discover/compose/atmosphere/expand/
recommend), so the bad curve hit ~100% of searches whenever Gemini throttled.

## Change (smallest valuable slice, additive)
- New `core/retry.py`: single source of truth for the retry schedule.
  - `build_retry_options(...)` constructs `HttpRetryOptions` (status codes
    `[429,500,503,504]` unchanged).
  - `worst_case_backoff_seconds(...)` — pure helper used to prove the bound.
- `_create_model()` (executor) and `_run_evaluation_case()` (eval runner) both
  build their retry options via `build_retry_options` → guaranteed **parity**.
- Backoff params are env-driven via `common.config` /
  `core.types.ExecutorConfig` with bounded defaults: `RETRY_EXP_BASE=2`,
  `RETRY_MAX_DELAY=12`, `RETRY_ATTEMPTS=4`. Worst case ≈ 1+2+4 = **7s** over
  3 retries, far under `workflow_timeout`.
- `.env.example` documents the three vars.

## Why these defaults
exp_base=2, initial_delay=1, max_delay=12, attempts=4 → delays 1,2,4 (cap 12),
sum 7s. Keeps retries inside the interactive budget (< AGENT_TIMEOUT=60s,
≪ WORKFLOW_TIMEOUT=300s) while still smoothing transient 429/5xx bursts.

## Tests
- New `tests/unit/test_retry_backoff.py` — **11 tests**: worst-case schedule
  bound vs `workflow_timeout`; `max_delay` capping; a regression test showing
  the legacy `exp_base=7` config sums to 400s > 300s (the bug); builder field
  correctness + unchanged status codes; executor/eval parity; env-driven
  overrides via `load_config`; `ExecutorConfig.from_config` plumbing + fallback.
- **Full unit suite: 387 passed** (376 baseline + 11 new).
- Integration: 7 failed / 2 passed / 2 skipped — **byte-identical to clean
  `main`** (verified by stash + re-run). All failures are pre-existing
  environmental: SOCKS proxy without `socksio` installed + missing
  `GOOGLE_API_KEY`/`LANGFUSE_*`. Tracked separately by the "add socksio dev
  dep" backlog item. None touch retry logic.

## Risk / blast radius
Low. Additive + config-driven; no schema, migration, secret, auth, infra, or
new dependency. **Not** recommendation/agent output logic — only retry timing
on transient HTTP errors, so no book↔place grounding impact (no EVAL handoff
required). Diff: 291 insertions / 8 deletions, 7 files (< ~300-line limit).

## Verify / roll back
- Verify: `python3 -m pytest tests/unit -q` → 387 passed. Inspect a simulated
  throttle: worst-case backoff now bounded (~7s) instead of ~400s.
- Roll back: set `RETRY_EXP_BASE=7` / `RETRY_ATTEMPTS=5` (legacy) via env, or
  revert the commit. With no env vars set, defaults are the bounded values.
