### PR TITLE
build(deps): pin google-adk to the tested 1.x line (>=1.33.0,<2)

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -34,6 +34,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
+      - name: Assert google-adk pinned to the tested 1.x line
+        run: |
+          python -c "import importlib.metadata as m, sys; v = m.version('google-adk'); print('resolved google-adk', v); sys.exit(0 if v.split('.')[0] == '1' else 'ERROR: google-adk resolved to %s; expected the pinned 1.x major (>=1.33.0,<2)' % v)"
+
       - name: Create .env file for unit tests
         run: |
           echo "GOOGLE_API_KEY=test-key" > .env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 license = {text = "MIT"}
 
 dependencies = [
-    "google-adk[eval,db]>=1.33.0",
+    "google-adk[eval]>=1.33.0,<2",  # pin to tested 1.x line; <2 prevents non-reproducible jump to ADK 2.x. "db" extra dropped: not provided on 1.x (sqlalchemy ships as a core dep, so DatabaseSessionService still works).
     "pydantic>=2.5.0",
     "pydantic-settings>=2.1.0",
     "requests>=2.31.0",

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -1,0 +1,35 @@
+"""Dependency-pinning guards.
+
+The agent chain is built and tested against the google-adk 1.x line. The
+pin in pyproject.toml is ``google-adk[eval]>=1.33.0,<2`` so a clean
+install/CI/deploy resolves a 1.x release deterministically and can never
+silently float to a 2.x major (which is an untested, breaking API jump).
+
+These tests fail loudly if the *installed* ADK ever drifts off the
+intended 1.x line, turning a latent supply-chain risk into a red test.
+"""
+
+from importlib import metadata
+
+import pytest
+from packaging.version import Version
+
+
+def _adk_version() -> Version:
+    return Version(metadata.version("google-adk"))
+
+
+def test_google_adk_major_is_one():
+    """A 2.x (or higher) resolve is an untested major jump — fail the build."""
+    assert _adk_version().major == 1, (
+        f"google-adk resolved to {_adk_version()}; the project is pinned to the "
+        "1.x line (>=1.33.0,<2). A 2.x major is an untested, breaking jump — "
+        "see the ADK-pin opportunity before raising the ceiling."
+    )
+
+
+def test_google_adk_at_or_above_floor():
+    """Stay at/above the floor the agent chain was validated on."""
+    assert _adk_version() >= Version("1.33.0"), (
+        f"google-adk resolved to {_adk_version()}, below the tested 1.33.0 floor."
+    )


### PR DESCRIPTION
# build(deps): pin google-adk to the tested 1.x line (>=1.33.0,<2)

## What
`pyproject.toml` declared `google-adk[eval,db]>=1.33.0` with no upper bound, so a clean install/CI/deploy now resolves **google-adk 2.2.0** — a major-version jump past the 1.33.x line the agent chain was built and tested on. This pins ADK to the tested 1.x line (`google-adk[eval]>=1.33.0,<2`), drops the non-existent `db` extra, adds a CI guard that fails the build if the resolved ADK major isn't 1, and adds a unit test that turns a future drift to 2.x red in the suite.

## Why
Without an upper bound the build is non-reproducible: the same commit installs different ADK majors depending on when you install, so green-CI-today doesn't guarantee green-prod-next-month, and a future ADK release could silently break the discover/compose/recommend chain with no code change on our side. The unit suite happening to pass on 2.2.0 right now is luck, not a guarantee — which is what makes the risk easy to miss until it breaks prod. This is preventive reliability hygiene: one reversible constraint change plus guards so the drift can't recur silently.

## How
- **`pyproject.toml`** — `google-adk[eval,db]>=1.33.0` → `google-adk[eval]>=1.33.0,<2`.
  - The `<2` ceiling is the actual fix for the float to 2.x.
  - The `db` extra is **dropped** because google-adk 1.x does not provide it — `pip` emits `WARNING: google-adk 1.35.2 does not provide the extra 'db'` and ignores it, so the old `[eval,db]` spec was already inconsistent (the floor and the extra disagreed). Verified that `sqlalchemy` ships as a **core** dependency of google-adk 1.35.2, so `DatabaseSessionService` (used in `services/session_service.py`) still works without the extra.
- **`.github/workflows/codex.yml`** — a post-install step asserts `importlib.metadata.version("google-adk")` starts with `1`, failing the build on an unexpected major.
- **`tests/unit/test_dependencies.py`** — two tests assert the installed ADK is on the `>=1.33.0,<2` line (major == 1, version >= 1.33.0), so a drift to 2.x is caught in `make test` as well as the CI guard.

No application code, schema/migration, secret, auth, or paid dependency changed. Rollback = revert this commit.

## Review & test
Focus review on the extras decision: confirm dropping `db` is correct. Verification done locally on a fresh clone (Python 3.10, ADK resolves to **1.35.2**):

```
# correct resolution + the db-extra is genuinely absent on 1.x
pip install --dry-run "google-adk[eval,db]>=1.33.0,<2"
#   -> WARNING: google-adk 1.35.2 does not provide the extra 'db'
pip install -e ".[dev]"                       # resolves google-adk 1.35.2

# sqlalchemy still present, DatabaseSessionService importable without the db extra
python -c "from google.adk.sessions import DatabaseSessionService; import sqlalchemy; print(sqlalchemy.__version__)"
#   -> 2.0.51

# CI guard passes on a 1.x major
python -c "import importlib.metadata as m,sys; v=m.version('google-adk'); sys.exit(0 if v.split('.')[0]=='1' else 1)"

# full unit suite green on the pinned version
make test
#   -> 409 passed  (incl. test_services DatabaseSessionService cases + 2 new dependency guards)
```

Edge cases covered: the `db`-extra/floor inconsistency is resolved (extra dropped, not silently swallowed); `DatabaseSessionService` (prod `USE_DATABASE=true` path) verified working since sqlalchemy is a core ADK dep; the CI guard and the new unit test both fail loudly on a 2.x resolve. Not upgrading to ADK 2.x (out of scope — needs a full agent-chain regression).
