### PR TITLE
chore: add .dockerignore to keep secrets/cruft out of image build con…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,83 @@
+# .dockerignore — keep the image build context minimal and free of secrets.
+# IMPORTANT: README.md and pyproject.toml are intentionally NOT excluded —
+# `pip install .` (setuptools, readme = "README.md") needs both at build time.
+
+# Version control
+.git
+.gitignore
+.github
+
+# Python caches / build artifacts
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+dist/
+*.egg-info/
+.eggs/
+wheels/
+
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+
+# Secrets & local env (must never be baked into image layers)
+.env
+.env.*
+*.pem
+*.key
+service-account*.json
+credentials.json
+
+# Tests & coverage artifacts (not part of the runtime package)
+tests/
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+.cache
+
+# Docs & project meta not needed at runtime (README.md kept on purpose)
+docs/
+claude.md
+AGENTS.md
+
+# Evaluation: package source is kept; only generated outputs are excluded
+evaluation/results/
+evaluation/langfuse_datasets.json
+evaluation/metrics.json
+
+# Local databases / caches / logs
+*.db
+*.sqlite
+*.sqlite3
+.adk/
+.agent_cache/
+.session_cache/
+logs/
+*.log
+
+# IDE / editor
+.vscode/
+.idea/
+*.iml
+*.swp
+
+# OS cruft
+.DS_Store
+._*
+Thumbs.db
+
+# Docker
+docker-compose.override.yml
+
+# Backups / archives
+*.bak
+*.backup
+*.zip
+*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -159,7 +159,6 @@ temp/
 .terraform/
 
 # Docker
-.dockerignore
 docker-compose.override.yml
 
 # ========================================


### PR DESCRIPTION
## What
Adds a `.dockerignore` to storyland-ai and removes the `.dockerignore` entry from `.gitignore` so the new file is actually tracked. The ignore list excludes secrets (`.env`, `*.pem`, `*.key`, `service-account*.json`, `credentials.json`), VCS data (`.git`, `.github`), the test suite, docs, Python/coverage caches, local DBs, logs, editor/OS cruft, and generated evaluation artifacts. `README.md`, `pyproject.toml`, and all packaged source directories are deliberately kept.

## Why
The Dockerfile does `COPY . .` with no `.dockerignore`, so the entire working tree — including a developer's local `.env` if present — is copied into an image layer. The service reads `GOOGLE_API_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_PUBLIC_KEY` from `.env`, so an accidental local `.env` would bake live secrets into the image. Removing the build context's access to those files closes the secret-into-layer vector and shrinks the context (tests, docs, caches, eval datasets no longer shipped).

Note: `.gitignore` previously listed `.dockerignore` itself under its Docker section, which would have silently prevented this file from ever being committed — that line is removed here.

## How
- New `.dockerignore`. Patterns mirror `.gitignore`'s secret/cache rules plus `tests/`, `docs/`, and generated eval outputs.
- - `README.md` and `pyproject.toml` are intentionally NOT excluded: setuptools (`build-backend = setuptools.build_meta`, `readme = "README.md"`) needs both during `pip install .`. The `evaluation` package is kept; only its generated outputs (`evaluation/results/`, `langfuse_datasets.json`, `metrics.json`) are excluded.
- - `.gitignore`: dropped the `.dockerignore` line so the file is tracked.
Scope is intentionally limited to the build-context fix. The Dockerfile's other hardening items from the same ticket (non-root `USER`, `HEALTHCHECK`, pinned base digest) are deferred to a follow-up PR because they change container runtime behavior and need a real `docker build`/run to verify, which this change does not.

## Review & test
- No application code changes; runtime image contents are unaffected except that the excluded files are no longer copied in.
- - Build context still contains everything `pip install .` needs: matching the tracked file list against `.dockerignore` shows the only excluded `*.py` files are under `tests/`; `pyproject.toml`, `README.md`, and every packaged dir survive.
- - `git check-ignore .dockerignore` returns non-zero (not ignored) after the `.gitignore` change.
- - Sanity-check when convenient: `docker build -t storyland-ai .` should still succeed.