### PR TITLE
chore(docker): exclude .claude/ + .mcp.json from image build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,6 +32,8 @@ ENV/
 *.key
 service-account*.json
 credentials.json
+.claude/
+.mcp.json
 
 # Tests & coverage artifacts (not part of the runtime package)
 tests/


### PR DESCRIPTION
## Why
During the G5 deploy boundary check (2026-06-24), a real **GOOGLE_API_KEY was found baked into a published storyland-ai image layer** at `/app/.claude/settings.local.json`. It got there because `deploy.sh`'s rsync and the existing `.dockerignore` (#170) both copy `.claude/` into the build context, and `COPY . .` bakes it in.

(The specific key was already **expired/dead** and **prod was never on it** — prod uses a different key in on-box `.env.prod`. So this is hygiene, not an active-credential incident. But the *vector* is real: a future live key in `.claude/` would leak the same way.)

## What
- Add `.claude/` and `.mcp.json` to `.dockerignore` (dev-local Claude Code files, never needed at runtime, prone to holding tokens).

## Risk
Build-only; no application behavior change. Pairs with the infra-side fix (`--exclude .claude` in `deploy.sh` rsync) so the dir is dropped both before and during the build. This is what makes item #173's "no secret layers" acceptance genuinely true on the next ai rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)