### PR TITLE
test: add socksio dev dep so the VCR integration suite replays under a SOCKS proxy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "vcrpy>=6.0.0",
     "responses>=0.25.0",
     "httpx>=0.27.0",
+    "socksio>=1.0.0",  # SOCKS transport for httpx so the VCR integration suite replays under a SOCKS proxy (CI/sandbox); offline cassette replay otherwise
 ]
 
 [tool.pytest.ini_options]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,6 +9,11 @@ from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 # Load environment variables from .env file
 load_dotenv()
 
+# Provide a dummy GOOGLE_API_KEY for offline VCR cassette replay when none is set
+# (e.g. proxied/no-key sandbox or autonomous QA runs). setdefault never overrides a
+# real key, so CI — which injects secrets.GOOGLE_API_KEY — and live runs are unaffected.
+os.environ.setdefault("GOOGLE_API_KEY", "test-key-for-vcr-replay")
+
 
 def normalize_query_string(url):
     """


### PR DESCRIPTION
# test: add socksio dev dep so the VCR integration suite replays under a SOCKS proxy

## What
Adds `socksio>=1.0.0` to the `dev` optional-dependency group in `pyproject.toml`, and sets a
dummy `GOOGLE_API_KEY` default in `tests/integration/conftest.py` for offline cassette replay.
Pure test-infra change — no production code, no schema, no CI/workflow edits.

## Why
The cassette-based integration suite (`@pytest.mark.vcr()`) reports 4 false failures whenever it
runs without outbound network + live credentials — i.e. in SOCKS-proxied / no-key environments
such as the sandbox and autonomous QA runs:

- `tests/integration/test_llm_scoring.py` (×3): `ImportError: SOCKS proxy in use but 'socksio' not
  installed`, raised while constructing `genai.Client()`, only when a SOCKS `*_PROXY` env is set.
  GitHub runners don't set one, so CI is already green; the proxied sandbox does, so it errors.
- `test_langfuse_integration.py::...test_book_metadata_workflow_with_langfuse` (×1):
  `ValueError: No API key was provided`, because `GOOGLE_API_KEY` is unset locally. This test is
  not `real_api`-marked and has a committed cassette, so it replays with any key value present.

These are environment artifacts, not real defects, but they make green-vs-red depend on where the
suite runs and erode trust in the autonomous QA/sandbox signal. Adding the SOCKS transport removes
the ImportError; the conftest key default lets offline cassette replay run fully green.

## How
- `pyproject.toml` — one line added to `[project.optional-dependencies].dev`:
  `"socksio>=1.0.0"` (the SOCKS transport httpx negotiates a proxy through). Additive only.
- `tests/integration/conftest.py` — `os.environ.setdefault("GOOGLE_API_KEY", "test-key-for-vcr-replay")`
  immediately after `load_dotenv()`. `setdefault` never overrides an existing value, so CI (which
  injects `secrets.GOOGLE_API_KEY`) and live runs (`make test-integration-live`) are unaffected;
  it only supplies a placeholder for offline cassette replay.

No tests were modified, no CI YAML changed (secrets are already wired), and no secret values are
handled here (that remains an owner/Release-Eng step). Rollback = revert this commit.

## Review & test
- Confirm the only changes are the two additive lines above (no test logic touched).
- CI is the authoritative gate: the integration job installs the `dev` extra and runs the VCR
  suite — it should stay green (it already was on GitHub runners).
- Offline / proxied check (reproduces the original failure mode):
  `pip install -e ".[dev]" && make test-integration` — previously 4 failed under a SOCKS proxy /
  no key; with socksio + the conftest default all 4 replay their cassettes and pass.
- Live path unchanged: `make test-integration-live` still runs against real APIs when secrets +
  network are present.
