### PR TITLE
feat: bound book_title/author/preferences sizes on /discover + /local-atmosphere (422 before Gemini)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -15,6 +15,36 @@ from pydantic import BaseModel, Field, field_validator
 
 # --- Request Models ---
 
+# Input-size bounds: reject oversized payloads with a 422 BEFORE any prompt is
+# built or Gemini is called (cost + prompt-injection-surface guard). 200 matches
+# the existing UserLocation.label / ExpandRequest caps.
+MAX_TITLE_LENGTH = 200
+MAX_AUTHOR_LENGTH = 200
+MAX_PREFERENCES_KEYS = 30
+MAX_PREFERENCE_KEY_LENGTH = 100
+MAX_PREFERENCE_VALUE_LENGTH = 500
+
+
+def _bound_preferences(value):
+    """Bound the free-form preferences dict (key count + per-key/value length)."""
+    if value is None:
+        return value
+    if len(value) > MAX_PREFERENCES_KEYS:
+        raise ValueError(
+            f"preferences may contain at most {MAX_PREFERENCES_KEYS} keys"
+        )
+    for key, val in value.items():
+        if not isinstance(key, str) or len(key) > MAX_PREFERENCE_KEY_LENGTH:
+            raise ValueError(
+                "preferences keys must be strings of at most "
+                f"{MAX_PREFERENCE_KEY_LENGTH} characters"
+            )
+        if len(str(val)) > MAX_PREFERENCE_VALUE_LENGTH:
+            raise ValueError(
+                f"preferences values must be at most {MAX_PREFERENCE_VALUE_LENGTH} characters"
+            )
+    return value
+
 
 class DiscoverRequest(BaseModel):
     """Request body for POST /api/v1/itinerary/discover."""
@@ -35,8 +65,12 @@ class DiscoverRequest(BaseModel):
         }
     }
 
-    book_title: str = Field(min_length=1, description="Title of the book")
-    author: str = Field(min_length=1, description="Author name (required)")
+    book_title: str = Field(
+        min_length=1, max_length=MAX_TITLE_LENGTH, description="Title of the book"
+    )
+    author: str = Field(
+        min_length=1, max_length=MAX_AUTHOR_LENGTH, description="Author name (required)"
+    )
     preferences: Optional[dict] = Field(
         default=None, description="User travel preferences"
     )
@@ -58,6 +92,12 @@ class DiscoverRequest(BaseModel):
         if not normalized:
             raise ValueError("author must not be empty")
         return normalized
+
+    @field_validator("preferences")
+    @classmethod
+    def validate_preferences(cls, value):
+        """Bound preferences size before it flows into the prompt."""
+        return _bound_preferences(value)
 
 
 class ComposeRequest(BaseModel):
@@ -199,8 +239,12 @@ class LocalAtmosphereRequest(BaseModel):
         }
     }
 
-    book_title: str = Field(min_length=1, description="Title of the book")
-    author: str = Field(min_length=1, description="Author name (required)")
+    book_title: str = Field(
+        min_length=1, max_length=MAX_TITLE_LENGTH, description="Title of the book"
+    )
+    author: str = Field(
+        min_length=1, max_length=MAX_AUTHOR_LENGTH, description="Author name (required)"
+    )
     user_location: UserLocation = Field(description="User's current location")
     radius_km: int = Field(
         default=80,
@@ -227,6 +271,11 @@ class LocalAtmosphereRequest(BaseModel):
         if not normalized:
             raise ValueError("author must not be empty")
         return normalized
+
+    @field_validator("preferences")
+    @classmethod
+    def validate_preferences(cls, value):
+        return _bound_preferences(value)
 
 
 # --- SSE Event Models ---

--- a/tests/unit/test_request_input_limits.py
+++ b/tests/unit/test_request_input_limits.py
@@ -1,0 +1,71 @@
+"""Unit tests for request input-size bounds on DiscoverRequest / LocalAtmosphereRequest.
+
+Imports ONLY from api.models (pydantic-only) so the suite stays light: oversized
+book_title / author / preferences must raise a ValidationError (-> HTTP 422) BEFORE
+any prompt is built or Gemini is called.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from api.models import (
+    DiscoverRequest,
+    LocalAtmosphereRequest,
+    MAX_TITLE_LENGTH,
+    MAX_AUTHOR_LENGTH,
+    MAX_PREFERENCES_KEYS,
+    MAX_PREFERENCE_VALUE_LENGTH,
+)
+
+VALID_LOCATION = {"lat": 40.7128, "lng": -74.0060, "label": "New York, NY"}
+
+
+def test_discover_rejects_oversized_book_title():
+    with pytest.raises(ValidationError):
+        DiscoverRequest(book_title="x" * (MAX_TITLE_LENGTH + 1), author="A")
+
+
+def test_discover_rejects_oversized_author():
+    with pytest.raises(ValidationError):
+        DiscoverRequest(book_title="1984", author="A" * (MAX_AUTHOR_LENGTH + 1))
+
+
+def test_discover_rejects_too_many_preference_keys():
+    prefs = {f"k{i}": "v" for i in range(MAX_PREFERENCES_KEYS + 1)}
+    with pytest.raises(ValidationError):
+        DiscoverRequest(book_title="1984", author="George Orwell", preferences=prefs)
+
+
+def test_discover_rejects_oversized_preference_value():
+    prefs = {"budget": "x" * (MAX_PREFERENCE_VALUE_LENGTH + 1)}
+    with pytest.raises(ValidationError):
+        DiscoverRequest(book_title="1984", author="George Orwell", preferences=prefs)
+
+
+def test_discover_accepts_max_length_title_and_normal_prefs():
+    req = DiscoverRequest(
+        book_title="t" * MAX_TITLE_LENGTH,
+        author="George Orwell",
+        preferences={"budget": "luxury", "preferred_pace": "relaxed"},
+    )
+    assert len(req.book_title) == MAX_TITLE_LENGTH
+    assert req.preferences == {"budget": "luxury", "preferred_pace": "relaxed"}
+
+
+def test_local_atmosphere_rejects_oversized_book_title():
+    with pytest.raises(ValidationError):
+        LocalAtmosphereRequest(
+            book_title="x" * (MAX_TITLE_LENGTH + 1),
+            author="A",
+            user_location=VALID_LOCATION,
+        )
+
+
+def test_local_atmosphere_accepts_valid_input():
+    req = LocalAtmosphereRequest(
+        book_title="Wuthering Heights",
+        author="Emily Bronte",
+        user_location=VALID_LOCATION,
+        preferences={"pace": "slow"},
+    )
+    assert req.book_title == "Wuthering Heights"


### PR DESCRIPTION
## What
Bounds the user-controlled free-text inputs on the two most expensive endpoints (`/discover`, `/local-atmosphere`) so oversized payloads return **HTTP 422 before any prompt is built or Gemini is called**.

- `book_title` / `author` on `DiscoverRequest` + `LocalAtmosphereRequest` → `max_length=200` (matches the existing `UserLocation.label` / `ExpandRequest` caps).
- `preferences` → shared `_bound_preferences()` validator: ≤30 keys, ≤100-char keys, ≤500-char values.

## Why
`book_title`/`author` had only `min_length=1` (no upper bound) and `preferences` was an unbounded `Optional[dict]`, all flowing straight into `build_discovery_prompt()` → Gemini. An oversized title/author/prefs inflated token spend on the priciest path and widened the prompt-injection surface. This closes that and makes the contract consistent with every other bounded text field in the module.

## Tests
New `tests/unit/test_request_input_limits.py` (imports only `api.models`, pydantic-only): oversized title / author / preference-key-count / preference-value → `ValidationError`; max-length (200) title + normal prefs → OK; `LocalAtmosphereRequest` oversized-title guard. **Full unit suite: 480 passed / 0 failed.**

## Scope / gate
Pure additive request-boundary validation. No schema/migration/secret/auth/rec/agent-logic change → **not G4, no eval**. Rollback = revert. Opportunity: bound-request-input-sizes (RICE 30).