### PR TITLE
feat(session): bounded retention sweep for in-memory/SQLite session store

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,14 @@ LANGFUSE_HOST=https://cloud.langfuse.com
 # Always on. Tune the TTL / max entries below.
 CACHE_TTL_SECONDS=86400
 CACHE_MAX_ENTRIES=500
+
+# Session Retention (services/session_retention.py)
+# Bounds the in-memory / SQLite session store so discover->compose job state
+# does not accumulate forever (RAM OOM in-memory; unbounded sessions table in
+# SQLite). A periodic sweep evicts sessions older than SESSION_TTL_SECONDS and,
+# in-memory, caps the count at SESSION_MAX_ENTRIES (oldest evicted first).
+# SESSION_TTL_SECONDS=0 disables the sweep (kill-switch). 24h default is well
+# above a full discover->compose->expand lifetime, so mid-flow jobs survive.
+SESSION_TTL_SECONDS=86400
+SESSION_MAX_ENTRIES=10000
+SESSION_SWEEP_INTERVAL_SECONDS=300

--- a/api/app.py
+++ b/api/app.py
@@ -12,14 +12,47 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from api.dependencies import initialize, shutdown
 from api.routes import router, system_router
+from services.session_retention import SessionSweeper
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Initialize on startup, cleanup on shutdown."""
-    await initialize()
-    yield
-    await shutdown()
+    """Initialize on startup, cleanup on shutdown.
+
+    Also starts the bounded session-retention sweep so the in-memory /
+    SQLite session store does not grow unbounded on the single box (evicts
+    discover->compose job state older than SESSION_TTL_SECONDS; disabled when
+    SESSION_TTL_SECONDS=0).
+    """
+    state = await initialize()
+
+    def _live_session_services():
+        # The executor's store is the discover->compose leak source. The
+        # place->book resolver keeps its own isolated in-memory store, created
+        # lazily on first request - include it once it exists.
+        services = [state.executor.session_service]
+        import api.dependencies as deps
+
+        resolver = getattr(deps, "_place_to_book_resolver", None)
+        if resolver is not None:
+            svc = getattr(resolver, "_session_service", None)
+            if svc is not None:
+                services.append(svc)
+        return services
+
+    sweeper = SessionSweeper(
+        services=_live_session_services,
+        ttl_seconds=state.config.session_ttl_seconds,
+        max_entries=state.config.session_max_entries,
+        interval_seconds=state.config.session_sweep_interval_seconds,
+    )
+    sweeper.start()
+    app.state.session_sweeper = sweeper
+    try:
+        yield
+    finally:
+        await sweeper.stop()
+        await shutdown()
 
 
 def create_app() -> FastAPI:

--- a/common/config.py
+++ b/common/config.py
@@ -49,6 +49,14 @@ class Config:
     rate_limit_requests: int
     rate_limit_window_seconds: int
     max_inflight_requests: int
+    # Bounded session retention sweep (services/session_retention.py).
+    # Periodically evicts discover->compose job sessions older than the TTL and
+    # caps the in-memory store size, so RAM (in-memory) / the SQLite sessions
+    # table stop growing unbounded on the single box. SESSION_TTL_SECONDS=0
+    # disables the sweep (config kill-switch). All additive / reversible.
+    session_ttl_seconds: int
+    session_max_entries: int
+    session_sweep_interval_seconds: int
 
 
 def _require_env(key: str) -> str:
@@ -113,6 +121,12 @@ def load_config() -> Config:
         - RATE_LIMIT_WINDOW_SECONDS: rate-limit window length (default: 60)
         - MAX_INFLIGHT_REQUESTS: max concurrent in-flight heavy requests;
           0 disables (default: 0)
+        - SESSION_TTL_SECONDS: evict sessions older than this many seconds;
+          0 disables the retention sweep (default: 86400 = 24h)
+        - SESSION_MAX_ENTRIES: in-memory session count cap, oldest evicted
+          first once exceeded (default: 10000)
+        - SESSION_SWEEP_INTERVAL_SECONDS: how often the sweep runs
+          (default: 300)
 
     Returns:
         Config object
@@ -145,6 +159,11 @@ def load_config() -> Config:
         rate_limit_requests=_env_int("RATE_LIMIT_REQUESTS", 0),
         rate_limit_window_seconds=_env_int("RATE_LIMIT_WINDOW_SECONDS", 60),
         max_inflight_requests=_env_int("MAX_INFLIGHT_REQUESTS", 0),
+        session_ttl_seconds=_env_int("SESSION_TTL_SECONDS", 86400),
+        session_max_entries=_env_int("SESSION_MAX_ENTRIES", 10000),
+        session_sweep_interval_seconds=_env_int(
+            "SESSION_SWEEP_INTERVAL_SECONDS", 300
+        ),
     )
 
 

--- a/services/session_retention.py
+++ b/services/session_retention.py
@@ -1,0 +1,296 @@
+"""
+Bounded session retention for the in-memory / SQLite ADK session stores.
+
+The ADK ``InMemorySessionService`` and SQLite ``DatabaseSessionService`` have no
+TTL, eviction, or cleanup of their own, so on the single self-hosted box the
+discover -> compose job state (regions, composer envelopes, full itineraries
+keyed by ``job_id``) accumulates forever:
+
+* in-memory -> RAM grows monotonically with traffic until an OOM kill drops
+  *all* live jobs at once;
+* SQLite    -> the ``sessions`` table grows unbounded, degrading lookup latency.
+
+This module adds a single periodic background sweep (started from the FastAPI
+lifespan) that evicts sessions older than ``SESSION_TTL_SECONDS`` and, for the
+in-memory store, caps the total count at ``SESSION_MAX_ENTRIES`` (oldest-update
+first). It is additive and reversible:
+
+* ``SESSION_TTL_SECONDS=0`` disables the sweep entirely (config kill-switch ->
+  byte-identical legacy behaviour);
+* the default TTL (24h) is comfortably longer than a full discover -> compose ->
+  expand lifetime, and every ``append_event`` refreshes a session's
+  ``last_update_time``, so an actively-used mid-flow session is never evicted.
+
+The sweep is intentionally tolerant: any unexpected store shape is logged and
+skipped rather than raised, so a retention hiccup can never take down request
+serving.
+"""
+
+import asyncio
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Iterable, List, Sequence, Tuple, Union
+
+from common.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def _iter_inmemory_sessions(store) -> List[Tuple[str, str, str, object]]:
+    """Flatten an InMemorySessionService's nested store into a list.
+
+    ADK stores in-memory sessions as ``store.sessions[app_name][user_id][session_id]``.
+    Returns ``(app_name, user_id, session_id, session)`` tuples. A snapshot list
+    (not a live generator) so we can delete while iterating safely.
+    """
+    out: List[Tuple[str, str, str, object]] = []
+    sessions = getattr(store, "sessions", None)
+    if not isinstance(sessions, dict):
+        return out
+    for app_name, users in list(sessions.items()):
+        if not isinstance(users, dict):
+            continue
+        for user_id, sess_map in list(users.items()):
+            if not isinstance(sess_map, dict):
+                continue
+            for session_id, session in list(sess_map.items()):
+                out.append((app_name, user_id, session_id, session))
+    return out
+
+
+def _session_age_seconds(session, now: float) -> float:
+    """Seconds since a session was last updated.
+
+    Reads ADK's ``last_update_time`` (epoch seconds, bumped on every
+    ``append_event``). Unknown/garbage timestamps return 0.0 (treated as
+    "fresh" so we never evict a session we can't reason about).
+    """
+    ts = getattr(session, "last_update_time", None)
+    try:
+        if ts is None:
+            return 0.0
+        return max(0.0, now - float(ts))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+async def _prune_inmemory(store, ttl_seconds: int, max_entries: int) -> int:
+    """Evict expired + over-cap sessions from an in-memory store. Returns count."""
+    entries = _iter_inmemory_sessions(store)
+    if not entries:
+        return 0
+
+    now = time.time()
+    evicted = 0
+    survivors: List[Tuple[str, str, str, object]] = []
+
+    # 1) Age-based expiry.
+    for app_name, user_id, session_id, session in entries:
+        if ttl_seconds > 0 and _session_age_seconds(session, now) > ttl_seconds:
+            if await _delete_session(store, app_name, user_id, session_id):
+                evicted += 1
+        else:
+            survivors.append((app_name, user_id, session_id, session))
+
+    # 2) Hard cap: if still over the cap, evict oldest-update first (age/LRU).
+    if max_entries > 0 and len(survivors) > max_entries:
+        survivors.sort(key=lambda e: getattr(e[3], "last_update_time", 0.0) or 0.0)
+        overflow = len(survivors) - max_entries
+        for app_name, user_id, session_id, _session in survivors[:overflow]:
+            if await _delete_session(store, app_name, user_id, session_id):
+                evicted += 1
+
+    return evicted
+
+
+async def _delete_session(store, app_name: str, user_id: str, session_id: str) -> bool:
+    """Best-effort ``delete_session`` (ADK's API is async). Never raises."""
+    try:
+        await store.delete_session(
+            app_name=app_name, user_id=user_id, session_id=session_id
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 - retention must never crash serving
+        logger.warning(
+            "session_evict_failed",
+            app_name=app_name,
+            session_id=session_id,
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        return False
+
+
+def _engine_of(store):
+    """Return the SQLAlchemy engine backing a DatabaseSessionService, if any."""
+    for attr in ("db_engine", "_engine", "engine"):
+        engine = getattr(store, attr, None)
+        if engine is not None:
+            return engine
+    return None
+
+
+async def _prune_database(store, ttl_seconds: int) -> int:
+    """Best-effort age-based prune of the SQLite/SQL ``sessions`` table.
+
+    Runs ``DELETE FROM sessions WHERE update_time < :cutoff`` against the ADK
+    engine. Handles both sync and async SQLAlchemy engines. Any failure
+    (unexpected schema, engine shape, driver) is logged and swallowed - the
+    in-memory path is the primary OOM guard, and a DB prune hiccup must not
+    break serving.
+    """
+    if ttl_seconds <= 0:
+        return 0
+    engine = _engine_of(store)
+    if engine is None:
+        return 0
+
+    try:
+        from sqlalchemy import text
+
+        cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(
+            seconds=ttl_seconds
+        )
+        stmt = text("DELETE FROM sessions WHERE update_time < :cutoff")
+        params = {"cutoff": cutoff}
+
+        # Async engine (e.g. sqlite+aiosqlite).
+        try:
+            from sqlalchemy.ext.asyncio import AsyncEngine
+
+            if isinstance(engine, AsyncEngine):
+                async with engine.begin() as conn:
+                    result = await conn.execute(stmt, params)
+                return int(getattr(result, "rowcount", 0) or 0)
+        except ImportError:
+            pass
+
+        # Sync engine.
+        with engine.begin() as conn:
+            result = conn.execute(stmt, params)
+        return int(getattr(result, "rowcount", 0) or 0)
+    except Exception as exc:  # noqa: BLE001 - best-effort, never crash the sweep
+        logger.warning(
+            "session_db_prune_skipped",
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        return 0
+
+
+async def prune_sessions(session_service, ttl_seconds: int, max_entries: int) -> int:
+    """Evict expired (and, in-memory, over-cap) sessions from one store.
+
+    Dispatches on the store shape: an in-memory store (has a ``.sessions``
+    dict) gets age + cap eviction; anything exposing a SQL engine gets the
+    age-based table prune. Returns the number of sessions evicted. Never raises.
+    """
+    try:
+        if isinstance(getattr(session_service, "sessions", None), dict):
+            return await _prune_inmemory(session_service, ttl_seconds, max_entries)
+        if _engine_of(session_service) is not None:
+            return await _prune_database(session_service, ttl_seconds)
+    except Exception as exc:  # noqa: BLE001 - defensive belt-and-suspenders
+        logger.warning(
+            "session_prune_failed",
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+    return 0
+
+
+# A provider yields the session services that are currently live. We use a
+# callable (not a fixed list) because some stores - e.g. the place->book
+# resolver's isolated in-memory store - are created lazily on first request,
+# after the sweep has already started.
+ServicesProvider = Union[Callable[[], Iterable[object]], Sequence[object]]
+
+
+class SessionSweeper:
+    """Periodic background task that prunes live session stores.
+
+    Started/stopped from the FastAPI lifespan. Disabled (no task) when
+    ``ttl_seconds <= 0`` so ``SESSION_TTL_SECONDS=0`` is a true kill-switch.
+    """
+
+    def __init__(
+        self,
+        services: ServicesProvider,
+        ttl_seconds: int,
+        max_entries: int,
+        interval_seconds: int,
+    ):
+        self._services = services
+        self.ttl_seconds = ttl_seconds
+        self.max_entries = max_entries
+        self.interval_seconds = interval_seconds
+        self._task = None
+
+    def _resolve_services(self) -> List[object]:
+        provider = self._services
+        try:
+            items = provider() if callable(provider) else provider
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "session_services_provider_failed",
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
+            return []
+        # De-dupe by identity (two callers may share a service instance).
+        seen: List[object] = []
+        for svc in items or []:
+            if svc is not None and all(svc is not s for s in seen):
+                seen.append(svc)
+        return seen
+
+    def start(self) -> None:
+        """Launch the sweep loop (no-op when retention is disabled)."""
+        if self.ttl_seconds <= 0:
+            logger.info("session_sweep_disabled", ttl_seconds=self.ttl_seconds)
+            return
+        if self._task is not None:
+            return
+        self._task = asyncio.create_task(self._run())
+        logger.info(
+            "session_sweep_started",
+            ttl_seconds=self.ttl_seconds,
+            max_entries=self.max_entries,
+            interval_seconds=self.interval_seconds,
+        )
+
+    async def stop(self) -> None:
+        """Cancel the sweep loop and wait for it to unwind."""
+        task = self._task
+        self._task = None
+        if task is None:
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def sweep_once(self) -> int:
+        """Run one prune pass across all live stores. Returns total evicted."""
+        total = 0
+        for svc in self._resolve_services():
+            total += await prune_sessions(svc, self.ttl_seconds, self.max_entries)
+        if total:
+            logger.info("session_sweep_evicted", count=total)
+        return total
+
+    async def _run(self) -> None:
+        interval = max(1, self.interval_seconds)
+        while True:
+            try:
+                await asyncio.sleep(interval)
+                await self.sweep_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001 - keep the loop alive
+                logger.warning(
+                    "session_sweep_iteration_failed",
+                    error=str(exc),
+                    error_type=type(exc).__name__,
+                )

--- a/tests/unit/test_session_retention.py
+++ b/tests/unit/test_session_retention.py
@@ -1,0 +1,124 @@
+"""
+Unit tests for bounded session retention (services/session_retention.py).
+
+Exercises the in-memory eviction policy (age TTL + max-entry cap), the
+config kill-switch, and the SessionSweeper lifecycle against a real ADK
+InMemorySessionService.
+"""
+
+import time
+
+from services.session_service import create_session_service
+from services.session_retention import SessionSweeper, prune_sessions
+
+APP = "storyland"
+USER = "u1"
+
+
+def _stored(svc, sid):
+    """Reach the live stored Session (get_session returns a deep copy in ADK)."""
+    return svc.sessions[APP][USER][sid]
+
+
+async def _inmemory_with(specs):
+    """Build an in-memory service with sessions aged by `age_seconds`.
+
+    specs: list of (session_id, age_seconds-since-last-update).
+    """
+    svc = create_session_service(use_database=False)
+    now = time.time()
+    for sid, age in specs:
+        await svc.create_session(app_name=APP, user_id=USER, session_id=sid)
+        _stored(svc, sid).last_update_time = now - age
+    return svc
+
+
+async def _exists(svc, sid):
+    return (
+        await svc.get_session(app_name=APP, user_id=USER, session_id=sid)
+    ) is not None
+
+
+class TestPruneInMemory:
+    async def test_expired_evicted_survivors_untouched(self):
+        svc = await _inmemory_with([("old", 100_000), ("fresh", 10)])
+        evicted = await prune_sessions(svc, ttl_seconds=86400, max_entries=10_000)
+        assert evicted == 1
+        assert not await _exists(svc, "old")
+        assert await _exists(svc, "fresh")
+
+    async def test_recently_refreshed_session_survives(self):
+        # A session updated 5s ago survives a 60s TTL even though we asked to
+        # prune — mirrors append_event refreshing last_update_time on active use.
+        svc = await _inmemory_with([("active", 5)])
+        evicted = await prune_sessions(svc, ttl_seconds=60, max_entries=10_000)
+        assert evicted == 0
+        assert await _exists(svc, "active")
+
+    async def test_over_cap_evicts_oldest_update_first(self):
+        # s0 newest update ... s4 oldest; all within TTL. cap=2 -> drop 3 oldest.
+        svc = await _inmemory_with([(f"s{i}", float(i)) for i in range(5)])
+        evicted = await prune_sessions(svc, ttl_seconds=86400, max_entries=2)
+        assert evicted == 3
+        survivors = {sid for sid in (f"s{i}" for i in range(5)) if await _exists(svc, sid)}
+        assert survivors == {"s0", "s1"}
+
+    async def test_ttl_zero_is_noop(self):
+        svc = await _inmemory_with([("old", 1_000_000)])
+        evicted = await prune_sessions(svc, ttl_seconds=0, max_entries=10_000)
+        assert evicted == 0
+        assert await _exists(svc, "old")
+
+    async def test_max_entries_zero_disables_cap(self):
+        svc = await _inmemory_with([(f"s{i}", float(i)) for i in range(5)])
+        evicted = await prune_sessions(svc, ttl_seconds=86400, max_entries=0)
+        assert evicted == 0
+
+    async def test_empty_store_is_noop(self):
+        svc = create_session_service(use_database=False)
+        assert await prune_sessions(svc, ttl_seconds=86400, max_entries=10) == 0
+
+
+class TestSessionSweeper:
+    def test_disabled_when_ttl_zero(self):
+        sweeper = SessionSweeper(
+            services=[], ttl_seconds=0, max_entries=10, interval_seconds=1
+        )
+        sweeper.start()
+        assert sweeper._task is None  # no background task spawned (kill-switch)
+
+    async def test_sweep_once_across_callable_provider(self):
+        svc = await _inmemory_with([("old", 100_000), ("fresh", 1)])
+        sweeper = SessionSweeper(
+            services=lambda: [svc],
+            ttl_seconds=86400,
+            max_entries=10_000,
+            interval_seconds=300,
+        )
+        assert await sweeper.sweep_once() == 1
+        assert not await _exists(svc, "old")
+        assert await _exists(svc, "fresh")
+
+    async def test_provider_dedupes_shared_service(self):
+        svc = await _inmemory_with([("old", 100_000)])
+        sweeper = SessionSweeper(
+            services=lambda: [svc, svc],  # same instance twice
+            ttl_seconds=86400,
+            max_entries=10_000,
+            interval_seconds=300,
+        )
+        # Pruned exactly once — not double-counted, no error on the gone session.
+        assert await sweeper.sweep_once() == 1
+
+    async def test_start_then_stop_lifecycle(self):
+        svc = create_session_service(use_database=False)
+        sweeper = SessionSweeper(
+            services=lambda: [svc],
+            ttl_seconds=86400,
+            max_entries=10,
+            interval_seconds=300,
+        )
+        sweeper.start()
+        assert sweeper._task is not None
+        await sweeper.stop()
+        assert sweeper._task is None


### PR DESCRIPTION
# feat(session): bounded retention sweep for the in-memory/SQLite session store

## What
Adds a periodic background sweep, started from the FastAPI lifespan, that bounds the
ADK session store so it stops growing without limit. The sweep evicts discover→compose
job sessions whose last update is older than `SESSION_TTL_SECONDS` and, for the in-memory
backend, caps the total session count at `SESSION_MAX_ENTRIES` (evicting the oldest-update
sessions first). For the SQLite/`DatabaseSessionService` backend it runs a best-effort
age-based `DELETE` on the `sessions` table on the same interval.

Defaults: 24h TTL, 10000-entry cap, 300s sweep interval. `SESSION_TTL_SECONDS=0` disables
the sweep entirely (config kill-switch → byte-identical legacy behaviour). Flagless and
reversible (rollback = revert commit).

## Why
`services/session_service.py` returns either an in-memory or a SQLite ADK session store,
and neither has any TTL, eviction, or cleanup. On the single self-hosted box this is a
slow-burn reliability failure: in-memory, every job's full state (regions, composer
envelopes, full itineraries keyed by `job_id`) is retained forever, so RAM grows
monotonically with traffic until an OOM kill drops *all* live jobs at once; in SQLite, the
`sessions` table grows unbounded and `get_session` latency degrades over time. Bounded
retention converts an inevitable crash into steady-state operation and gives ops a knob
(TTL/cap) instead of a time bomb. The TTL default (24h) is comfortably longer than a full
discover→compose→expand lifetime, and ADK refreshes `last_update_time` on every
`append_event`, so an actively-used mid-flow session is never evicted.

## How
- `services/session_retention.py` (new) — the retention layer:
  - `prune_sessions(service, ttl, max_entries)` dispatches on store shape: an in-memory
    store (has a `.sessions` dict) gets age-based expiry + an oldest-update-first cap; a
    store exposing a SQL engine gets the age-based table prune.
  - In-memory eviction snapshots `sessions[app][user][session_id]`, reads ADK's
    `last_update_time`, and removes expired/over-cap entries via the public async
    `delete_session` API. Unknown/garbage timestamps are treated as "fresh" (never evicted).
  - `SessionSweeper` is the lifespan-owned periodic task. `start()` is a no-op when
    `ttl <= 0` (true kill-switch); `stop()` cancels cleanly. It pulls the set of live
    session services from a provider callable each pass (so lazily-created stores are
    picked up) and de-dupes shared instances by identity.
  - Every store interaction is wrapped so a retention hiccup logs and is skipped — it can
    never raise into request serving or kill the sweep loop.
- `api/app.py` — the lifespan builds a `SessionSweeper` over the live session services and
  start()/stop()s it around `yield`. The provider returns the executor's session store
  (the discover→compose leak source) plus, once it has been lazily created, the
  `PlaceToBookResolver`'s isolated in-memory store (which has the same unbounded-growth
  shape).
- `common/config.py` — three new optional settings: `SESSION_TTL_SECONDS` (default 86400),
  `SESSION_MAX_ENTRIES` (default 10000), `SESSION_SWEEP_INTERVAL_SECONDS` (default 300).
- `.env.example` — documents the three vars + the kill-switch.
- `tests/unit/test_session_retention.py` (new) — covers age expiry with survivors
  untouched, recently-refreshed survival, oldest-first over-cap eviction, the `ttl=0` /
  `max_entries=0` no-ops, the empty store, and the `SessionSweeper` lifecycle
  (disabled-when-ttl-0, sweep_once across a callable provider, shared-instance de-dupe,
  start/stop).

Notes / out of scope: not migrating to Redis/an external store; not durable user-data
persistence; no change to the discover→compose contract. The SQLite prune is best-effort
(guarded against schema/engine differences) since prod's default backend is in-memory
(`USE_DATABASE=false`) — the in-memory path is the verified primary OOM guard. The
`ExecutorConfig` (core/types.py) is intentionally untouched: the sweep runs in the API
lifespan reading `common.config.Config` directly, so a direct core-SDK embedder that does
not use the FastAPI app would run its own sweep.

## Review & test
- Verify: `make test` (full unit suite incl. the new `test_session_retention.py`),
  `make lint` (or `ruff`/`flake8` per repo), and an import/boot check of `api.app`.
- Focus areas:
  1. In-memory eviction uses ADK's documented `sessions[app][user][session_id]` structure
     and `last_update_time`; confirm against the installed ADK 1.x that the attribute names
     match (the prune is defensive via `getattr`, but the unit test asserts real eviction
     against a live `InMemorySessionService`).
  2. The lifespan must always `stop()` the sweeper before `shutdown()` (it does, in a
     `finally`).
  3. `SESSION_TTL_SECONDS=0` must spawn no task and change nothing (kill-switch test).
- Edge cases covered by tests: mid-flow (recently refreshed) session survives a short TTL;
  over-cap evicts oldest-update first down to the cap; shared service instance pruned once.
