### PR TITLE
feat: rec-explanation tone guardrail (explain the book↔place fit, never grade the reader)

### DIFF
--- a/agents/prompts.py
+++ b/agents/prompts.py
@@ -71,5 +71,42 @@ def load_prompts(version: str = CURRENT_PROMPT_VERSION) -> AgentPrompts:
             )
         with open(path, encoding="utf-8") as f:
             data = json.load(f)
-        _cache[version] = AgentPrompts(**data["agents"])
+        agents_data = _inject_tone_guardrail(data["agents"])
+        _cache[version] = AgentPrompts(**agents_data)
     return _cache[version]
+
+
+# Agents that emit reader-facing explanation text ("why it fits" / reason /
+# overview / summary). The rec-explanation tone guardrail clause is appended to
+# each so the model never writes reader-directed judgement. Researcher agents
+# (which only gather candidates) and pure formatters that don't author the
+# explanation copy are intentionally excluded.
+_EXPLANATION_AGENTS = (
+    "trip_composer",
+    "local_atmosphere_formatter",
+    "expansion_formatter",
+    "book_recommendation_formatter",
+    "place_to_book_formatter",
+)
+
+
+def _inject_tone_guardrail(agents_data: dict) -> dict:
+    """Append the reader-safety tone guardrail to explanation-producing prompts.
+
+    Returns a shallow copy with the guardrail appended to each explanation
+    agent's instruction. Idempotent: skips an instruction that already carries
+    the clause (the cache also makes load_prompts a no-op after the first call).
+
+    The guardrail constant is imported lazily here (not at module load) so the
+    ``agents`` package never imports the heavy ``core`` package at import time,
+    avoiding an agents<->core import cycle. By the time load_prompts() first
+    runs, all modules are fully initialized.
+    """
+    from core.guardrails import READER_TONE_GUARDRAIL
+
+    out = dict(agents_data)
+    for name in _EXPLANATION_AGENTS:
+        instruction = out.get(name)
+        if isinstance(instruction, str) and READER_TONE_GUARDRAIL not in instruction:
+            out[name] = instruction + READER_TONE_GUARDRAIL
+    return out

--- a/core/extraction.py
+++ b/core/extraction.py
@@ -14,6 +14,11 @@ from typing import Optional, Tuple
 from pydantic import ValidationError
 
 from common.logging import get_logger
+from core.guardrails import (
+    sanitize_itinerary_explanations,
+    sanitize_expansion_explanations,
+    sanitize_book_recommendations,
+)
 from models.book import BookRecommendationsResult
 from models.itinerary import TripItinerary, ComposerEnvelope, ExpansionResult
 
@@ -167,7 +172,9 @@ def extract_itinerary_from_response(
     grounding_text = state_accessor.grounding_research_text
 
     def _finalize(itinerary_dict, suggestions):
-        return downgrade_ungrounded_match_types(itinerary_dict, grounding_text), suggestions
+        itinerary_dict = downgrade_ungrounded_match_types(itinerary_dict, grounding_text)
+        itinerary_dict = sanitize_itinerary_explanations(itinerary_dict)
+        return itinerary_dict, suggestions
 
     # Primary: composer_envelope from session state (set by output_key="composer_envelope")
     envelope_data = state_accessor.composer_envelope
@@ -210,7 +217,9 @@ def extract_itinerary_from_response(
 
 def extract_expansion_from_state(state_accessor) -> Optional[dict]:
     """Extract and validate the last expansion result from session state."""
-    return validate_expansion_result(state_accessor.last_expansion)
+    return sanitize_expansion_explanations(
+        validate_expansion_result(state_accessor.last_expansion)
+    )
 
 
 def validate_book_recommendations_result(value: object) -> Optional[dict]:
@@ -236,7 +245,9 @@ def validate_book_recommendations_result(value: object) -> Optional[dict]:
 
 def extract_book_recommendations_from_state(state_accessor) -> Optional[dict]:
     """Extract and validate the last book recommendations result from session state."""
-    return validate_book_recommendations_result(state_accessor.last_book_recommendations)
+    return sanitize_book_recommendations(
+        validate_book_recommendations_result(state_accessor.last_book_recommendations)
+    )
 
 
 def _normalize_text(text: object) -> str:

--- a/core/guardrails/__init__.py
+++ b/core/guardrails/__init__.py
@@ -1,0 +1,25 @@
+"""Output-tone / safety guardrails for reader-facing explanation text.
+
+Currently exposes the rec-explanation *tone* guardrail: the system-instruction
+clause that keeps every "why it fits" explanation focused on the book<->place
+fit, plus the deterministic, zero-spend output checker that strips any
+reader-directed judgement that slips through.
+"""
+
+from .tone_guardrail import (
+    READER_TONE_GUARDRAIL,
+    flag_reader_directed,
+    sanitize_explanation,
+    sanitize_itinerary_explanations,
+    sanitize_expansion_explanations,
+    sanitize_book_recommendations,
+)
+
+__all__ = [
+    "READER_TONE_GUARDRAIL",
+    "flag_reader_directed",
+    "sanitize_explanation",
+    "sanitize_itinerary_explanations",
+    "sanitize_expansion_explanations",
+    "sanitize_book_recommendations",
+]

--- a/core/guardrails/tone_guardrail.py
+++ b/core/guardrails/tone_guardrail.py
@@ -1,0 +1,248 @@
+"""Rec-explanation tone guardrail.
+
+Storyland's recommendations are AI-generated and *explained* ("why this place
+fits this book"). This guardrail keeps every such explanation focused on the
+book<->place **fit** and forbids the model from characterizing, psychoanalyzing,
+grading, moralizing about, or inferring the identity of the **reader** or their
+taste. It is purely downside-protective (cf. the Dec-2024 Fable AI blow-up where
+an "explained" AI graded users' reading taste with bigoted commentary).
+
+Two layers, one source of truth (this module):
+
+1. ``READER_TONE_GUARDRAIL`` — a system-instruction clause + prohibited-pattern
+   list appended to every explanation-producing agent prompt (see
+   ``agents.prompts.load_prompts``). This is the primary control: the model is
+   told not to write reader-directed judgements.
+
+2. ``flag_reader_directed`` / ``sanitize_explanation`` — a deterministic,
+   regex/string-rule checker (ZERO Gemini calls, safe to run on every request)
+   that scans finalized explanation text and drops any reader-directed clause
+   that slipped through, falling back to the fit-only explanation. Wired into the
+   ``core.extraction`` finalization points (itinerary, expansion, book recs).
+
+Conservative & fail-open by design — it must never make a result worse:
+  * It only removes clauses that judge the *reader*; legitimate fit text about
+    scenes, themes, history, mood, or geography (incl. benign second person like
+    "you'll walk the same misty streets") is never touched.
+  * If sanitizing would empty a required field, a neutral fit-only fallback is
+    used instead of surfacing an empty or reader-grading line.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List, Optional, Tuple
+
+from common.logging import get_logger
+
+logger = get_logger("storyland.core.guardrails.tone")
+
+
+# --------------------------------------------------------------------------- #
+# System-instruction clause (primary control). Appended to every
+# explanation-producing agent prompt so the model never writes reader-directed
+# judgement in the first place. Same module feeds the deterministic checker
+# below, so the prompt and the check stay in lock-step.
+# --------------------------------------------------------------------------- #
+READER_TONE_GUARDRAIL = (
+    "\n\n## READER-SAFETY GUARDRAIL (explanation tone)\n"
+    "Every explanation you write — the \"why it fits\" / reason / overview / "
+    "summary text — must describe ONLY why the place or book fits: its scenes, "
+    "themes, history, mood, geography, or atmosphere. You must NEVER "
+    "characterize, psychoanalyze, grade, rank, moralize about, or infer the "
+    "identity, demographics, intelligence, politics, or worth of the reader or "
+    "their taste.\n"
+    "Prohibited — never write anything like these:\n"
+    "- Verdicts on the reader's taste or character (\"your taste is…\", "
+    "\"this says a lot about you\", \"you seem like…\").\n"
+    "- Labels or inferences about who the reader is (\"as a sophisticated "
+    "reader…\", \"readers like you…\", \"you're the kind of person who…\").\n"
+    "- Any praise, criticism, or moral judgement aimed at the reader rather than "
+    "the book<->place fit.\n"
+    "Keep the focus on the book and the place. Second person is fine ONLY to "
+    "describe what the reader will see or experience at the place — never to "
+    "judge the reader."
+)
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic checker (secondary, zero-spend safety net).
+#
+# Each pattern targets a reader-DIRECTED judgement (a verdict/label/inference
+# about the reader or their taste/identity). Patterns are deliberately narrow
+# and high-precision to avoid stripping legitimate fit explanations that happen
+# to use second person to invite the reader into the *place* ("you'll wander the
+# foggy quays", "you can stand where the duel was fought").
+# --------------------------------------------------------------------------- #
+_READER_NOUNS = r"(?:taste|tastes|personality|character|soul|mind|intellect|reading habits?|reading|choices?|preferences?|picks?|selections?)"
+
+_PATTERNS: tuple[tuple[str, "re.Pattern[str]"], ...] = (
+    # "your taste is…", "your reading choices reveal…"
+    (
+        "reader_taste_verdict",
+        re.compile(
+            r"\byour\s+" + _READER_NOUNS
+            + r"\b[^.!?]*\b(is|are|says?|reveals?|suggests?|shows?|tells?|reflects?|betrays?|screams?|means?)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    # "you seem like…", "you sound like the type…", "you come across as…"
+    (
+        "reader_inference",
+        re.compile(
+            r"\byou\s+(?:seem|sound|appear|come across)\b[^.!?]*\b(?:to be|like|as)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    # "you're the kind/sort/type of reader/person who…"
+    (
+        "reader_type_label",
+        re.compile(
+            r"\byou(?:'re| are)\s+(?:the\s+)?(?:kind|sort|type)\s+of\s+(?:reader|person|traveler|traveller|soul)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    # "readers/people/travellers like you…"
+    (
+        "people_like_you",
+        re.compile(
+            r"\b(?:readers?|people|travel(?:l)?ers?|souls?|minds?)\s+like\s+you\b",
+            re.IGNORECASE,
+        ),
+    ),
+    # "this says/reveals/tells (a lot) about you/your taste"
+    (
+        "says_about_you",
+        re.compile(
+            r"\b(?:this|that|it)\s+(?:says|reveals|tells\s+us|suggests|shows)\b[^.!?]*\babout\s+(?:you|your)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    # "as a sophisticated/discerning/serious/basic/pretentious reader…" —
+    # an identity adjective applied to the reader (plain "as a reader" is NOT
+    # matched: an adjective between the article and the noun is required).
+    (
+        "reader_identity_label",
+        re.compile(
+            r"\bas\s+an?\s+\w+\s+(?:reader|person|traveler|traveller)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    # "you must be (a/an/the kind of)…" — direct identity inference
+    (
+        "reader_must_be",
+        re.compile(
+            r"\byou\s+must\s+be\s+(?:a|an|the|quite|really|very|someone)\b",
+            re.IGNORECASE,
+        ),
+    ),
+)
+
+# Neutral fit-only fallback used only when sanitizing would otherwise empty a
+# required explanation field (never surface an empty or reader-grading line).
+_FIT_FALLBACK = "Chosen for how its setting and atmosphere echo the book."
+
+_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
+
+
+def flag_reader_directed(text: object) -> List[str]:
+    """Return the reader-directed-judgement pattern labels matched in ``text``.
+
+    Empty list means the text is clean. Non-string / empty input -> ``[]``
+    (fail-open). This is pure string work — no model/network calls.
+    """
+    if not isinstance(text, str) or not text.strip():
+        return []
+    return [label for label, pattern in _PATTERNS if pattern.search(text)]
+
+
+def sanitize_explanation(
+    text: object, fallback: Optional[str] = None
+) -> Tuple[str, List[str]]:
+    """Strip reader-directed clauses from an explanation, sentence by sentence.
+
+    Returns ``(clean_text, matched_labels)``. Any sentence containing a
+    prohibited reader-directed pattern is dropped; the remaining fit-only
+    sentences are rejoined. If every sentence is dropped (or the input is
+    non-string), the neutral fit-only ``fallback`` is returned so a required
+    field is never emptied. ``matched_labels`` is empty when nothing was stripped.
+    """
+    if not isinstance(text, str) or not text.strip():
+        return (text if isinstance(text, str) else ""), []
+
+    matched = flag_reader_directed(text)
+    if not matched:
+        return text, []
+
+    kept: List[str] = []
+    for sentence in _SENTENCE_SPLIT.split(text.strip()):
+        if not sentence.strip():
+            continue
+        if flag_reader_directed(sentence):
+            continue
+        kept.append(sentence.strip())
+
+    clean = " ".join(kept).strip()
+    if not clean:
+        clean = (fallback or _FIT_FALLBACK)
+    return clean, matched
+
+
+def _sanitize_field(container: dict, key: str) -> int:
+    """Sanitize ``container[key]`` in place. Returns 1 if it was changed."""
+    if not isinstance(container, dict):
+        return 0
+    original = container.get(key)
+    clean, matched = sanitize_explanation(original)
+    if matched and clean != original:
+        container[key] = clean
+        return 1
+    return 0
+
+
+def sanitize_itinerary_explanations(itinerary_dict: Optional[dict]) -> Optional[dict]:
+    """Sanitize every reader-facing explanation field in an itinerary dict.
+
+    Covers ``summary_text``, each city's ``overview``, and each stop's
+    ``reason``. Mutates and returns the same dict (fail-open on None/empty).
+    """
+    if not itinerary_dict:
+        return itinerary_dict
+
+    changed = _sanitize_field(itinerary_dict, "summary_text")
+    for city in itinerary_dict.get("cities") or []:
+        changed += _sanitize_field(city, "overview")
+        for stop in city.get("stops") or []:
+            changed += _sanitize_field(stop, "reason")
+
+    if changed:
+        logger.info("itinerary_tone_sanitized", fields=changed)
+    return itinerary_dict
+
+
+def sanitize_expansion_explanations(expansion_dict: Optional[dict]) -> Optional[dict]:
+    """Sanitize the ``reason`` on each expansion place (fail-open on None)."""
+    if not expansion_dict:
+        return expansion_dict
+
+    changed = 0
+    for place in expansion_dict.get("places") or []:
+        changed += _sanitize_field(place, "reason")
+
+    if changed:
+        logger.info("expansion_tone_sanitized", fields=changed)
+    return expansion_dict
+
+
+def sanitize_book_recommendations(rec_dict: Optional[dict]) -> Optional[dict]:
+    """Sanitize the ``reason`` on each book recommendation (fail-open on None)."""
+    if not rec_dict:
+        return rec_dict
+
+    changed = 0
+    for rec in rec_dict.get("recommendations") or []:
+        changed += _sanitize_field(rec, "reason")
+
+    if changed:
+        logger.info("book_recommendations_tone_sanitized", fields=changed)
+    return rec_dict

--- a/tests/unit/test_tone_guardrail.py
+++ b/tests/unit/test_tone_guardrail.py
@@ -1,0 +1,181 @@
+"""Tests for the rec-explanation tone guardrail.
+
+Covers:
+  * core.guardrails.tone_guardrail.flag_reader_directed — catches reader-directed
+    verdicts/labels/inferences, ignores legitimate fit explanations (incl. benign
+    second person about the place).
+  * sanitize_explanation — drops only the offending sentence, keeps fit-only text,
+    falls back when everything is stripped, is fail-open on non-string input.
+  * sanitize_{itinerary,expansion,book_recommendations} — walk the reader-facing
+    fields and are fail-open on None/empty.
+  * agents.prompts.load_prompts — appends READER_TONE_GUARDRAIL to the
+    explanation-producing agents only, and is idempotent.
+
+All deterministic and offline — no Gemini/model calls.
+"""
+
+import pytest
+
+from core.guardrails.tone_guardrail import (
+    READER_TONE_GUARDRAIL,
+    flag_reader_directed,
+    sanitize_explanation,
+    sanitize_itinerary_explanations,
+    sanitize_expansion_explanations,
+    sanitize_book_recommendations,
+    _FIT_FALLBACK,
+)
+
+
+READER_DIRECTED = [
+    "Your taste is rather pedestrian, but this town still works.",
+    "Your reading choices reveal a melancholic streak.",
+    "You seem like the anxious type, so a quiet village suits you.",
+    "You're the kind of reader who needs constant stimulation.",
+    "Readers like you usually prefer something lighter.",
+    "This says a lot about you and your shallow preferences.",
+    "As a sophisticated reader, you will appreciate the nuance.",
+    "You must be quite the romantic to pick this one.",
+]
+
+FIT_ONLY = [
+    "You'll wander the same foggy quays the detective walked at midnight.",
+    "Chosen for its gothic cathedrals and mist-laden moors that mirror the dread.",
+    "The cafe's candle-lit interior echoes the book's slow-burn romance.",
+    "Stand where the duel was fought on these very steps.",
+    "As a reader, immerse yourself in the salt-air harbour the author describes.",
+    "This neighbourhood reveals the city's literary past in every plaque.",
+    "You can walk the trail that inspired the wilderness chapters.",
+    "With a relaxed pace in mind, this itinerary lingers in two coastal towns.",
+]
+
+
+class TestFlagReaderDirected:
+    @pytest.mark.parametrize("text", READER_DIRECTED)
+    def test_flags_reader_directed(self, text):
+        assert flag_reader_directed(text), f"should flag: {text!r}"
+
+    @pytest.mark.parametrize("text", FIT_ONLY)
+    def test_passes_fit_only(self, text):
+        assert flag_reader_directed(text) == [], f"should NOT flag: {text!r}"
+
+    def test_fail_open_on_non_string(self):
+        assert flag_reader_directed(None) == []
+        assert flag_reader_directed(123) == []
+        assert flag_reader_directed("") == []
+        assert flag_reader_directed("   ") == []
+
+
+class TestSanitizeExplanation:
+    def test_clean_text_unchanged(self):
+        text = FIT_ONLY[0]
+        clean, matched = sanitize_explanation(text)
+        assert clean == text
+        assert matched == []
+
+    def test_drops_only_offending_sentence(self):
+        text = (
+            "Chosen for its mist-laden moors that mirror the novel's dread. "
+            "Your taste is rather basic, frankly. "
+            "Stand where the duel was fought."
+        )
+        clean, matched = sanitize_explanation(text)
+        assert matched  # something was flagged
+        assert "Your taste is" not in clean
+        assert "mist-laden moors" in clean
+        assert "duel was fought" in clean
+
+    def test_full_strip_falls_back(self):
+        text = "Your taste is shallow. You seem like a tourist."
+        clean, matched = sanitize_explanation(text)
+        assert matched
+        assert clean == _FIT_FALLBACK
+
+    def test_custom_fallback(self):
+        clean, _ = sanitize_explanation("Readers like you are lazy.", fallback="X")
+        assert clean == "X"
+
+    def test_fail_open_on_non_string(self):
+        assert sanitize_explanation(None) == ("", [])
+        assert sanitize_explanation(42) == ("", [])
+
+
+class TestSanitizeWalkers:
+    def test_itinerary_sanitized(self):
+        itin = {
+            "summary_text": "A trip for you. This says a lot about you and your taste.",
+            "cities": [
+                {
+                    "overview": "Your reading habits suggest you'd love this.",
+                    "stops": [
+                        {"name": "Quay", "reason": "Foggy quays echo the novel's gloom."},
+                        {"name": "Bar", "reason": "You're the kind of reader who drinks alone."},
+                    ],
+                }
+            ],
+        }
+        out = sanitize_itinerary_explanations(itin)
+        assert "about you" not in out["summary_text"]
+        assert "reading habits" not in out["cities"][0]["overview"]
+        # clean stop untouched, dirty stop scrubbed
+        assert out["cities"][0]["stops"][0]["reason"] == "Foggy quays echo the novel's gloom."
+        assert "kind of reader" not in out["cities"][0]["stops"][1]["reason"]
+
+    def test_itinerary_fail_open(self):
+        assert sanitize_itinerary_explanations(None) is None
+        assert sanitize_itinerary_explanations({}) == {}
+
+    def test_expansion_sanitized(self):
+        exp = {"places": [{"reason": "Readers like you love this."}, {"reason": "Quiet gothic chapel."}]}
+        out = sanitize_expansion_explanations(exp)
+        assert "like you" not in out["places"][0]["reason"]
+        assert out["places"][1]["reason"] == "Quiet gothic chapel."
+
+    def test_expansion_fail_open(self):
+        assert sanitize_expansion_explanations(None) is None
+
+    def test_book_recommendations_sanitized(self):
+        rec = {"recommendations": [
+            {"title": "A", "reason": "Your taste is basic, so try this."},
+            {"title": "B", "reason": "A windswept saga set on the same coast."},
+        ]}
+        out = sanitize_book_recommendations(rec)
+        assert "Your taste is" not in out["recommendations"][0]["reason"]
+        assert out["recommendations"][1]["reason"] == "A windswept saga set on the same coast."
+
+    def test_book_recommendations_fail_open(self):
+        assert sanitize_book_recommendations(None) is None
+
+
+class TestPromptInjection:
+    def test_guardrail_constant_has_scope_and_prohibited_list(self):
+        # AC1: the clause scopes output to the fit and carries a prohibited list.
+        assert "READER-SAFETY GUARDRAIL" in READER_TONE_GUARDRAIL
+        assert "Prohibited" in READER_TONE_GUARDRAIL
+        assert "never" in READER_TONE_GUARDRAIL.lower()
+
+    def test_explanation_agents_carry_guardrail(self):
+        from agents.prompts import load_prompts, _EXPLANATION_AGENTS
+
+        prompts = load_prompts()
+        for name in _EXPLANATION_AGENTS:
+            assert READER_TONE_GUARDRAIL in getattr(prompts, name), name
+
+    def test_researcher_agents_do_not_carry_guardrail(self):
+        from agents.prompts import load_prompts
+
+        prompts = load_prompts()
+        # Researchers only gather candidates; they don't author explanations.
+        assert READER_TONE_GUARDRAIL not in prompts.book_recommendation_researcher
+        assert READER_TONE_GUARDRAIL not in prompts.city_researcher
+
+    def test_injection_idempotent(self):
+        from agents.prompts import _inject_tone_guardrail
+
+        base = {"trip_composer": "Plan a trip.", "city_researcher": "Search."}
+        once = _inject_tone_guardrail(base)
+        twice = _inject_tone_guardrail(once)
+        assert once["trip_composer"] == twice["trip_composer"]
+        assert once["trip_composer"].count("READER-SAFETY GUARDRAIL") == 1
+        # non-explanation agent untouched
+        assert twice["city_researcher"] == "Search."


### PR DESCRIPTION
# feat: rec-explanation tone guardrail (explain the book↔place fit, never grade the reader)

## What
Adds a reader-safety tone guardrail to the AI rec-explanation surface so every
generated explanation ("why this place/book fits") stays focused on the
book↔place fit and never characterizes, psychoanalyzes, grades, moralizes about,
or infers the identity of the reader or their taste. Two layers, one source of
truth (`core/guardrails/tone_guardrail.py`):

1. A `READER_TONE_GUARDRAIL` system-instruction clause + prohibited-pattern list,
   appended to every explanation-producing agent prompt at load time.
2. A deterministic, zero-spend output checker (`flag_reader_directed` /
   `sanitize_explanation`) wired into the itinerary, expansion, and
   book-recommendation finalization in `core/extraction.py`. It strips any
   reader-directed clause that slips through and falls back to the fit-only text.

## Why
Storyland's recs are AI-generated and *explained*, and "explained" AI that judges
the reader is reputationally radioactive (cf. the Dec-2024 Fable blow-up, where an
AI year-in-reading feature graded users' taste with bigoted commentary → backlash
→ full AI shutdown). Nothing previously constrained our explanation tone toward
the reader. This is a purely downside-protective guardrail on the core trust
surface — low probability of the failure, catastrophic if it ever fires.

This is distinct from the existing factual hallucination/grounding guardrail
(`downgrade_ungrounded_match_types`, `filter_grounded_recommendations`): that
protects the *correctness* of book↔place claims; this protects the *tone toward
the reader*. It deliberately follows the same conservative, fail-open,
server-side post-processing pattern.

## How
- `core/guardrails/tone_guardrail.py` (new):
  - `READER_TONE_GUARDRAIL` — the system-instruction clause + prohibited-pattern
    list (single source feeding both the prompt and the checker).
  - `flag_reader_directed(text) -> list[str]` — high-precision regex rules that
    match reader-directed verdicts/labels/inferences ("your taste is…", "readers
    like you…", "you're the kind of reader who…", "as a <adj> reader…", etc.).
    Plain second person about the *place* ("you'll wander the foggy quays") and
    plain "as a reader" are intentionally NOT matched.
  - `sanitize_explanation(text)` — drops only the offending sentence(s), keeps the
    fit-only text, and uses a neutral fit fallback if everything is stripped so a
    required field is never emptied.
  - `sanitize_{itinerary,expansion,book_recommendations}_explanations` — walk the
    reader-facing fields (`summary_text`, city `overview`, stop/place/rec
    `reason`); fail-open on None/empty; log a structured event when they act.
- `agents/prompts.py` — `load_prompts()` appends `READER_TONE_GUARDRAIL` to the
  five explanation-producing agents (`trip_composer`, `local_atmosphere_formatter`,
  `expansion_formatter`, `book_recommendation_formatter`, `place_to_book_formatter`);
  researcher/gatherer agents are excluded. Idempotent. The guardrail constant is
  imported lazily inside the injector to avoid an `agents`↔`core` import cycle.
- `core/extraction.py` — sanitizers wired into the three live finalization points
  (`extract_itinerary_from_response._finalize`, `extract_expansion_from_state`,
  `extract_book_recommendations_from_state`), running right after the existing
  grounding post-validation.

Additive, flagless (a safety guardrail we'd never want toggled off in prod);
rollback = revert the commit. No schema/contract change — explanation field
shapes are unchanged. The reader-facing explanation text is generated AI-side and
travels ai→be→fe (BE forwards untouched, FE renders), so the guardrail correctly
lives AI-side; a grep of be (storyland-services) + fe (storyland-web) found no
hardcoded explanation scaffolding that grades the reader (AC3 confirmed).

## Review & test
- Focus: the precision of `flag_reader_directed` (no false positives that strip
  legitimate fit copy) and that `sanitize_*` never empties a required field.
- New `tests/unit/test_tone_guardrail.py` (32 tests): positive/negative pattern
  cases, sentence-level stripping + fallback, fail-open on None/non-string, the
  three walkers, and the prompt injection (explanation agents carry the clause,
  researchers don't, idempotent).
- Verify: `pytest tests/unit/` — full unit suite green (546 passed) and `ruff
  check` clean. All deterministic and offline — no Gemini/network calls.
- Note on the optional live eval: a confirmatory Langfuse assertion that
  vibe/taste-judgment-prone prompts stay clean and don't regress grounding is
  filed separately as a HELD, spend-gated (G4) eval handoff. It is NOT required to
  merge this PR — the deterministic checker + unit tests are the gate.
