### PR TITLE
feat: expose place→book reverse-routing over HTTP (gateway-internal e…

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -13,6 +13,7 @@ from fastapi import Depends, Header, HTTPException, Request
 from common.config import Config, load_config
 from common.logging import configure_logging, get_logger
 from core.executor import WorkflowExecutor
+from core.place_to_book import PlaceToBookResolver
 from core.types import ExecutorConfig
 
 
@@ -25,6 +26,7 @@ class AppState:
 
 
 _app_state: Optional[AppState] = None
+_place_to_book_resolver: Optional[PlaceToBookResolver] = None
 
 
 async def initialize() -> AppState:
@@ -49,10 +51,11 @@ async def initialize() -> AppState:
 
 async def shutdown() -> None:
     """Cleanup on application shutdown."""
-    global _app_state
+    global _app_state, _place_to_book_resolver
     if _app_state:
         await _app_state.executor.close()
     _app_state = None
+    _place_to_book_resolver = None
 
 
 def get_app_state() -> AppState:
@@ -60,6 +63,21 @@ def get_app_state() -> AppState:
     if _app_state is None:
         raise RuntimeError("Application not initialized. Call initialize() first.")
     return _app_state
+
+
+def get_place_to_book_resolver() -> PlaceToBookResolver:
+    """Return the process-wide place→book resolver (lazy singleton).
+
+    Reuses the executor's already-constructed model so we don't spin up a second
+    Gemini client, and keeps the resolver's in-process cache warm across
+    requests. The resolver keeps its own (in-memory) session service, isolated
+    from the discovery/compose session lifecycle.
+    """
+    global _place_to_book_resolver
+    if _place_to_book_resolver is None:
+        app_state = get_app_state()
+        _place_to_book_resolver = PlaceToBookResolver(model=app_state.executor.model)
+    return _place_to_book_resolver
 
 
 def verify_gateway_secret(request: Request) -> None:

--- a/api/models.py
+++ b/api/models.py
@@ -116,6 +116,40 @@ class RecommendBooksRequest(BaseModel):
     )
 
 
+class PlaceToBookRequest(BaseModel):
+    """Request body for POST /api/v1/place-to-book (internal: gateway → AI).
+
+    Reverse-discovery input: a free-text destination resolved to grounded,
+    literal/vibe-labelled book candidates. The gateway (storyland-services)
+    calls this endpoint, then runs the authoritative Google Books existence
+    check on each returned candidate.
+    """
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {"place": "Lisbon"},
+                {"place": "the Scottish Highlands"},
+            ]
+        }
+    }
+
+    place: str = Field(
+        min_length=1,
+        max_length=120,
+        description="Free-text destination (e.g. 'Lisbon', 'Tokyo, Japan')",
+    )
+
+    @field_validator("place")
+    @classmethod
+    def validate_place(cls, value: str) -> str:
+        """Require a non-empty, non-whitespace place string."""
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("place must not be empty")
+        return normalized
+
+
 class UserLocation(BaseModel):
     """User's current location for the local-atmosphere flow."""
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -8,7 +8,12 @@ All business logic lives in core.executor — routes are thin wiring.
 from fastapi import APIRouter, Depends, HTTPException
 from sse_starlette.sse import EventSourceResponse
 
-from api.dependencies import get_app_state, get_gateway_user_id, verify_gateway_secret
+from api.dependencies import (
+    get_app_state,
+    get_gateway_user_id,
+    get_place_to_book_resolver,
+    verify_gateway_secret,
+)
 from api.models import (
     DiscoverRequest,
     ComposeRequest,
@@ -18,6 +23,7 @@ from api.models import (
     HealthResponse,
     JobStatusResponse,
     JobStatus,
+    PlaceToBookRequest,
 )
 from api.streaming import (
     discover_stream,
@@ -27,7 +33,9 @@ from api.streaming import (
     local_atmosphere_stream,
 )
 from common.logging import get_logger
+from core.place_to_book import PlaceToBookResolver
 from core.session_state import SessionStateAccessor
+from models.place_to_book import PlaceToBookResult
 
 logger = get_logger("storyland.api.routes")
 
@@ -384,3 +392,28 @@ async def get_status(job_id: str, user_id: str = Depends(get_gateway_user_id)):
         has_regions=bool(state.get("region_analysis", {}).get("regions")),
         has_itinerary=status == JobStatus.COMPLETED,
     )
+
+
+@router.post(
+    "/place-to-book",
+    response_model=PlaceToBookResult,
+    tags=["place-to-book"],
+    summary="Resolve a destination to grounded book candidates (reverse discovery)",
+)
+async def place_to_book(
+    request: PlaceToBookRequest,
+    resolver: PlaceToBookResolver = Depends(get_place_to_book_resolver),
+) -> PlaceToBookResult:
+    """
+    Reverse-discovery: a free-text destination → grounded, labelled book
+    candidates (books *set there* = ``literal``; books that *evoke* the place =
+    ``vibe``). Returns a clean ``found=false`` envelope with an empty candidate
+    list when the place can't be grounded — never a fabricated list.
+
+    Internal endpoint (gateway secret enforced): the storyland-services gateway
+    calls this, then runs the authoritative Google Books existence check and
+    decorates each candidate with the user-facing grounding object. Non-streaming
+    JSON — the resolver is a single bounded, in-process-cached lookup.
+    """
+    logger.info("place_to_book_request", place=request.place)
+    return await resolver.resolve(request.place)

--- a/core/executor.py
+++ b/core/executor.py
@@ -171,6 +171,11 @@ class WorkflowExecutor:
         """Expose config for health checks."""
         return self._config
 
+    @property
+    def model(self):
+        """Expose the shared LLM model (e.g. for the place→book resolver)."""
+        return self._model
+
     def _create_model(self) -> Gemini:
         retry_config = build_retry_options(
             attempts=self._config.retry_attempts,

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1250,3 +1250,152 @@ class TestDomainEventToSSEBookRecommendations:
         data = json.loads(sse["data"])
         assert len(data["recommendations"]) == 5
         assert data["book_recommendation_count"] == 2
+
+
+# =============================================================================
+# Place→Book reverse-discovery endpoint (internal: gateway → AI)
+# =============================================================================
+
+from api.models import PlaceToBookRequest
+from models.place_to_book import PlaceBookCandidate, PlaceToBookResult
+
+
+class TestPlaceToBookRequest:
+    """Validation for the POST /api/v1/place-to-book request body."""
+
+    def test_minimal_request(self):
+        req = PlaceToBookRequest(place="Lisbon")
+        assert req.place == "Lisbon"
+
+    def test_place_is_trimmed(self):
+        req = PlaceToBookRequest(place="  Tokyo  ")
+        assert req.place == "Tokyo"
+
+    def test_blank_place_raises(self):
+        with pytest.raises(ValidationError):
+            PlaceToBookRequest(place="   ")
+
+    def test_missing_place_raises(self):
+        with pytest.raises(ValidationError):
+            PlaceToBookRequest()
+
+    def test_overlong_place_raises(self):
+        with pytest.raises(ValidationError):
+            PlaceToBookRequest(place="x" * 121)
+
+
+class _FakeResolver:
+    """Stand-in for PlaceToBookResolver: records calls, returns a fixed result."""
+
+    def __init__(self, result: PlaceToBookResult) -> None:
+        self._result = result
+        self.calls: list[str] = []
+
+    async def resolve(self, place: str) -> PlaceToBookResult:
+        self.calls.append(place)
+        return self._result
+
+
+@pytest.fixture
+def reset_p2b_singleton():
+    """Ensure the module-level resolver singleton doesn't leak across tests."""
+    import api.dependencies as deps
+    deps._place_to_book_resolver = None
+    yield
+    deps._place_to_book_resolver = None
+
+
+class TestPlaceToBookEndpoint:
+    """Tests for POST /api/v1/place-to-book (resolver mocked, no network)."""
+
+    @pytest.mark.asyncio
+    async def test_found_returns_labelled_candidates(
+        self, test_client, reset_p2b_singleton
+    ):
+        import api.dependencies as deps
+
+        result = PlaceToBookResult(
+            place="Lisbon",
+            query="lisbon",
+            found=True,
+            message=None,
+            candidates=[
+                PlaceBookCandidate(
+                    title="The Book of Disquiet",
+                    author="Fernando Pessoa",
+                    description="A real book.",
+                    why_it_fits="Pessoa's Lisbon, street by street.",
+                    match_type="literal",
+                    maps_to="Baixa, Lisbon",
+                ),
+                PlaceBookCandidate(
+                    title="The Shadow of the Wind",
+                    author="Carlos Ruiz Zafón",
+                    why_it_fits="Same old-European, melancholy mood.",
+                    match_type="vibe",
+                    maps_to=None,
+                ),
+            ],
+        )
+        fake = _FakeResolver(result)
+        deps._place_to_book_resolver = fake
+
+        response = await test_client.post(
+            "/api/v1/place-to-book", json={"place": "Lisbon"}
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["found"] is True
+        assert data["place"] == "Lisbon"
+        assert len(data["candidates"]) == 2
+        assert data["candidates"][0]["match_type"] == "literal"
+        assert data["candidates"][0]["maps_to"] == "Baixa, Lisbon"
+        assert data["candidates"][1]["match_type"] == "vibe"
+        assert data["candidates"][1]["maps_to"] is None
+        assert fake.calls == ["Lisbon"]
+
+    @pytest.mark.asyncio
+    async def test_not_found_returns_empty_envelope(
+        self, test_client, reset_p2b_singleton
+    ):
+        import api.dependencies as deps
+
+        result = PlaceToBookResult(
+            place="Gotham",
+            query="gotham",
+            found=False,
+            message="We haven't mapped Gotham yet.",
+            candidates=[],
+        )
+        deps._place_to_book_resolver = _FakeResolver(result)
+
+        response = await test_client.post(
+            "/api/v1/place-to-book", json={"place": "Gotham"}
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["found"] is False
+        assert data["candidates"] == []
+        assert "Gotham" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_blank_place_rejected_before_resolver(
+        self, test_client, reset_p2b_singleton
+    ):
+        import api.dependencies as deps
+
+        fake = _FakeResolver(
+            PlaceToBookResult(place="x", query="x", found=False, candidates=[])
+        )
+        deps._place_to_book_resolver = fake
+
+        response = await test_client.post(
+            "/api/v1/place-to-book", json={"place": "   "}
+        )
+        assert response.status_code == 422
+        assert fake.calls == []  # validation short-circuits before the resolver
+
+    @pytest.mark.asyncio
+    async def test_missing_place_rejected(self, test_client, reset_p2b_singleton):
+        response = await test_client.post("/api/v1/place-to-book", json={})
+        assert response.status_code == 422


### PR DESCRIPTION
# feat: expose place→book reverse-routing over HTTP (gateway-internal endpoint)

## What
Adds `POST /api/v1/place-to-book`, a gateway-internal (secret-enforced) JSON endpoint that wraps the existing `PlaceToBookResolver` reverse-routing capability. Given a free-text destination it returns grounded, literal/vibe-labelled book candidates (`PlaceToBookResult`), or a clean `found=false` empty envelope when the place can't be grounded. The resolver is exposed as a lazy process-wide singleton that reuses the executor's already-constructed model, and a `model` property is added to `WorkflowExecutor` to support that.

This is one increment of the larger Place→Book reverse-discovery feature. It is the wiring step that makes the resolver reachable from the storyland-services gateway — it is **not** user-facing on its own (no FE entry yet; the gateway still serves its curated seed until it swaps to this endpoint).

## Why
The reverse-routing resolver landed in an earlier increment as an **isolated capability**, explicitly *not* wired into the HTTP API (see the module docstring in `core/place_to_book.py`). The gateway (storyland-services) talks to this service strictly over HTTP, so before the gateway can swap its curated place→book seed for live AI candidates it needs an HTTP surface to call. This PR provides exactly that stable, bounded contract for the gateway to integrate against — mirroring the "BE contract lands first, then integrate" sequencing already used across the service boundary.

The resolver's recommendation/grounding logic is unchanged; this PR only adds an HTTP entrypoint over it. Output is identical to the already-validated isolated capability, so no model/agent behavior changes.

## How
- `api/routes.py`: new `place_to_book` handler on the existing gateway `router` (so `verify_gateway_secret` applies → internal-only). Non-streaming JSON — the resolver is a single bounded, in-process-cached lookup, unlike the SSE itinerary flows. `response_model=PlaceToBookResult` (reused from `models/place_to_book.py`).
- `api/models.py`: new `PlaceToBookRequest` (`place`, 1–120 chars, trimmed, non-empty) — `max_length=120` matches the gateway's existing query bound.
- `api/dependencies.py`: `get_place_to_book_resolver()` lazy singleton, built from `app_state.executor.model`; reset on `shutdown()`. Keeps one Gemini client and a warm in-process cache; the resolver keeps its own in-memory session service, isolated from the discovery/compose lifecycle.
- `core/executor.py`: additive `model` property (mirrors the existing `session_service`/`config` properties).
- No new deps, no new model/API, no schema/migration/secret/auth change. Additive and flagless; rollback = revert.

PR is one increment of a multi-PR feature. It precedes the gateway "swap curated seed → live AI candidates" increment (which will add the gateway-side client method that calls this endpoint and runs the authoritative Google Books existence check on each returned candidate). Grounding posture is unchanged: literal matches name a real `maps_to`; vibe matches force `maps_to=None`; ungroundable places return a clean not-found state — never a fabricated list.

## Review & test
- Focus: the route is correctly mounted under the gateway-secret router (`/api/v1/place-to-book`, internal-only); the resolver singleton is reused (not re-created per request) and reset on shutdown; the not-found / empty-candidate path is preserved end-to-end.
- Added unit tests in `tests/unit/test_api.py`: `PlaceToBookRequest` validation (trim, blank/missing rejected, max-length) and the endpoint with the resolver mocked (no network) — labelled-candidate path, not-found envelope, blank-place 422 short-circuits before the resolver, missing-place 422.
- Verify: `make test` (full unit suite, offline). Targeted: `pytest tests/unit/test_api.py -k "PlaceToBook"`.
- **Test-run note:** the full suite could **not** be executed in the build sandbox this run — the `google-adk`/`grpcio` dependency wheels would not download (package-index access stalled in the sandbox), so the venv could not be provisioned. All five changed files pass `python -m py_compile`, and the change mirrors the existing (tested) `get_status` route and the already-merged+eval-validated resolver. Please confirm green via CI / `make test` on re-review before merge.

*No eval needed: this PR adds an HTTP wrapper over the already-merged, already-eval-validated resolver and does not change agent/recommendation logic or output.*