### PR TITLE
feat(ai): derive match_type server-side — downgrade ungrounded litera…

### DIFF
--- a/core/extraction.py
+++ b/core/extraction.py
@@ -95,6 +95,60 @@ def extract_json_from_text(text: str) -> Optional[dict]:
     return None
 
 
+# Match types that assert a grounded, verifiable book<->place connection and
+# therefore must trace to the grounded discovery research. The other two
+# ("thematic", "vibe") are explicitly weaker/atmospheric claims that need no
+# source, so they are never touched here.
+_GROUNDED_MATCH_TYPES = ("literal", "historical")
+
+# The weakest, safest claim. An ungroundable strong claim is downgraded to this
+# (never dropped, never upgraded), mirroring the schema default and the org
+# "choose the weaker claim when unsure" guardrail.
+_DOWNGRADE_TARGET = "vibe"
+
+
+def downgrade_ungrounded_match_types(
+    itinerary_dict: Optional[dict], grounding_text: str
+) -> Optional[dict]:
+    """Downgrade literal/historical stops that don't trace to grounded research.
+
+    The trust core of the hallucination guardrail: the formatter self-labels each
+    stop's ``match_type``, but a self-label is not evidence. Here we *derive* the
+    label server-side from a real check — any stop the formatter marked
+    ``literal``/``historical`` whose name does not appear in the grounded
+    discovery research (city/landmark/author/context) is downgraded to the
+    weakest claim (``vibe``) and has its ``grounding_source`` cleared, since the
+    cited evidence didn't hold up. Stops are never dropped and never upgraded.
+
+    Conservative and fail-open by design (it must never make results worse):
+      * No grounding text captured -> return unchanged (we cannot prove anything
+        is ungrounded, e.g. the local-atmosphere path has no discovery research).
+      * ``thematic``/``vibe`` stops are left untouched (no source required).
+    """
+    if not itinerary_dict:
+        return itinerary_dict
+
+    haystack = _normalize_text(grounding_text)
+    if not haystack:
+        return itinerary_dict
+
+    downgraded = 0
+    for city in itinerary_dict.get("cities") or []:
+        for stop in city.get("stops") or []:
+            if stop.get("match_type") not in _GROUNDED_MATCH_TYPES:
+                continue
+            name = _normalize_text(stop.get("name"))
+            if name and name in haystack:
+                continue
+            stop["match_type"] = _DOWNGRADE_TARGET
+            stop["grounding_source"] = None
+            downgraded += 1
+
+    if downgraded:
+        logger.info("itinerary_match_type_downgraded", downgraded=downgraded)
+    return itinerary_dict
+
+
 def extract_itinerary_from_response(
     final_response, state_accessor
 ) -> Optional[Tuple[dict, list]]:
@@ -110,20 +164,25 @@ def extract_itinerary_from_response(
     Returns:
         (itinerary_dict, suggestions_list) tuple or None
     """
+    grounding_text = state_accessor.grounding_research_text
+
+    def _finalize(itinerary_dict, suggestions):
+        return downgrade_ungrounded_match_types(itinerary_dict, grounding_text), suggestions
+
     # Primary: composer_envelope from session state (set by output_key="composer_envelope")
     envelope_data = state_accessor.composer_envelope
     if envelope_data is not None:
         result = validate_composer_envelope(envelope_data)
         if result is not None:
             logger.info("itinerary_from_envelope")
-            return result
+            return _finalize(*result)
 
     # Legacy fallback: bare TripItinerary from state (set by output_key="final_itinerary")
     state_itinerary = state_accessor.final_itinerary
     itinerary_result = validate_trip_itinerary(state_itinerary)
     if itinerary_result is not None:
         logger.info("itinerary_from_state")
-        return itinerary_result, []
+        return _finalize(itinerary_result, [])
 
     # Text fallback: parse from final response text
     if (
@@ -139,12 +198,12 @@ def extract_itinerary_from_response(
                     env_result = validate_composer_envelope(candidate)
                     if env_result is not None:
                         logger.info("itinerary_from_text_envelope_fallback")
-                        return env_result
+                        return _finalize(*env_result)
                     # Then bare itinerary
                     itinerary_result = validate_trip_itinerary(candidate)
                     if itinerary_result is not None:
                         logger.info("itinerary_from_text_fallback")
-                        return itinerary_result, []
+                        return _finalize(itinerary_result, [])
 
     return None
 

--- a/core/session_state.py
+++ b/core/session_state.py
@@ -5,6 +5,7 @@ Wraps the ADK session.state dict with typed properties, eliminating
 magic string key access scattered across the codebase.
 """
 
+import json
 from typing import Optional, List
 
 
@@ -138,6 +139,47 @@ class SessionStateAccessor:
     @property
     def book_context(self) -> Optional[dict]:
         return self._state.get(SessionStateKeys.BOOK_CONTEXT)
+
+    @property
+    def city_discovery(self) -> Optional[object]:
+        return self._state.get(SessionStateKeys.CITY_DISCOVERY)
+
+    @property
+    def landmark_discovery(self) -> Optional[object]:
+        return self._state.get(SessionStateKeys.LANDMARK_DISCOVERY)
+
+    @property
+    def author_sites(self) -> Optional[object]:
+        return self._state.get(SessionStateKeys.AUTHOR_SITES)
+
+    @property
+    def grounding_research_text(self) -> str:
+        """Concatenate the grounded discovery research into one text blob.
+
+        Joins the book-context, city, landmark, and author-site discovery
+        outputs (the grounded research the composer draws from) into a single
+        string so itinerary claims can be checked against what the grounding
+        chain actually found. Returns "" when no discovery research is present
+        (e.g. the local-atmosphere path), which callers treat as "cannot prove
+        anything ungrounded" and leave labels unchanged.
+        """
+        parts: List[str] = []
+        for value in (
+            self.book_context,
+            self.city_discovery,
+            self.landmark_discovery,
+            self.author_sites,
+        ):
+            if not value:
+                continue
+            if isinstance(value, str):
+                parts.append(value)
+            else:
+                try:
+                    parts.append(json.dumps(value, ensure_ascii=False, default=str))
+                except (TypeError, ValueError):
+                    parts.append(str(value))
+        return "\n".join(parts)
 
     @property
     def last_book_recommendations(self) -> Optional[dict]:

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -35,6 +35,7 @@ from core.extraction import (
     extract_itinerary_from_response,
     extract_expansion_from_state,
     extract_book_recommendations_from_state,
+    downgrade_ungrounded_match_types,
 )
 from core.events import ExpansionReady
 from core.regions import get_valid_region_ids, validate_region_selection
@@ -784,3 +785,143 @@ class TestExtractBookRecommendationsFromState:
     def test_returns_none_for_invalid_data(self):
         accessor = SessionStateAccessor({"last_book_recommendations": {"bad": "data"}})
         assert extract_book_recommendations_from_state(accessor) is None
+
+
+# =============================================================================
+# Hallucination guardrail — match_type grounding assertion (PR 2 of 4)
+# =============================================================================
+
+
+def _itinerary_with_stops(stops):
+    return {
+        "cities": [
+            {
+                "name": "Atlanta",
+                "country": "United States",
+                "days_suggested": 2,
+                "overview": "test",
+                "stops": stops,
+            }
+        ],
+        "summary_text": "test",
+    }
+
+
+def _stop(name, match_type, grounding_source=None):
+    return {
+        "name": name,
+        "type": "landmark",
+        "reason": "test",
+        "time_of_day": "morning",
+        "source": "composed",
+        "match_type": match_type,
+        "grounding_source": grounding_source,
+    }
+
+
+# Grounded research that names a real, sourced place but NOT the fabricated one.
+_RESEARCH = "Margaret Mitchell House is the author's home in Atlanta where she wrote the novel."
+
+
+class TestDowngradeUngroundedMatchTypes:
+    def test_ungrounded_literal_downgraded_to_vibe(self):
+        itin = _itinerary_with_stops(
+            [_stop("Faulkner Invented Manor", "literal", grounding_source="chapter 3")]
+        )
+        out = downgrade_ungrounded_match_types(itin, _RESEARCH)
+        stop = out["cities"][0]["stops"][0]
+        assert stop["match_type"] == "vibe"
+        # the cited source did not hold up -> cleared
+        assert stop["grounding_source"] is None
+
+    def test_grounded_literal_preserved(self):
+        itin = _itinerary_with_stops(
+            [_stop("Margaret Mitchell House", "literal", grounding_source="author's home")]
+        )
+        out = downgrade_ungrounded_match_types(itin, _RESEARCH)
+        stop = out["cities"][0]["stops"][0]
+        assert stop["match_type"] == "literal"
+        assert stop["grounding_source"] == "author's home"
+
+    def test_ungrounded_historical_downgraded(self):
+        itin = _itinerary_with_stops([_stop("Nonexistent Battlefield", "historical")])
+        out = downgrade_ungrounded_match_types(itin, _RESEARCH)
+        assert out["cities"][0]["stops"][0]["match_type"] == "vibe"
+
+    def test_thematic_and_vibe_untouched(self):
+        itin = _itinerary_with_stops(
+            [_stop("Some Atmospheric Cafe", "thematic"), _stop("A Moody Park", "vibe")]
+        )
+        out = downgrade_ungrounded_match_types(itin, _RESEARCH)
+        assert out["cities"][0]["stops"][0]["match_type"] == "thematic"
+        assert out["cities"][0]["stops"][1]["match_type"] == "vibe"
+
+    def test_never_drops_stops(self):
+        itin = _itinerary_with_stops(
+            [
+                _stop("Margaret Mitchell House", "literal"),
+                _stop("Invented Place", "literal"),
+                _stop("Mood Cafe", "vibe"),
+            ]
+        )
+        out = downgrade_ungrounded_match_types(itin, _RESEARCH)
+        assert len(out["cities"][0]["stops"]) == 3
+
+    def test_fail_open_when_no_research(self):
+        itin = _itinerary_with_stops([_stop("Invented Place", "literal", grounding_source="x")])
+        out = downgrade_ungrounded_match_types(itin, "")
+        stop = out["cities"][0]["stops"][0]
+        # cannot prove ungrounded -> labels untouched
+        assert stop["match_type"] == "literal"
+        assert stop["grounding_source"] == "x"
+
+    def test_matching_is_case_insensitive(self):
+        itin = _itinerary_with_stops([_stop("margaret mitchell HOUSE", "literal")])
+        out = downgrade_ungrounded_match_types(itin, _RESEARCH)
+        assert out["cities"][0]["stops"][0]["match_type"] == "literal"
+
+    def test_none_itinerary_returns_none(self):
+        assert downgrade_ungrounded_match_types(None, _RESEARCH) is None
+
+
+class TestGroundingResearchText:
+    def test_concatenates_discovery_keys(self):
+        accessor = SessionStateAccessor(
+            {
+                "book_context": {"themes": ["war"]},
+                "landmark_discovery": "Margaret Mitchell House, Atlanta",
+                "city_discovery": {"cities": ["Atlanta"]},
+            }
+        )
+        text = accessor.grounding_research_text
+        assert "Margaret Mitchell House" in text
+        assert "Atlanta" in text
+        assert "war" in text
+
+    def test_empty_when_no_discovery(self):
+        assert SessionStateAccessor({}).grounding_research_text == ""
+
+
+class TestExtractItineraryAppliesDowngrade:
+    def test_envelope_path_downgrades_ungrounded_literal(self):
+        itin = _itinerary_with_stops([_stop("Invented Place", "literal", grounding_source="x")])
+        envelope = {"itinerary": itin, "suggestions": []}
+        accessor = SessionStateAccessor(
+            {
+                "composer_envelope": envelope,
+                "landmark_discovery": "Margaret Mitchell House is in Atlanta.",
+            }
+        )
+        result = extract_itinerary_from_response(None, accessor)
+        assert result is not None
+        itinerary, _ = result
+        stop = itinerary["cities"][0]["stops"][0]
+        assert stop["match_type"] == "vibe"
+        assert stop["grounding_source"] is None
+
+    def test_envelope_path_fail_open_without_discovery(self):
+        itin = _itinerary_with_stops([_stop("Invented Place", "literal")])
+        envelope = {"itinerary": itin, "suggestions": []}
+        accessor = SessionStateAccessor({"composer_envelope": envelope})
+        itinerary, _ = extract_itinerary_from_response(None, accessor)
+        assert itinerary["cities"][0]["stops"][0]["match_type"] == "literal"


### PR DESCRIPTION
## What
Adds a server-side grounding assertion over the composed itinerary: every place stop the formatter labels `literal` or `historical` must trace to the grounded discovery research, otherwise its `match_type` is downgraded to the weakest claim (`vibe`) and its `grounding_source` is cleared. Stops are never dropped and never upgraded. `thematic`/`vibe` stops are left untouched. The check fails open — when no discovery research was captured (e.g. the local-atmosphere path), labels are left unchanged.

PR 1 (#163) added the `match_type` + `grounding_source` fields to `CityStop`; this PR adds the enforcement that makes the label trustworthy. PR 3 (be passthrough) and PR 4 (fe chip) follow. Not user-facing on its own.

## Why
Storyland's #1 quality risk is the AI fabricating book<->place connections. After PR 1 the formatter self-labels each stop, but a self-label is not evidence — a hallucinated `literal` claim renders identically to a sourced one. This PR derives the label from a real check instead of trusting the formatter: a strong (`literal`/`historical`) claim survives only if the place name appears in the grounded discovery research (book-context / city / landmark / author-site outputs the composer drew from). Ambiguous/ungroundable strong claims degrade to the safest claim rather than being surfaced as fact — matching the org "choose the weaker claim when unsure" guardrail and the schema's `vibe` default.

## How
- `core/session_state.py`: adds `city_discovery` / `landmark_discovery` / `author_sites` accessors and a `grounding_research_text` property that concatenates the grounded discovery outputs into one text blob (JSON-serialising non-string values), returning `""` when no discovery research is present.
- `core/extraction.py`: adds `downgrade_ungrounded_match_types(itinerary_dict, grounding_text)` — tolerant, case-insensitive substring match of each stop's name against the grounding haystack; downgrades unmatched `literal`/`historical` stops to `vibe` and nulls their `grounding_source`. Wired into `extract_itinerary_from_response` via a small `_finalize` step so all extraction paths (envelope, bare-itinerary, text fallback) apply it uniformly. Mirrors the existing `filter_grounded_recommendations` / place->book grounding filters (output-side, fail-open, never makes results worse).
- No prompt change, no new model/API/dep, no schema/migration/secret/auth. Additive and flagless; rollback = revert.

## Review & test
Focus: confirm (1) downgrade never drops or upgrades a stop, (2) the fail-open paths (no research captured, or research present but stop genuinely grounded) leave labels intact, (3) the haystack is assembled from the grounded discovery state, not the formatter's own output.
- New unit tests in `tests/unit/test_core.py`: `TestDowngradeUngroundedMatchTypes` (ungrounded literal->vibe + source cleared, grounded literal preserved, ungrounded historical->vibe, thematic/vibe untouched, never-drops, fail-open-without-research, case-insensitive, None->None), `TestGroundingResearchText`, and `TestExtractItineraryAppliesDowngrade` (end-to-end through `extract_itinerary_from_response`).
- Verify: `make test` (full offline unit suite).
- Test-run note: the full suite could not be executed in the build sandbox this run — the `google-adk`/`grpcio` dependency wheels would not download, so the venv could not be provisioned. The two changed source files + the test file pass `python -m py_compile`, and the new logic was verified directly against the real `core.extraction`/`core.session_state` modules (which do not import `google-adk`) — all 12 assertions pass. Please confirm `make test` is green via CI before merge.

## Grounding / gate
This changes the grounding/recommendation path, so the org **mandatory QA factual-grounding sign-off** applies and is a **founder-notified G4 eval-spend gate** (the eval makes live Gemini calls). A scoped EVAL handoff is filed marked `HOLD — DO NOT RUN: founder spend-approval required`; delivery stays **provisional** until Olga approves the spend and the `geographical_accuracy` / `book_relevance` scores come back non-regressed on the eval set. The eval is NOT auto-run.

PR 2 of 4 — Hallucination guardrail (match_type label + grounding check). Follows: PR 3 (`be` passthrough), PR 4 (`fe` chip).
