### PR TITLE
feat(api): rate-limit + in-flight concurrency cap on the expensive discovery endpoints

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -15,6 +15,7 @@ from common.logging import configure_logging, get_logger
 from core.executor import WorkflowExecutor
 from core.place_to_book import PlaceToBookResolver
 from core.types import ExecutorConfig
+from api.ratelimit import InFlightLimiter, SlidingWindowRateLimiter
 
 
 @dataclass
@@ -23,6 +24,8 @@ class AppState:
 
     config: Config
     executor: WorkflowExecutor
+    rate_limiter: SlidingWindowRateLimiter
+    inflight_limiter: InFlightLimiter
 
 
 _app_state: Optional[AppState] = None
@@ -43,7 +46,18 @@ async def initialize() -> AppState:
     executor_config = ExecutorConfig.from_config(config)
     executor = WorkflowExecutor(executor_config)
 
-    _app_state = AppState(config=config, executor=executor)
+    rate_limiter = SlidingWindowRateLimiter(
+        max_requests=config.rate_limit_requests,
+        window_seconds=config.rate_limit_window_seconds,
+    )
+    inflight_limiter = InFlightLimiter(max_in_flight=config.max_inflight_requests)
+
+    _app_state = AppState(
+        config=config,
+        executor=executor,
+        rate_limiter=rate_limiter,
+        inflight_limiter=inflight_limiter,
+    )
 
     logger.info("api_initialized", model=config.model_name)
     return _app_state
@@ -122,3 +136,52 @@ def get_gateway_user_id(
     if not x_user_id:
         raise HTTPException(status_code=403, detail="X-User-ID header is required")
     return x_user_id
+
+
+def _rate_limit_key(request: Request, x_user_id: str | None) -> str:
+    """Identify the caller for rate limiting: user id when known, else client IP."""
+    if x_user_id:
+        return f"user:{x_user_id}"
+    client = request.client
+    return f"ip:{client.host}" if client else "ip:unknown"
+
+
+def enforce_rate_limit(
+    request: Request,
+    x_user_id: str | None = Header(default=None, alias="X-User-ID"),
+) -> None:
+    """Per-identity request-rate cap on the expensive endpoints.
+
+    No-op unless RATE_LIMIT_REQUESTS is configured (> 0). Raises HTTP 429 with a
+    Retry-After hint when a user/IP exceeds its window budget.
+    """
+    limiter = get_app_state().rate_limiter
+    if not limiter.enabled:
+        return
+    if not limiter.allow(_rate_limit_key(request, x_user_id)):
+        raise HTTPException(
+            status_code=429,
+            detail="Rate limit exceeded. Please slow down and retry shortly.",
+            headers={"Retry-After": str(get_app_state().config.rate_limit_window_seconds)},
+        )
+
+
+async def limit_inflight():
+    """Bounded concurrency guard for one expensive request.
+
+    No-op unless MAX_INFLIGHT_REQUESTS is configured (> 0). Acquires a slot for
+    the duration of the request (held across SSE streaming via the yield) and
+    releases it when the response completes. Sheds load with HTTP 503 when the
+    box is already at capacity rather than queueing work onto the single loop.
+    """
+    limiter = get_app_state().inflight_limiter
+    if not limiter.try_acquire():
+        raise HTTPException(
+            status_code=503,
+            detail="Server is busy processing other requests. Please retry shortly.",
+            headers={"Retry-After": "5"},
+        )
+    try:
+        yield
+    finally:
+        limiter.release()

--- a/api/ratelimit.py
+++ b/api/ratelimit.py
@@ -1,0 +1,140 @@
+"""
+Application-level load-shedding for the expensive AI endpoints.
+
+The discovery chain (``/discover``, ``/compose``, ``/expand``,
+``/local-atmosphere``, ``/recommend-books``, ``/place-to-book``) drives a full
+multi-agent Gemini workflow per call on a single-process uvicorn box. Without a
+guard, one authenticated caller (or a misbehaving gateway) can issue unbounded
+distinct-query searches and run many heavy chains in parallel — inflating Gemini
+spend and exhausting the one Lightsail box (OOM / cascading workflow timeouts).
+The result cache only absorbs *identical* repeats, not a flood of distinct
+titles.
+
+Two independent, in-process, additive guards live here. Both are config-gated
+and **disabled by default** (limit ``<= 0``), so production behaviour is
+unchanged until limits are set via env — additive and reversible:
+
+1. :class:`SlidingWindowRateLimiter` — per-identity request-rate cap. Caps the
+   number of requests one user/IP may make per rolling window (HTTP 429 when
+   exceeded). Bounds worst-case spend per caller.
+2. :class:`InFlightLimiter` — bounded concurrent-in-flight cap. Limits how many
+   heavy chains run at once (HTTP 503 when full). It **sheds** load immediately
+   rather than queueing, so excess requests fail fast instead of piling onto the
+   single event loop.
+
+Single-process design note: a plain ``int`` counter and per-key ``deque`` are
+safe here because the asyncio event loop is single-threaded and none of these
+methods ``await`` between the capacity check and the mutation.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict, deque
+from typing import Deque, Dict, Optional
+
+
+class InFlightLimiter:
+    """Bounds the number of concurrently in-flight expensive requests.
+
+    ``max_in_flight <= 0`` disables the cap (every acquire succeeds), so the
+    guard is a no-op until an operator opts in.
+    """
+
+    def __init__(self, max_in_flight: int) -> None:
+        self._max = max_in_flight
+        self._active = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self._max > 0
+
+    @property
+    def active(self) -> int:
+        return self._active
+
+    @property
+    def max_in_flight(self) -> int:
+        return self._max
+
+    def try_acquire(self) -> bool:
+        """Reserve a slot. Returns ``False`` (shed) when at capacity."""
+        if not self.enabled:
+            return True
+        if self._active >= self._max:
+            return False
+        self._active += 1
+        return True
+
+    def release(self) -> None:
+        """Free a previously-acquired slot (idempotent below zero)."""
+        if not self.enabled:
+            return
+        if self._active > 0:
+            self._active -= 1
+
+
+class SlidingWindowRateLimiter:
+    """Per-key sliding-window request-rate limiter.
+
+    Allows at most ``max_requests`` calls per ``window_seconds`` for each key
+    (typically a user id or client IP). ``max_requests <= 0`` disables it.
+
+    Memory is bounded: per-key hit timestamps older than the window are evicted
+    on access, and an occasional sweep drops keys that have gone idle so a flood
+    of distinct keys can't grow the map without bound.
+    """
+
+    def __init__(
+        self,
+        max_requests: int,
+        window_seconds: float,
+        gc_threshold: int = 1024,
+    ) -> None:
+        self._max = max_requests
+        self._window = float(window_seconds)
+        self._gc_threshold = gc_threshold
+        self._hits: Dict[str, Deque[float]] = defaultdict(deque)
+
+    @property
+    def enabled(self) -> bool:
+        return self._max > 0 and self._window > 0
+
+    @property
+    def tracked_keys(self) -> int:
+        return len(self._hits)
+
+    def allow(self, key: str, now: Optional[float] = None) -> bool:
+        """Record a hit for ``key`` and report whether it is within the limit.
+
+        ``now`` is injectable for deterministic tests; it defaults to a
+        monotonic clock so wall-clock changes can't distort the window.
+        """
+        if not self.enabled:
+            return True
+        now = time.monotonic() if now is None else now
+
+        if len(self._hits) > self._gc_threshold:
+            self._gc(now)
+
+        hits = self._hits[key]
+        cutoff = now - self._window
+        while hits and hits[0] <= cutoff:
+            hits.popleft()
+
+        if len(hits) >= self._max:
+            # Over the limit: don't record this hit. Drop the key if it carries
+            # no live timestamps so a rejected one-off caller leaves no residue.
+            if not hits:
+                del self._hits[key]
+            return False
+
+        hits.append(now)
+        return True
+
+    def _gc(self, now: float) -> None:
+        """Drop keys whose most recent hit has aged out of the window."""
+        cutoff = now - self._window
+        stale = [k for k, dq in self._hits.items() if not dq or dq[-1] <= cutoff]
+        for k in stale:
+            del self._hits[k]

--- a/api/routes.py
+++ b/api/routes.py
@@ -9,9 +9,11 @@ from fastapi import APIRouter, Depends, HTTPException
 from sse_starlette.sse import EventSourceResponse
 
 from api.dependencies import (
+    enforce_rate_limit,
     get_app_state,
     get_gateway_user_id,
     get_place_to_book_resolver,
+    limit_inflight,
     verify_gateway_secret,
 )
 from api.models import (
@@ -43,7 +45,10 @@ logger = get_logger("storyland.api.routes")
 # and for standalone testing without the gateway.
 system_router = APIRouter(tags=["system"])
 
-router = APIRouter(tags=["itinerary"], dependencies=[Depends(verify_gateway_secret)])
+router = APIRouter(
+    tags=["itinerary"],
+    dependencies=[Depends(verify_gateway_secret), Depends(enforce_rate_limit)],
+)
 
 
 def _derive_job_status(state: dict) -> JobStatus:
@@ -78,6 +83,7 @@ async def health_check() -> HealthResponse:
 
 @router.post(
     "/itinerary/discover",
+    dependencies=[Depends(limit_inflight)],
     summary="Discover locations for a book",
     responses={
         200: {
@@ -128,6 +134,7 @@ async def discover(request: DiscoverRequest, user_id: str = Depends(get_gateway_
 
 @router.post(
     "/itinerary/{job_id}/compose",
+    dependencies=[Depends(limit_inflight)],
     summary="Compose itinerary for selected regions",
     responses={
         200: {
@@ -173,6 +180,7 @@ async def compose(job_id: str, request: ComposeRequest, user_id: str = Depends(g
 
 @router.post(
     "/itinerary/local-atmosphere",
+    dependencies=[Depends(limit_inflight)],
     summary="Build a local-atmosphere itinerary near the user",
     responses={
         200: {
@@ -233,6 +241,7 @@ async def local_atmosphere(
 
 @router.post(
     "/itinerary/{job_id}/expand",
+    dependencies=[Depends(limit_inflight)],
     summary="Expand itinerary with new places",
     responses={
         200: {
@@ -287,6 +296,7 @@ async def expand(
 
 @router.post(
     "/itinerary/{job_id}/recommend-books",
+    dependencies=[Depends(limit_inflight)],
     summary="Get book recommendations based on book and destinations",
     responses={
         200: {
@@ -396,6 +406,7 @@ async def get_status(job_id: str, user_id: str = Depends(get_gateway_user_id)):
 
 @router.post(
     "/place-to-book",
+    dependencies=[Depends(limit_inflight)],
     response_model=PlaceToBookResult,
     tags=["place-to-book"],
     summary="Resolve a destination to grounded book candidates (reverse discovery)",

--- a/common/config.py
+++ b/common/config.py
@@ -43,6 +43,12 @@ class Config:
     # return (default 3) so a thin researcher result never forces an invented
     # 5th book. Tunable via REC_MIN_RESULTS.
     rec_min_results: int
+    # Load-shedding guards for the expensive discovery chain (api/ratelimit.py).
+    # Both DISABLED by default (value <= 0) so prod behaviour is unchanged until
+    # an operator opts in; additive and reversible.
+    rate_limit_requests: int
+    rate_limit_window_seconds: int
+    max_inflight_requests: int
 
 
 def _require_env(key: str) -> str:
@@ -102,6 +108,11 @@ def load_config() -> Config:
         - LANGFUSE_PUBLIC_KEY: Langfuse public key
         - LANGFUSE_HOST: Langfuse host URL
         - ENVIRONMENT: deployment environment tag (default: "local")
+        - RATE_LIMIT_REQUESTS: max requests per window per user/IP on the
+          expensive endpoints; 0 disables (default: 0)
+        - RATE_LIMIT_WINDOW_SECONDS: rate-limit window length (default: 60)
+        - MAX_INFLIGHT_REQUESTS: max concurrent in-flight heavy requests;
+          0 disables (default: 0)
 
     Returns:
         Config object
@@ -131,6 +142,9 @@ def load_config() -> Config:
         retry_max_delay=_env_float("RETRY_MAX_DELAY", 12.0),
         retry_attempts=_env_int("RETRY_ATTEMPTS", 4),
         rec_min_results=_env_int("REC_MIN_RESULTS", 3),
+        rate_limit_requests=_env_int("RATE_LIMIT_REQUESTS", 0),
+        rate_limit_window_seconds=_env_int("RATE_LIMIT_WINDOW_SECONDS", 60),
+        max_inflight_requests=_env_int("MAX_INFLIGHT_REQUESTS", 0),
     )
 
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -600,11 +600,19 @@ def mock_executor():
 def mock_app_state(mock_executor):
     """Create a mock AppState for testing."""
     from api.dependencies import AppState
+    from api.ratelimit import InFlightLimiter, SlidingWindowRateLimiter
 
     mock_config = MagicMock()
     mock_config.model_name = "gemini-2.0-flash-lite"
 
-    return AppState(config=mock_config, executor=mock_executor)
+    # Load-shedding guards default to disabled (limit 0) so endpoint tests
+    # exercise the handlers without rate-limit/concurrency interference.
+    return AppState(
+        config=mock_config,
+        executor=mock_executor,
+        rate_limiter=SlidingWindowRateLimiter(max_requests=0, window_seconds=60),
+        inflight_limiter=InFlightLimiter(max_in_flight=0),
+    )
 
 
 @pytest.fixture

--- a/tests/unit/test_ratelimit.py
+++ b/tests/unit/test_ratelimit.py
@@ -1,0 +1,184 @@
+"""Unit tests for the load-shedding guards (api/ratelimit.py) and the FastAPI
+dependencies that wire them in (api/dependencies.py).
+
+These exercise pure in-process logic — no network, no Gemini, no app init — so
+they run fast and deterministically. Time is injected so the sliding window is
+tested without sleeping.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+import api.dependencies as deps
+from api.dependencies import AppState, enforce_rate_limit, limit_inflight
+from api.ratelimit import InFlightLimiter, SlidingWindowRateLimiter
+
+
+# ---------------------------------------------------------------------------
+# InFlightLimiter
+# ---------------------------------------------------------------------------
+class TestInFlightLimiter:
+    def test_disabled_always_acquires(self):
+        lim = InFlightLimiter(0)
+        assert not lim.enabled
+        assert all(lim.try_acquire() for _ in range(100))
+        assert lim.active == 0  # disabled limiter never tracks
+
+    def test_caps_at_max(self):
+        lim = InFlightLimiter(2)
+        assert lim.try_acquire() is True
+        assert lim.try_acquire() is True
+        assert lim.active == 2
+        assert lim.try_acquire() is False  # shed
+        assert lim.active == 2
+
+    def test_release_frees_a_slot(self):
+        lim = InFlightLimiter(1)
+        assert lim.try_acquire() is True
+        assert lim.try_acquire() is False
+        lim.release()
+        assert lim.active == 0
+        assert lim.try_acquire() is True
+
+    def test_release_never_goes_negative(self):
+        lim = InFlightLimiter(1)
+        lim.release()
+        lim.release()
+        assert lim.active == 0
+
+    def test_release_noop_when_disabled(self):
+        lim = InFlightLimiter(0)
+        lim.release()  # must not raise
+        assert lim.active == 0
+
+
+# ---------------------------------------------------------------------------
+# SlidingWindowRateLimiter
+# ---------------------------------------------------------------------------
+class TestSlidingWindowRateLimiter:
+    def test_disabled_always_allows(self):
+        lim = SlidingWindowRateLimiter(max_requests=0, window_seconds=60)
+        assert not lim.enabled
+        assert all(lim.allow("u") for _ in range(50))
+        assert lim.tracked_keys == 0
+
+    def test_zero_window_is_disabled(self):
+        lim = SlidingWindowRateLimiter(max_requests=5, window_seconds=0)
+        assert not lim.enabled
+        assert lim.allow("u") is True
+
+    def test_caps_within_window(self):
+        lim = SlidingWindowRateLimiter(max_requests=3, window_seconds=60)
+        assert lim.allow("u", now=1000.0) is True
+        assert lim.allow("u", now=1000.1) is True
+        assert lim.allow("u", now=1000.2) is True
+        assert lim.allow("u", now=1000.3) is False  # 4th in window
+
+    def test_window_slides(self):
+        lim = SlidingWindowRateLimiter(max_requests=2, window_seconds=10)
+        assert lim.allow("u", now=100.0) is True
+        assert lim.allow("u", now=105.0) is True
+        assert lim.allow("u", now=109.0) is False
+        # First hit (t=100) ages out at t>110; t=111 leaves one live hit (105).
+        assert lim.allow("u", now=111.0) is True
+
+    def test_keys_are_isolated(self):
+        lim = SlidingWindowRateLimiter(max_requests=1, window_seconds=60)
+        assert lim.allow("a", now=1.0) is True
+        assert lim.allow("b", now=1.0) is True
+        assert lim.allow("a", now=1.1) is False
+
+    def test_rejected_hit_is_not_recorded(self):
+        lim = SlidingWindowRateLimiter(max_requests=1, window_seconds=10)
+        assert lim.allow("u", now=0.0) is True
+        assert lim.allow("u", now=1.0) is False
+        assert lim.allow("u", now=2.0) is False
+        # Only the first hit counts; after it ages out a new hit is allowed.
+        assert lim.allow("u", now=11.0) is True
+
+    def test_gc_bounds_idle_keys(self):
+        lim = SlidingWindowRateLimiter(max_requests=1, window_seconds=5, gc_threshold=10)
+        # Seed many distinct keys far in the past.
+        for i in range(20):
+            lim.allow(f"k{i}", now=0.0)
+        assert lim.tracked_keys == 20
+        # A later access past the gc threshold sweeps aged-out keys.
+        lim.allow("fresh", now=1000.0)
+        assert lim.tracked_keys == 1
+
+
+# ---------------------------------------------------------------------------
+# FastAPI dependency wiring
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def fake_state(monkeypatch):
+    """Install a minimal AppState carrying real limiter instances."""
+    def _install(rate_limiter, inflight_limiter, window=60):
+        state = AppState(
+            config=SimpleNamespace(rate_limit_window_seconds=window),
+            executor=SimpleNamespace(),
+            rate_limiter=rate_limiter,
+            inflight_limiter=inflight_limiter,
+        )
+        monkeypatch.setattr(deps, "_app_state", state)
+        return state
+    return _install
+
+
+def _request(host="1.2.3.4"):
+    return SimpleNamespace(client=SimpleNamespace(host=host), headers={})
+
+
+class TestEnforceRateLimit:
+    def test_noop_when_disabled(self, fake_state):
+        fake_state(SlidingWindowRateLimiter(0, 60), InFlightLimiter(0))
+        # No exception even when called many times.
+        for _ in range(10):
+            enforce_rate_limit(_request(), x_user_id=None)
+
+    def test_raises_429_when_exceeded(self, fake_state):
+        fake_state(SlidingWindowRateLimiter(max_requests=1, window_seconds=60), InFlightLimiter(0))
+        enforce_rate_limit(_request(), x_user_id="alice")  # first allowed
+        with pytest.raises(HTTPException) as exc:
+            enforce_rate_limit(_request(), x_user_id="alice")
+        assert exc.value.status_code == 429
+        assert "Retry-After" in exc.value.headers
+
+    def test_user_and_ip_keys_are_distinct(self, fake_state):
+        fake_state(SlidingWindowRateLimiter(max_requests=1, window_seconds=60), InFlightLimiter(0))
+        enforce_rate_limit(_request(host="9.9.9.9"), x_user_id="bob")
+        # Different identity (anonymous IP) is not throttled by bob's budget.
+        enforce_rate_limit(_request(host="9.9.9.9"), x_user_id=None)
+
+
+class TestLimitInflight:
+    async def test_acquires_and_releases(self, fake_state):
+        inflight = InFlightLimiter(1)
+        fake_state(SlidingWindowRateLimiter(0, 60), inflight)
+        gen = limit_inflight()
+        await gen.__anext__()              # acquire + yield
+        assert inflight.active == 1
+        with pytest.raises(StopAsyncIteration):
+            await gen.__anext__()          # runs finally -> release
+        assert inflight.active == 0
+
+    async def test_sheds_with_503_when_full(self, fake_state):
+        inflight = InFlightLimiter(1)
+        fake_state(SlidingWindowRateLimiter(0, 60), inflight)
+        assert inflight.try_acquire() is True  # box already full
+        gen = limit_inflight()
+        with pytest.raises(HTTPException) as exc:
+            await gen.__anext__()
+        assert exc.value.status_code == 503
+        assert inflight.active == 1  # the rejected request took no slot
+
+    async def test_noop_when_disabled(self, fake_state):
+        inflight = InFlightLimiter(0)
+        fake_state(SlidingWindowRateLimiter(0, 60), inflight)
+        gen = limit_inflight()
+        await gen.__anext__()
+        assert inflight.active == 0
+        with pytest.raises(StopAsyncIteration):
+            await gen.__anext__()


### PR DESCRIPTION
# feat(api): rate-limit + in-flight concurrency cap on the expensive discovery endpoints

## What
Adds two additive, in-process, config-gated load-shedding guards to the
storyland-ai API and wires them into the expensive endpoints
(`/itinerary/discover`, `/compose`, `/expand`, `/local-atmosphere`,
`/recommend-books`, `/place-to-book`):

1. A per-identity sliding-window **rate limit** (HTTP 429 when a user/IP exceeds
   its budget), applied router-wide.
2. A bounded **in-flight concurrency cap** (HTTP 503 when the box is already at
   capacity), applied to each heavy endpoint — it sheds load immediately rather
   than queueing work onto the single event loop.

Both default to **disabled** (`limit <= 0`); production behaviour is unchanged
until limits are set via env, so this is fully additive and reversible.

## Why
`POST /itinerary/discover` (and `compose`/`expand`/`local-atmosphere`/
`recommend-books`/`place-to-book`) each trigger the full multi-agent Gemini chain
per call, but the service has no application-level rate limit and no in-flight
concurrency cap. The Dockerfile runs a single uvicorn process (no `--workers`),
so concurrent heavy workflows all share one event loop and the one Lightsail
box's memory/CPU. `verify_gateway_secret` blocks anonymous callers but gives no
per-user throttle and no spend ceiling — one authenticated caller (or a
misbehaving gateway) can issue unbounded distinct-query searches and run many
heavy chains in parallel. The result cache only absorbs identical repeats, not a
flood of distinct titles. These guards convert that unbounded cost/overload tail
into a predictable, sheddable load with fast 429/503s.

## How
- New `api/ratelimit.py`:
  - `SlidingWindowRateLimiter` — per-key (`user:<id>` / `ip:<host>`) rolling
    window; rejected hits are not recorded; idle keys are GC'd so a flood of
    distinct keys can't grow the map unbounded. Time is injectable for tests.
  - `InFlightLimiter` — plain counter with `try_acquire()`/`release()`; sheds
    (returns `False`) at capacity. Single-process/single-loop, so no lock is
    needed (no `await` between check and mutation).
- `common/config.py` — three new optional env vars, all defaulting to off:
  `RATE_LIMIT_REQUESTS` (0), `RATE_LIMIT_WINDOW_SECONDS` (60),
  `MAX_INFLIGHT_REQUESTS` (0).
- `api/dependencies.py` — limiters constructed in `initialize()` and attached to
  `AppState`; two dependencies: `enforce_rate_limit` (429) and `limit_inflight`
  (a yield-dependency that holds a slot for the request's lifetime — including
  across the SSE stream — and releases it in `finally`, 503 when full).
- `api/routes.py` — `enforce_rate_limit` added router-wide; `limit_inflight`
  added to each of the six expensive endpoints.

Tradeoff: in-flight slots are held for the full SSE stream duration (intended —
that is exactly the window during which the heavy chain runs).

## Review & test
- Run: `make test` (the `tests/unit/` suite). New `tests/unit/test_ratelimit.py`
  covers both limiters (disabled passthrough, capping, window slide, per-key
  isolation, rejected-not-recorded, idle-key GC, over-release safety) and the
  FastAPI dependencies (429 on excess, 503 when full + slot released, no-op when
  disabled). `tests/unit/test_api.py`'s `mock_app_state` fixture was updated to
  construct the limiters (disabled), so existing endpoint tests are unaffected.
- Verify defaults are a no-op: with no new env vars set, `enforce_rate_limit`
  and `limit_inflight` short-circuit (limiters report `enabled == False`).
- Suggested starting prod values once enabled (operator's call):
  `RATE_LIMIT_REQUESTS=30`, `RATE_LIMIT_WINDOW_SECONDS=60`,
  `MAX_INFLIGHT_REQUESTS=4`.

No change to recommendation/agent logic — guards sit in front of the chain and
do not alter outputs, so no eval is required.
