### PR TITLE
fix(auth): fail closed on identity — trust only the gateway X-User-ID header

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -101,41 +101,33 @@ def verify_gateway_secret(request: Request) -> None:
         raise HTTPException(status_code=403, detail="Forbidden")
 
 
-def _user_from_jwt(authorization: str | None) -> str | None:
-    """Extract email/sub from a Bearer JWT payload without verifying the signature."""
-    if not authorization or not authorization.startswith("Bearer "):
-        return None
-    try:
-        import base64
-        import json
-        payload_b64 = authorization.split(" ", 1)[1].split(".")[1]
-        payload_b64 += "=" * (4 - len(payload_b64) % 4)
-        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
-        return payload.get("email") or payload.get("sub") or None
-    except Exception:
-        return None
-
-
 def get_gateway_user_id(
     x_user_id: str | None = Header(default=None, alias="X-User-ID"),
-    authorization: str | None = Header(default=None),
 ) -> str:
     """
-    Extract the authenticated user_id.
+    Resolve the authenticated user_id from the trusted X-User-ID header.
 
-    Priority:
-    1. X-User-ID header (set by the backend proxy after JWT validation)
-    2. JWT payload from Authorization header (when frontend calls AI directly)
-    3. 'dev_user' fallback for local development
+    The backend gateway sets X-User-ID only AFTER it has validated the caller's
+    JWT, so this service trusts X-User-ID and nothing else. It deliberately does
+    NOT inspect or trust the raw Authorization JWT: this service cannot verify
+    the token's signature, and trusting an unverified claim would let a forged
+    token impersonate any user (sessions/itineraries are scoped by user_id).
 
-    Raises HTTP 403 if INTERNAL_API_SECRET is configured but X-User-ID is absent.
+    Resolution:
+    1. X-User-ID present                          -> that user_id.
+    2. Absent + ALLOW_DEV_USER=true (local dev)   -> shared 'dev_user'.
+    3. Absent otherwise                           -> fail closed, HTTP 403.
+
+    Failing closed removes the previous foot-gun: whenever INTERNAL_API_SECRET
+    was unset, identity silently fell back to an unverified JWT claim (or a
+    shared 'dev_user'), so a single misconfigured deploy could open cross-tenant
+    access. Identity now requires the trusted header regardless of that secret.
     """
-    secret = get_app_state().config.internal_api_secret
-    if not secret:
-        return x_user_id or _user_from_jwt(authorization) or "dev_user"
-    if not x_user_id:
-        raise HTTPException(status_code=403, detail="X-User-ID header is required")
-    return x_user_id
+    if x_user_id:
+        return x_user_id
+    if get_app_state().config.allow_dev_user:
+        return "dev_user"
+    raise HTTPException(status_code=403, detail="X-User-ID header is required")
 
 
 def _rate_limit_key(request: Request, x_user_id: str | None) -> str:

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -8,7 +8,7 @@ available to all request handlers via get_app_state().
 from dataclasses import dataclass
 from typing import Optional
 
-from fastapi import Depends, Header, HTTPException, Request
+from fastapi import Header, HTTPException, Request
 
 from common.config import Config, load_config
 from common.logging import configure_logging, get_logger

--- a/common/config.py
+++ b/common/config.py
@@ -32,6 +32,11 @@ class Config:
     langfuse_host: Optional[str]
     environment: str
     internal_api_secret: str
+    # Local-dev only escape hatch. When ALLOW_DEV_USER=true and no trusted
+    # X-User-ID header is present, identity falls back to the shared
+    # 'dev_user'. Default false so non-local deploys fail closed (403)
+    # instead of silently collapsing callers into one session namespace.
+    allow_dev_user: bool
     # Result cache for the Discovery chain (always on; validated in prod 2026-06-17).
     cache_ttl_seconds: int
     cache_max_entries: int
@@ -93,6 +98,14 @@ def _env_float(key: str, default: float) -> float:
     return float(value)
 
 
+def _env_bool(key: str, default: bool) -> bool:
+    """Get optional boolean environment variable with a default."""
+    value = os.getenv(key)
+    if value is None:
+        return default
+    return value.lower() == "true"
+
+
 def load_config() -> Config:
     """
     Load configuration from environment variables.
@@ -116,6 +129,9 @@ def load_config() -> Config:
         - LANGFUSE_PUBLIC_KEY: Langfuse public key
         - LANGFUSE_HOST: Langfuse host URL
         - ENVIRONMENT: deployment environment tag (default: "local")
+        - ALLOW_DEV_USER: local-dev only; when "true", a request with no
+          trusted X-User-ID header resolves to the shared "dev_user".
+          Default false (production fails closed with 403). (default: false)
         - RATE_LIMIT_REQUESTS: max requests per window per user/IP on the
           expensive endpoints; 0 disables (default: 0)
         - RATE_LIMIT_WINDOW_SECONDS: rate-limit window length (default: 60)
@@ -150,6 +166,7 @@ def load_config() -> Config:
         langfuse_host=os.getenv("LANGFUSE_HOST"),
         environment=os.getenv("ENVIRONMENT", "local"),
         internal_api_secret=os.getenv("INTERNAL_API_SECRET", ""),
+        allow_dev_user=_env_bool("ALLOW_DEV_USER", False),
         cache_ttl_seconds=_env_int("CACHE_TTL_SECONDS", 86400),
         cache_max_entries=_env_int("CACHE_MAX_ENTRIES", 500),
         retry_exp_base=_env_float("RETRY_EXP_BASE", 2.0),

--- a/tests/unit/test_gateway_auth.py
+++ b/tests/unit/test_gateway_auth.py
@@ -1,0 +1,74 @@
+"""Fail-closed identity guards for ``get_gateway_user_id``.
+
+Regression coverage for the unverified-signature-JWT / shared-``dev_user``
+foot-gun: ``api/dependencies.get_gateway_user_id`` previously fell back to an
+*unverified* JWT claim (or a shared ``dev_user``) whenever ``INTERNAL_API_SECRET``
+was unset, so a forged token — or a single misconfigured deploy — could read or
+write another user's sessions/itineraries (everything is scoped by ``user_id``).
+
+The hardened contract these tests pin:
+  * trust ONLY the gateway-set ``X-User-ID`` header,
+  * never parse/trust the raw Authorization JWT,
+  * fall back to ``dev_user`` ONLY behind the explicit local ``ALLOW_DEV_USER`` flag,
+  * otherwise fail closed with HTTP 403 (never a shared id).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+import api.dependencies as deps
+
+
+@pytest.fixture
+def install_state(monkeypatch):
+    """Install a stub AppState whose config exposes the auth-relevant fields."""
+
+    def _install(internal_api_secret: str = "", allow_dev_user: bool = False):
+        config = SimpleNamespace(
+            internal_api_secret=internal_api_secret,
+            allow_dev_user=allow_dev_user,
+        )
+        monkeypatch.setattr(deps, "get_app_state", lambda: SimpleNamespace(config=config))
+
+    return _install
+
+
+def test_returns_trusted_x_user_id(install_state):
+    """Present X-User-ID is the identity (the only trusted source)."""
+    install_state(internal_api_secret="s3cret")
+    assert deps.get_gateway_user_id(x_user_id="alice") == "alice"
+
+
+def test_missing_identity_fails_closed_when_secret_set(install_state):
+    """No X-User-ID with the secret set -> 403 (unchanged prod behaviour)."""
+    install_state(internal_api_secret="s3cret")
+    with pytest.raises(HTTPException) as exc:
+        deps.get_gateway_user_id(x_user_id=None)
+    assert exc.value.status_code == 403
+
+
+def test_missing_identity_fails_closed_when_secret_unset(install_state):
+    """The core fix: secret unset must NOT collapse to a shared id — fail closed."""
+    install_state(internal_api_secret="", allow_dev_user=False)
+    with pytest.raises(HTTPException) as exc:
+        deps.get_gateway_user_id(x_user_id=None)
+    assert exc.value.status_code == 403
+
+
+def test_dev_user_only_behind_explicit_flag(install_state):
+    """``dev_user`` is reachable only when ALLOW_DEV_USER is explicitly true."""
+    install_state(internal_api_secret="", allow_dev_user=True)
+    assert deps.get_gateway_user_id(x_user_id=None) == "dev_user"
+
+
+def test_x_user_id_wins_even_with_dev_flag(install_state):
+    """A real trusted id always beats the dev fallback."""
+    install_state(internal_api_secret="", allow_dev_user=True)
+    assert deps.get_gateway_user_id(x_user_id="bob") == "bob"
+
+
+def test_unverified_jwt_helper_is_removed():
+    """The unverified-signature JWT path must be gone entirely."""
+    assert not hasattr(deps, "_user_from_jwt")


### PR DESCRIPTION
# fix(auth): fail closed on identity — trust only the gateway X-User-ID header

## What
`api/dependencies.get_gateway_user_id()` no longer trusts an unverified
Authorization JWT payload, and no longer collapses callers into a shared
`dev_user` when `INTERNAL_API_SECRET` is unset. The authenticated `user_id` is
now resolved solely from the trusted, gateway-set `X-User-ID` header. The
`dev_user` fallback survives only behind a new, explicit `ALLOW_DEV_USER`
local-development flag (default off); in every other case a request with no
`X-User-ID` fails closed with HTTP 403. The unverified-JWT helper
(`_user_from_jwt`) is deleted entirely.

## Why
`_user_from_jwt()` base64-decoded the JWT payload and trusted its `email`/`sub`
claim as the `user_id` **without verifying the token signature**, and
`get_gateway_user_id()` fell back to that unverified identity (or a shared
`dev_user`) whenever `INTERNAL_API_SECRET` was falsy. Because every session and
itinerary is scoped by `user_id`, a forged/edited token could read or write
another user's data. Production is not exploitable today (the secret is set and
`X-User-ID` is required), but the safety of the whole tenant boundary hung on a
single env var being present on every deploy, forever — a latent foot-gun. This
service cannot verify the JWT signature itself (it has no access to the
gateway's signing key, and there is no JWT library in the dependency set), so
the correct hardening is to stop trusting the raw token and require the header
the gateway sets only *after* it has validated the JWT — i.e. fail closed.

## How
- `api/dependencies.py`: removed `_user_from_jwt()` and its `authorization`
  header parameter. `get_gateway_user_id()` is now: return `X-User-ID` if
  present; else return `dev_user` only when `config.allow_dev_user` is true;
  else raise `HTTPException(403, "X-User-ID header is required")`. The
  `INTERNAL_API_SECRET`-conditional branch that selected the unsafe fallback is
  gone — identity no longer depends on whether that secret is set.
- `common/config.py`: added an optional `ALLOW_DEV_USER` boolean (new
  `_env_bool` helper, `Config.allow_dev_user` field, default `False`) plus
  docstring coverage.
- `tests/unit/test_gateway_auth.py` (new): pins the hardened contract.

Behaviour is **unchanged in production** (secret set + `X-User-ID` required →
returns `X-User-ID`, same as before; missing id → 403, same as before). The
only change for existing callers is that a deploy with the secret *unset* and no
`X-User-ID` now returns 403 instead of a guessable shared id, and local dev that
relied on the automatic `dev_user` must set `ALLOW_DEV_USER=true`. Additive and
reversible (revert the commit). No new dependency; no migration; no
recommendation/agent-logic change → not a G4-spend / eval change.

## Review & test
Focus review on `get_gateway_user_id()`: confirm there is no remaining path by
which an unauthenticated/forged caller obtains a non-empty `user_id`, and that
prod (secret set, `X-User-ID` present) is byte-for-byte unchanged.

Run the unit suite (`pytest -q`, or the focused module
`pytest tests/unit/test_gateway_auth.py -q`). The new tests assert:
- present `X-User-ID` → that id;
- missing `X-User-ID` with the secret set → 403;
- missing `X-User-ID` with the secret **unset** → 403 (the core fix: never a
  shared id);
- `dev_user` returned only when `ALLOW_DEV_USER=true`;
- a real `X-User-ID` still wins even with the dev flag on;
- `_user_from_jwt` no longer exists.

Acceptance criteria (from the spec): a tampered-payload token is rejected
(ignored in favour of `X-User-ID`); missing identity → 403, never a shared id.
