### PR TITLE
feat(discover): guard empty discovery with a clean NoRegions error

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -393,6 +393,26 @@ class WorkflowExecutor:
                     num_regions=len(state.regions),
                 )
 
+                # Empty-discovery guard: when discovery yields zero regions
+                # (obscure book, failed/empty google_search, extraction miss),
+                # emit a clean NoRegions error instead of a silent, empty-but-
+                # "successful" RegionsReady that dead-ends the user at the
+                # activation moment and is recorded as a success in the funnel.
+                # Mirrors the existing compose() NoRegions guard.
+                if not state.regions:
+                    logger.info("discovery_empty_regions", job_id=job_id[:8])
+                    await self._mark_session_failed(job_id, user_id)
+                    yield WorkflowError(
+                        message=(
+                            "We couldn't map locations for this book. "
+                            "Try another title or check the spelling."
+                        ),
+                        error_type="NoRegions",
+                        phase=Phase.DISCOVERY,
+                    )
+                    yield WorkflowComplete(job_id=job_id)
+                    return
+
                 # Store on miss: cache only non-empty, schema-validated region
                 # sets so a future hit can safely short-circuit the chain.
                 if state.regions:

--- a/tests/unit/test_empty_discovery_guard.py
+++ b/tests/unit/test_empty_discovery_guard.py
@@ -1,0 +1,115 @@
+"""Unit tests for the empty-discovery guard in WorkflowExecutor.discover().
+
+When the discovery chain returns zero regions (obscure book, failed/empty
+google_search, schema-extraction miss), discover() must emit a clean
+WorkflowError(error_type="NoRegions") + WorkflowComplete instead of a silent,
+empty-but-"successful" RegionsReady that dead-ends the user at the activation
+moment (and is recorded as a success by the funnel). Mirrors the existing
+compose() NoRegions guard. The guard is always on; rollback = revert the commit.
+"""
+
+from google.adk.events import Event
+from google.adk.events.event_actions import EventActions
+
+from core.events import RegionsReady, WorkflowError, WorkflowComplete
+from core.types import ExecutorConfig
+from core.session_state import SessionStateKeys
+
+
+def _make_executor(monkeypatch, regions):
+    """Build a WorkflowExecutor whose discovery chain is stubbed out.
+
+    The Gemini workflow + Runner are replaced so no real model is invoked.
+    ``regions`` is the region list the (fake) discovery run writes into
+    session state via append_event: pass [] to simulate an empty discovery,
+    or a non-empty list to simulate a normal run.
+    """
+    import core.executor as ex
+    from core.executor import WorkflowExecutor, APP_NAME
+    from services.session_service import create_session_service
+
+    # Stub the workflow builder: never construct/run a real Gemini chain.
+    monkeypatch.setattr(ex, "create_discovery_workflow", lambda *a, **k: object())
+
+    class _FakeRunner:
+        def __init__(self, *args, **kwargs):
+            self._session_service = kwargs.get("session_service")
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def run_async(self, user_id, session_id, new_message):
+            # Simulate the discovery chain writing (or not writing) regions
+            # into session state, exactly as the real run does.
+            if regions is not None:
+                session = await self._session_service.get_session(
+                    app_name=APP_NAME, user_id=user_id, session_id=session_id
+                )
+                ev = Event(
+                    invocation_id="system",
+                    author="system",
+                    actions=EventActions(
+                        state_delta={
+                            SessionStateKeys.REGION_ANALYSIS: {
+                                "regions": regions,
+                                "analysis_note": "note",
+                            }
+                        }
+                    ),
+                )
+                await self._session_service.append_event(session, ev)
+            if False:  # make this an async generator that yields no events
+                yield None
+
+    monkeypatch.setattr(ex, "Runner", _FakeRunner)
+
+    config = ExecutorConfig(
+        model_name="gemini-2.0-flash",
+        google_api_key="test-key",
+    )
+    return WorkflowExecutor(
+        config=config,
+        session_service=create_session_service(use_database=False),
+        model=object(),  # never used; the chain is stubbed
+    )
+
+
+class TestEmptyDiscoveryGuard:
+    async def test_empty_regions_emit_no_regions_error(self, monkeypatch):
+        """Zero regions -> clean NoRegions error, never an empty RegionsReady."""
+        executor = _make_executor(monkeypatch, regions=[])
+        events = [
+            e
+            async for e in executor.discover(
+                book_title="Asdkfj Nonexistent Title", author="Nobody"
+            )
+        ]
+
+        assert not any(isinstance(e, RegionsReady) for e in events), (
+            "must not emit an empty RegionsReady"
+        )
+        errors = [e for e in events if isinstance(e, WorkflowError)]
+        assert len(errors) == 1
+        assert errors[0].error_type == "NoRegions"
+        assert any(isinstance(e, WorkflowComplete) for e in events)
+
+    async def test_nonempty_regions_unaffected(self, monkeypatch):
+        """Happy path: a real region set still yields RegionsReady, no error."""
+        regions = [{"region_id": 1, "name": "Bath, England"}]
+        executor = _make_executor(monkeypatch, regions=regions)
+
+        events = [
+            e
+            async for e in executor.discover(
+                book_title="Persuasion", author="Jane Austen"
+            )
+        ]
+
+        regions_events = [e for e in events if isinstance(e, RegionsReady)]
+        assert len(regions_events) == 1
+        assert regions_events[0].regions == regions
+        assert not any(isinstance(e, WorkflowError) for e in events)
+        assert any(isinstance(e, WorkflowComplete) for e in events)


### PR DESCRIPTION
# feat(discover): guard empty discovery with a clean NoRegions error

**Repo:** storyland-ai · **Base:** `main` ← **Head:** `feat/empty-discovery-guard` (commit `1ca5f0e`)
**Opportunity:** [Discovery can emit an empty RegionsReady (no guard)](https://app.notion.com/p/382f624188bc817daa89e6edbe12cb3d) · RICE 36 · Approved (G1) · Effort S · Risk Low
**Diff:** 135 insertions / 0 deletions, 2 files (20 production lines + 115 tests). No flag, no deps/schema/secret/migration.

## What
`discover()` in `core/executor.py` yielded `RegionsReady(regions=state.regions)` unconditionally — it logged `num_regions` even when 0 and emitted a "successful" event with an empty list. The `NoRegions` empty-guard (`if not all_regions → WorkflowError`) existed only in `compose()` (~L485), not in `discover()`, and `api/streaming.py` maps `RegionsReady` straight to the client. So when discovery returned zero regions (obscure book, failed/empty `google_search`, schema-extraction miss), the user reached the core activation moment and saw an empty, error-free dead-end — and the funnel recorded it as a success, hiding the failure.

This PR adds the guard in `discover()`, right after the discovery chain runs and regions are extracted: when `state.regions` is empty, it marks the session failed and emits a clean `WorkflowError(error_type="NoRegions", phase=DISCOVERY)` + `WorkflowComplete` instead of an empty `RegionsReady`. Mirrors the existing `compose()` `NoRegions` guard exactly. A distinct `discovery_empty_regions` log line is emitted for observability. **Always on — no feature flag** (per owner preference; rollback = revert the commit).

## Why
The first result is the entire "wow." A silent empty `RegionsReady` is worse than an error: the user can't tell whether the app is broken, the book is unsupported, or they did something wrong — and the funnel counts it as a success, masking the failure from metrics. The fix mirrors a guard that already exists downstream, so it is low-risk and consistent with established patterns.

## Files
- `core/executor.py` — empty-discovery guard branch in `discover()`.
- `tests/unit/test_empty_discovery_guard.py` (new) — 2 tests.

## Acceptance criteria — met
1. **Obscure/nonsense title → `WorkflowError NoRegions` + `WorkflowComplete`, never an empty `RegionsReady`** — `test_empty_regions_emit_no_regions_error`.
2. **Client gets a friendly message** — `"We couldn't map locations for this book. Try another title or check the spelling."`
3. **Distinct signal for analytics** — `discovery_empty_regions` log + `NoRegions`/`phase=DISCOVERY` error type (distinct from compose's `phase=COMPOSITION`).
4. **Rollback** — revert commit `1ca5f0e` (no flag, per owner preference).

Happy path unchanged: `test_nonempty_regions_unaffected` confirms a real region set still yields `RegionsReady` with no error.

## Tests / suite
- New: `tests/unit/test_empty_discovery_guard.py` — **2 passed** (empty → NoRegions, never empty RegionsReady; happy path with real regions unaffected — both end-to-end with the discovery chain stubbed so no Gemini is invoked).
- **Full unit suite: 389 passed** (387 baseline + 2 new), 0 regressions. `py_compile` clean.
- Integration suite not run here (pre-existing environmental SOCKS/`socksio` + missing `GOOGLE_API_KEY`/`LANGFUSE_*` gaps in the sandbox, tracked by the separate "add socksio dev dep" item); this change is unit-gated and touches no integration path.

## Risk & grounding
Low — additive, no flag/schema/deps/secrets/migration/auth/infra. **Error-handling only:** it converts an empty-but-"successful" result into a clean error; it does **not** change recommendation, discovery, region, place, or book↔place output logic. **Zero fabrication / grounding risk → no EVAL/LIVE_TEST handoff required.** Not G4.

## Rollback
Revert commit `1ca5f0e`.
