### PR TITLE
feat(eval): place→book reverse-routing grounding eval runner + Langfuse run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # StoryLand AI - Makefile
 # Common commands for development and demo
 
-.PHONY: help install install-dev test test-cov test-agents test-models test-tools test-services test-api test-integration test-integration-live test-integration-vcr-record test-all eval eval-setup eval-setup-one eval-run eval-summary eval-report eval-export run-api db-reset db-show db-users clean check-env
+.PHONY: help install install-dev test test-cov test-agents test-models test-tools test-services test-api test-integration test-integration-live test-integration-vcr-record test-all eval eval-setup eval-setup-one eval-run eval-place-to-book eval-summary eval-report eval-export run-api db-reset db-show db-users clean check-env
 
 # Default target
 help:
@@ -26,7 +26,8 @@ help:
 	@echo "Evaluation (Langfuse):"
 	@echo "  make eval-setup              Create Langfuse datasets from all evalsets"
 	@echo "  make eval-setup-one EVALSET_FILE=<path>  Register a single evalset file"
-	@echo "  make eval-run      Run scheduled evaluations"
+	@echo "  make eval-run      Run scheduled evaluations (itinerary, book->place)"
+	@echo "  make eval-place-to-book      Run the place->book reverse-routing grounding eval"
 	@echo "  make eval-report   Generate evaluation trend report"
 	@echo "  make eval-summary  Show evaluation summary"
 	@echo ""
@@ -102,6 +103,9 @@ eval-setup-one:
 
 eval-run:
 	PYTHONIOENCODING=utf-8 .venv/bin/python evaluation/tools/run_scheduled_eval.py --output-dir evaluation/results --max-cases 10
+
+eval-place-to-book:
+	PYTHONIOENCODING=utf-8 .venv/bin/python evaluation/tools/run_place_to_book_eval.py --output-dir evaluation/results
 
 eval-summary:
 	.venv/bin/python evaluation/tools/eval_dashboard.py --action summary --days 7

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -48,12 +48,33 @@ This creates two datasets in Langfuse:
 ### Run Evaluations
 
 ```bash
-# Using Makefile
+# Itinerary (book→place) — LLM-as-judge scoring on the storyland_eval / books_v1 datasets
 make eval-run
-
-# Or directly
+# Or directly:
 python evaluation/tools/run_scheduled_eval.py
 ```
+
+### Place→Book grounding eval (reverse routing)
+
+The `place_to_book_v1` dataset is **not** scored by the itinerary judge — it is a
+deterministic grounding gate for the reverse-routing capability (`PlaceToBookResolver`):
+a real destination must return at least `min_literal` grounded `literal` candidates
+(each naming a real `maps_to`), and a fictional/ungroundable place must return the clean
+not-found state with no fabricated list. It has its own runner:
+
+```bash
+make eval-place-to-book
+# Or directly (re-registers the dataset items from the evalset, then runs all cases):
+python evaluation/tools/run_place_to_book_eval.py [--max-cases N] [--no-register]
+```
+
+Each case logs a Langfuse dataset run (`p2b_eval_YYYYMMDD_HHMMSS`) under `place_to_book_v1`
+with scores: `case_pass` (0/1), `found_classification` (0/1), `literal_grounded` (count),
+and `grounding_clean` (0/1 — every `literal` has a `maps_to`, every `vibe` has none).
+
+> Note: `_extract_input_from_case` stores `{place}` (not `{book_title, author}`) for
+> place→book cases, and carries the grounding expectations (`expect`, `min_literal`,
+> `expected_literal_examples`) into item metadata so the runner has a target to score.
 
 ### View Results
 
@@ -227,13 +248,15 @@ runner = Runner(agent=my_agent, plugins=[LoggingPlugin()])
 evaluation/
 ├── README.md                      # This file
 ├── tools/                         # Evaluation scripts
-│   ├── run_scheduled_eval.py      # Main evaluation runner
+│   ├── run_scheduled_eval.py      # Itinerary (book→place) eval runner — LLM-as-judge
+│   ├── run_place_to_book_eval.py  # Place→book reverse-routing grounding eval runner
 │   ├── eval_dashboard.py          # Dashboard and reporting
 │   ├── langfuse_eval.py           # Dataset creation pipeline
 │   ├── llm_scorer.py              # LLM-as-judge quality scoring
 │   └── setup_langfuse_eval.sh     # Setup script
 ├── storyland_eval.evalset.json    # Dataset (8 diverse books)
 ├── books_v1.evalset.json          # Dataset (10 books with expected output + criteria)
+├── place_to_book_v1.evalset.json  # Dataset (11 place→book reverse-routing grounding cases)
 ├── langfuse_datasets.json         # Dataset registry (gitignored)
 ├── results/                       # Evaluation run results (gitignored)
 ├── trend_report.md                # Generated trend report (tracked)

--- a/evaluation/tools/langfuse_eval.py
+++ b/evaluation/tools/langfuse_eval.py
@@ -144,6 +144,13 @@ class LangfuseEvalPipeline:
                 'creation_timestamp': case.get('creation_timestamp'),
                 'quality_criteria': quality_criteria,
             }
+            # Reverse-routing (place→book) grounding expectations, when present.
+            # These drive run_place_to_book_eval.py's pass/fail scoring; without
+            # them the item carries no usable target (the generic itinerary
+            # extractor would otherwise store an empty {book_title, author}).
+            for key in ('expect', 'min_literal', 'expected_literal_examples', 'notes'):
+                if key in case:
+                    metadata[key] = case[key]
 
             self.client.create_dataset_item(
                 dataset_name=dataset_name,
@@ -157,7 +164,15 @@ class LangfuseEvalPipeline:
         return dataset_name
 
     def _extract_input_from_case(self, case: Dict[str, Any]) -> Dict[str, Any]:
-        """Extract input data from eval case."""
+        """Extract input data from eval case.
+
+        Supports both evalset shapes:
+        - itinerary (book→place): ``{book_title, author}``
+        - reverse-routing (place→book): ``{place}`` — the resolver input for
+          ``run_place_to_book_eval.py``.
+        """
+        if case.get('place'):
+            return {'place': case['place']}
         return {
             'book_title': case.get('book_title', ''),
             'author': case.get('author', ''),

--- a/evaluation/tools/run_place_to_book_eval.py
+++ b/evaluation/tools/run_place_to_book_eval.py
@@ -1,0 +1,237 @@
+"""Run the place→book reverse-routing grounding eval against Langfuse.
+
+The itinerary eval (``run_scheduled_eval.py``) composes book→place itineraries
+and scores them with an LLM judge. The place→book capability is the *reverse*
+(``PlaceToBookResolver``: a destination → grounded, labelled book candidates),
+so it needs its own runner: a deterministic grounding check, not an LLM judge.
+
+For each ``place_to_book_v1`` dataset item this script:
+  1. resolves the place through the live ``PlaceToBookResolver``;
+  2. checks the evalset's grounding expectations (a real place returns at least
+     ``min_literal`` grounded ``literal`` candidates; a fictional/ungroundable
+     place returns the clean not-found state with no fabricated list);
+  3. logs a Langfuse dataset run with per-case scores, so the result shows up as
+     a proper experiment under the ``place_to_book_v1`` dataset alongside the
+     itinerary runs.
+
+Usage:
+    python evaluation/tools/run_place_to_book_eval.py [--max-cases N] [--no-register]
+"""
+
+import asyncio
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from common.config import load_config
+from common.logging import configure_logging, get_logger
+
+try:
+    from langfuse import Langfuse
+    LANGFUSE_AVAILABLE = True
+except ImportError:  # pragma: no cover - import guard
+    LANGFUSE_AVAILABLE = False
+
+logger = get_logger("storyland.place_to_book_eval")
+
+DATASET_NAME = "place_to_book_v1"
+EVALSET_FILE = "evaluation/place_to_book_v1.evalset.json"
+
+
+def score_case(result, expect: str, min_literal: Optional[int]) -> Dict[str, Any]:
+    """Score one resolved place against its grounding expectation.
+
+    Returns a dict with the boolean verdict plus the numeric signals logged to
+    Langfuse. ``literal`` candidates that survive ``enforce_label_invariants``
+    are, by construction, grounded (they name a real ``maps_to``); ``vibe``
+    candidates carry ``maps_to=None``.
+    """
+    candidates = [
+        {
+            "title": c.title,
+            "author": c.author,
+            "match_type": c.match_type,
+            "maps_to": c.maps_to,
+        }
+        for c in result.candidates
+    ]
+    n_literal_grounded = sum(
+        1 for c in candidates
+        if c["match_type"] == "literal" and (c["maps_to"] or "").strip()
+    )
+    # Invariant guard: literal => has maps_to; vibe => maps_to is null.
+    grounding_clean = all(
+        (c["match_type"] == "literal" and (c["maps_to"] or "").strip())
+        or (c["match_type"] == "vibe" and not (c["maps_to"] or "").strip())
+        for c in candidates
+    )
+
+    if expect == "found":
+        passed = bool(result.found) and n_literal_grounded >= (min_literal or 1)
+    else:  # not_found
+        passed = (not result.found) and len(candidates) == 0
+
+    found_classification = float(result.found == (expect == "found"))
+
+    return {
+        "expect": expect,
+        "found": bool(result.found),
+        "n_candidates": len(candidates),
+        "n_literal_grounded": n_literal_grounded,
+        "min_literal": min_literal,
+        "grounding_clean": bool(grounding_clean),
+        "found_classification": found_classification,
+        "pass": bool(passed),
+        "candidates": candidates,
+    }
+
+
+async def run(max_cases: Optional[int], register: bool, output_dir: str) -> Dict[str, Any]:
+    config = load_config()
+    configure_logging(level=config.log_level, enable_adk_debug=config.enable_adk_debug)
+
+    if not LANGFUSE_AVAILABLE:
+        raise RuntimeError("langfuse package not available")
+    if not (config.langfuse_public_key and config.langfuse_secret_key):
+        raise RuntimeError(
+            "Langfuse credentials missing — set LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY"
+        )
+
+    # Refresh the dataset items from the evalset so they carry the place + the
+    # grounding expectations (the generic itinerary extractor stored neither).
+    if register:
+        from evaluation.tools.langfuse_eval import LangfuseEvalPipeline
+        LangfuseEvalPipeline().create_dataset_from_evalset(
+            EVALSET_FILE, dataset_name=DATASET_NAME
+        )
+        logger.info("place_to_book_dataset_refreshed", dataset=DATASET_NAME)
+
+    from api import dependencies
+    await dependencies.initialize()
+    resolver = dependencies.get_place_to_book_resolver()
+
+    langfuse = Langfuse(
+        secret_key=config.langfuse_secret_key,
+        public_key=config.langfuse_public_key,
+        host=config.langfuse_host or "https://cloud.langfuse.com",
+    )
+    dataset = langfuse.get_dataset(DATASET_NAME)
+    items = list(dataset.items)
+    if max_cases is not None:
+        items = items[:max_cases]
+
+    run_name = f"p2b_eval_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+    run_metadata = {"dataset_name": DATASET_NAME, "evaluation_type": "place_to_book_grounding"}
+    case_results: List[Dict[str, Any]] = []
+
+    logger.info("starting_place_to_book_eval", dataset=DATASET_NAME, cases=len(items), run_name=run_name)
+
+    for item in items:
+        place = (item.input or {}).get("place")
+        meta = item.metadata or {}
+        expect = meta.get("expect", "found")
+        min_literal = meta.get("min_literal")
+
+        if not place:
+            logger.warning("place_to_book_item_missing_place", item_id=item.id)
+            case_results.append({"item_id": item.id, "status": "skipped", "reason": "no place in input"})
+            continue
+
+        with langfuse.start_as_current_observation(
+            as_type="span", name=run_name, metadata={**run_metadata, "eval_id": item.id},
+        ) as root_span:
+            try:
+                result = await resolver.resolve(place)
+                scored = score_case(result, expect, min_literal)
+                try:
+                    root_span.update(input={"place": place}, output=scored)
+                except Exception:  # pragma: no cover - richness only, never fatal
+                    pass
+                root_span.score_trace(
+                    name="case_pass", value=float(scored["pass"]),
+                    comment=f"{place}: expect={expect}, found={scored['found']}, "
+                            f"literal_grounded={scored['n_literal_grounded']}/{min_literal}",
+                )
+                root_span.score_trace(
+                    name="found_classification", value=scored["found_classification"],
+                    comment="1.0 = found/not-found matches the expected grounding state",
+                )
+                root_span.score_trace(
+                    name="literal_grounded", value=float(scored["n_literal_grounded"]),
+                    comment="Count of grounded `literal` candidates (each names a real maps_to)",
+                )
+                root_span.score_trace(
+                    name="grounding_clean", value=float(scored["grounding_clean"]),
+                    comment="1.0 = every literal has a maps_to and every vibe has none (no fabrication)",
+                )
+                case_results.append({"item_id": item.id, "place": place, "run_name": run_name, **scored})
+                logger.info(
+                    "place_to_book_case_evaluated", item_id=item.id, place=place,
+                    passed=scored["pass"], found=scored["found"],
+                    literal_grounded=scored["n_literal_grounded"],
+                )
+            finally:
+                langfuse.api.dataset_run_items.create(
+                    run_name=run_name,
+                    run_description=f"place→book grounding eval of {DATASET_NAME}",
+                    metadata=run_metadata,
+                    dataset_item_id=item.id,
+                    trace_id=root_span.trace_id,
+                    observation_id=root_span.id,
+                )
+
+    langfuse.flush()
+
+    evaluated = [c for c in case_results if "pass" in c]
+    passed = sum(1 for c in evaluated if c["pass"])
+    summary = {
+        "dataset_name": DATASET_NAME,
+        "run_name": run_name,
+        "timestamp": datetime.now().isoformat(),
+        "total": len(case_results),
+        "evaluated": len(evaluated),
+        "passed": passed,
+        "failed": len(evaluated) - passed,
+        "case_results": case_results,
+    }
+
+    out_path = Path(output_dir) / f"place_to_book_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(summary, indent=2, ensure_ascii=False))
+
+    print("\n" + "=" * 60)
+    print(f"place→book grounding eval — {DATASET_NAME}")
+    print("=" * 60)
+    for c in case_results:
+        if "pass" in c:
+            print(f"  [{'PASS' if c['pass'] else 'FAIL'}] {c['item_id']:<24} "
+                  f"expect={c['expect']:<9} found={c['found']} "
+                  f"literal_grounded={c['n_literal_grounded']}")
+        else:
+            print(f"  [SKIP] {c['item_id']} ({c.get('reason')})")
+    print("=" * 60)
+    print(f"Result: {passed}/{len(evaluated)} PASS | Langfuse run: {run_name}")
+    print(f"Results saved to {out_path}")
+    return summary
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run the place→book grounding eval against Langfuse")
+    parser.add_argument("--max-cases", type=int, default=None, help="Limit number of cases (default: all)")
+    parser.add_argument("--output-dir", default="evaluation/results", help="Directory for the local results JSON")
+    parser.add_argument(
+        "--no-register", action="store_true",
+        help="Skip refreshing dataset items from the evalset (assume already correct)",
+    )
+    args = parser.parse_args()
+    asyncio.run(run(max_cases=args.max_cases, register=not args.no_register, output_dir=args.output_dir))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_place_to_book_eval.py
+++ b/tests/unit/test_place_to_book_eval.py
@@ -1,0 +1,56 @@
+"""Unit tests for the place→book grounding eval scorer (run_place_to_book_eval.score_case)."""
+
+from types import SimpleNamespace
+
+from evaluation.tools.run_place_to_book_eval import score_case
+
+
+def _cand(match_type, maps_to, title="T", author="A"):
+    return SimpleNamespace(title=title, author=author, match_type=match_type, maps_to=maps_to)
+
+
+def _result(found, candidates):
+    return SimpleNamespace(found=found, candidates=candidates)
+
+
+def test_found_passes_with_enough_grounded_literals():
+    result = _result(True, [_cand("literal", "Baixa, Lisbon"), _cand("vibe", None)])
+    scored = score_case(result, expect="found", min_literal=1)
+    assert scored["pass"] is True
+    assert scored["n_literal_grounded"] == 1
+    assert scored["found_classification"] == 1.0
+    assert scored["grounding_clean"] is True
+
+
+def test_found_fails_when_below_min_literal():
+    # Only vibe candidates → zero grounded literals, fails min_literal=1.
+    result = _result(True, [_cand("vibe", None), _cand("vibe", None)])
+    scored = score_case(result, expect="found", min_literal=1)
+    assert scored["pass"] is False
+    assert scored["n_literal_grounded"] == 0
+
+
+def test_literal_without_maps_to_does_not_count_and_flags_unclean():
+    result = _result(True, [_cand("literal", None)])
+    scored = score_case(result, expect="found", min_literal=1)
+    assert scored["n_literal_grounded"] == 0
+    assert scored["grounding_clean"] is False
+    assert scored["pass"] is False
+
+
+def test_not_found_passes_on_clean_empty():
+    result = _result(False, [])
+    scored = score_case(result, expect="not_found", min_literal=None)
+    assert scored["pass"] is True
+    assert scored["found_classification"] == 1.0
+
+
+def test_not_found_fails_when_place_returns_candidates():
+    # Wakanda-style: a fictional place that surfaces vibe candidates instead of
+    # the clean not-found state. No fabrication (grounding_clean), but the
+    # not-found classification is wrong → the case must fail.
+    result = _result(True, [_cand("vibe", None), _cand("vibe", None)])
+    scored = score_case(result, expect="not_found", min_literal=None)
+    assert scored["pass"] is False
+    assert scored["found_classification"] == 0.0
+    assert scored["grounding_clean"] is True


### PR DESCRIPTION
## TL;DR
The place→book reverse-routing eval (`place_to_book_v1`) had no runner and its Langfuse dataset was mis-registered (empty inputs), so it could never run. This adds a dedicated runner that scores grounding deterministically and logs a proper Langfuse experiment, and fixes the registration. First run: **10/11 PASS** (Langfuse run `p2b_eval_20260621_223626`).

## What changed
- **`evaluation/tools/run_place_to_book_eval.py`** (new): for each `place_to_book_v1` case, resolves the place through the live `PlaceToBookResolver`, scores it deterministically (no LLM judge — this is the reverse of the itinerary eval), and logs a Langfuse dataset run with per-case scores: `case_pass`, `found_classification`, `literal_grounded` (count), `grounding_clean`.
- **`evaluation/tools/langfuse_eval.py`**: `_extract_input_from_case` now stores `{place}` for place→book cases (it was storing an empty `{book_title, author}`), and the grounding expectations (`expect`, `min_literal`, `expected_literal_examples`) are carried into item metadata so the runner has a target.
- **`Makefile`**: `make eval-place-to-book`.
- **`evaluation/README.md`**: documents the reverse-routing eval and its scores.
- **`tests/unit/test_place_to_book_eval.py`** (new): scorer coverage.

## Why
The hallucination guardrail for place→book (the reverse-routing capability, ai #164/#167) needs the same grounding validation the itinerary path gets. The dataset existed but was registered with the itinerary-shaped extractor, so every item had empty inputs and no usable target — there was no way to produce a scored run. Founder asked for the place→book eval to be a proper, visible Langfuse experiment rather than a one-off local script.

## Expected impact
A repeatable, scored place→book grounding gate visible in Langfuse next to the itinerary runs — regression detection for the reverse-routing capability.

## How to test
1. `make test` → 473 unit pass (incl. 5 new scorer tests); `make test-integration` → 7 pass.
2. Live: `make eval-place-to-book` (needs `GOOGLE_API_KEY` + Langfuse creds; ~$0.20 Gemini). Confirms a run under `place_to_book_v1` with 11 linked items + scores.
3. First run result: 10/11 PASS. The one fail is **Wakanda** (a culturally-known *fictional* place) returning `found=true` with honestly-labelled `vibe` books (`maps_to=null`) instead of the clean not-found state — **no fabrication**; flagged as a product follow-up (add a "real geography?" gate to the not-found path), not addressed here.

## Risks & rollback
Eval tooling only — no runtime/agent/API path touched, no schema/migration. The `langfuse_eval.py` change is additive and backward-compatible (itinerary cases unchanged). Rollback = revert commit.

## Scope
5 files, +342/−7. New runner (237) + tests (56) + docs/Makefile/registration fix.