### PR TITLE
feat: harden storyland-ai image — non-root USER + HEALTHCHECK + digest-pinned base (PR 2 of 2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.12-slim
+# Pin the base image by digest for reproducible builds (tag: python:3.12-slim).
+FROM python:3.12-slim@sha256:d764629ce0ddd8c71fd371e9901efb324a95789d2315a47db7e4d27e78f1b0e9
 
 WORKDIR /app
 
@@ -8,12 +9,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy application code
+# Copy application code (the repo .dockerignore keeps .env*/secrets/tests out of the build context)
 COPY . .
 
 # Install package and all dependencies
 RUN pip install --no-cache-dir .
 
+# Run as an unprivileged user (least privilege; shrinks RCE/SSRF blast radius).
+# uvicorn binds 8080 (>1024), so no root is required at runtime.
+RUN useradd --create-home --uid 10001 appuser \
+    && chown -R appuser:appuser /app
+USER appuser
+
 EXPOSE 8080
+
+# Liveness probe on the existing health route.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD curl -fsS http://localhost:8080/api/v1/health || exit 1
 
 CMD ["uvicorn", "api.app:create_app", "--factory", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
## What (PR 2 of 2 — runtime hardening; PR 1 `.dockerignore` was #170, merged)
- **Non-root:** create `appuser` (uid 10001), `chown /app`, `USER appuser` before `CMD`. uvicorn binds 8080 (>1024), so no root is needed at runtime — least privilege, shrinks the blast radius of any RCE/SSRF in the request path.
- **HEALTHCHECK** on the existing `GET /api/v1/health` route (`curl`, already installed in the image).
- **Digest-pinned base:** `python:3.12-slim@sha256:d764629…` for reproducible builds.

## Why
The image ran `uvicorn` as **root** with no `HEALTHCHECK` and an unpinned base. #170 closed the secret-into-layer vector (`.dockerignore`); this closes the remaining least-privilege + reproducibility + liveness gaps. Pure build/runtime hygiene, no application behavior change.

## Verification (docker-capable runner)
- `docker build` OK.
- `docker run --rm … whoami` → **appuser**; `id` → **uid=10001(appuser)**.
- `docker history` → **no `.env`/secret layers** (combined with #170's `.dockerignore`).
- Container boots and serves `/api/v1/health` → **HTTP 200** `{"status":"healthy","model_name":"gemini-2.5-flash"}` running as appuser.
- Docker **HEALTHCHECK** status flips to **healthy**.

## Gate
Build/runtime hygiene only — no app/rec/agent-logic, no schema/secret/migration → **not G4, no eval**. Rollback = revert. Deploy/runtime re-verification rides the infra-coordinated prod rebuild on the Lightsail box. Opportunity: storyland-ai Docker hardening (RICE 28).