### PR TITLE
feat: bias discovery on an optional vibe and surface it in the "why this fits"

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -46,6 +46,36 @@ def _bound_preferences(value):
     return value
 
 
+# Curated mood/vibe set mirrored from the gateway (storyland-services). The
+# gateway already validates + normalizes before forwarding, but we re-validate
+# here so the AI service never trusts an unbounded value into the discovery
+# prompt (defense in depth). Canonical form is lower-case; "slow-burn" keeps its
+# hyphen. Absent ⇒ today's behavior exactly; an unrecognized value is a 422.
+ALLOWED_VIBES = frozenset(
+    {"cozy", "melancholic", "adventurous", "slow-burn", "atmospheric", "hopeful"}
+)
+
+
+def _validate_vibe(value):
+    """Normalize + validate an optional mood/vibe token.
+
+    Returns the canonical lower-case token, or None when absent/blank. Raises
+    ValueError (→ 422) for a non-string or an out-of-set value so an unknown
+    vibe is never silently dropped into the prompt.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("vibe must be a string")
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    if normalized not in ALLOWED_VIBES:
+        allowed = ", ".join(sorted(ALLOWED_VIBES))
+        raise ValueError(f"vibe must be one of: {allowed}")
+    return normalized
+
+
 class DiscoverRequest(BaseModel):
     """Request body for POST /api/v1/itinerary/discover."""
 
@@ -74,6 +104,14 @@ class DiscoverRequest(BaseModel):
     preferences: Optional[dict] = Field(
         default=None, description="User travel preferences"
     )
+    vibe: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional explicit mood/vibe to bias discovery toward (curated set: "
+            "cozy, melancholic, adventurous, slow-burn, atmospheric, hopeful). "
+            "Absent ⇒ unchanged behavior."
+        ),
+    )
 
     @field_validator("book_title")
     @classmethod
@@ -98,6 +136,12 @@ class DiscoverRequest(BaseModel):
     def validate_preferences(cls, value):
         """Bound preferences size before it flows into the prompt."""
         return _bound_preferences(value)
+
+    @field_validator("vibe")
+    @classmethod
+    def validate_vibe(cls, value):
+        """Validate/normalize the optional mood/vibe token before the prompt."""
+        return _validate_vibe(value)
 
 
 class ComposeRequest(BaseModel):

--- a/api/routes.py
+++ b/api/routes.py
@@ -125,6 +125,7 @@ async def discover(request: DiscoverRequest, user_id: str = Depends(get_gateway_
         book_title=request.book_title,
         author=request.author,
         preferences=request.preferences,
+        vibe=request.vibe,
         user_id=user_id,
         executor=app_state.executor,
     )

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -127,12 +127,14 @@ async def discover_stream(
     preferences: Optional[dict],
     user_id: str,
     executor: WorkflowExecutor,
+    vibe: Optional[str] = None,
 ) -> AsyncGenerator[dict, None]:
     """Run phases 1-2 via executor and yield SSE events."""
     async for event in executor.discover(
         book_title=book_title,
         author=author,
         preferences=preferences,
+        vibe=vibe,
         user_id=user_id,
     ):
         yield domain_event_to_sse(event)

--- a/core/executor.py
+++ b/core/executor.py
@@ -244,11 +244,17 @@ class WorkflowExecutor:
 
     @staticmethod
     def _discovery_cache_key(
-        book_title: str, author: str, preferences: Optional[dict]
+        book_title: str,
+        author: str,
+        preferences: Optional[dict],
+        vibe: Optional[str] = None,
     ) -> str:
         """Build a normalized, versioned cache key for a discovery request.
 
-        Versioned prefix ('v1') lets a logic change invalidate cleanly.
+        Versioned prefix ('v1') lets a logic change invalidate cleanly. A
+        present ``vibe`` is appended so a vibe-annotated request never reuses an
+        unannotated (or differently-vibed) cached region set; an absent vibe
+        leaves the key byte-identical to the pre-vibe format.
         """
         norm_title = (book_title or "").strip().lower()
         norm_author = (author or "").strip().lower()
@@ -257,7 +263,11 @@ class WorkflowExecutor:
         pref_sig = hashlib.sha1(
             repr(pref_items).encode("utf-8")
         ).hexdigest()
-        return f"discover:v1:{norm_title}|{norm_author}|{pref_sig}"
+        key = f"discover:v1:{norm_title}|{norm_author}|{pref_sig}"
+        norm_vibe = (vibe or "").strip().lower()
+        if norm_vibe:
+            key += f"|vibe={norm_vibe}"
+        return key
 
     async def discover(
         self,
@@ -265,6 +275,7 @@ class WorkflowExecutor:
         author: str,
         preferences: Optional[dict] = None,
         user_id: str = "default",
+        vibe: Optional[str] = None,
     ) -> AsyncGenerator[DomainEvent, None]:
         """Run phases 1-2: confirm book metadata + location discovery.
 
@@ -312,7 +323,7 @@ class WorkflowExecutor:
         # the previously computed (already validated) regions and makes ZERO
         # Gemini calls. Only non-empty region sets are ever cached, so a hit
         # cannot introduce a new fabrication; staleness is bounded by the TTL.
-        cache_key = self._discovery_cache_key(book_title, author, preferences)
+        cache_key = self._discovery_cache_key(book_title, author, preferences, vibe)
         cached_region_analysis = await self._discovery_cache.get(cache_key)
         if cached_region_analysis:
             logger.info("discovery_cache_hit", job_id=job_id[:8])
@@ -363,7 +374,7 @@ class WorkflowExecutor:
                     plugins=[LoggingPlugin(), langfuse_plugin],
                 )
 
-                prompt = build_discovery_prompt(exact_title, exact_author)
+                prompt = build_discovery_prompt(exact_title, exact_author, vibe)
                 message = types.Content(
                     role="user", parts=[types.Part(text=prompt)]
                 )

--- a/core/prompts.py
+++ b/core/prompts.py
@@ -9,13 +9,33 @@ import json
 from typing import List
 
 
-def build_discovery_prompt(book_title: str, author: str) -> str:
-    """Build the user prompt for the discovery phase (phase 2)."""
-    return (
+def build_discovery_prompt(
+    book_title: str, author: str, vibe: str | None = None
+) -> str:
+    """Build the user prompt for the discovery phase (phase 2).
+
+    When ``vibe`` is provided it is appended as an explicit atmosphere
+    preference that re-weights *already-valid* candidates toward that mood and
+    asks the connection note to name it. It deliberately does NOT relax the
+    grounding requirement: places must still be genuinely connected to the book,
+    so the vibe can only tilt selection among honest candidates, never invent a
+    link. When ``vibe`` is None the returned prompt is byte-identical to before.
+    """
+    prompt = (
         f'Discover travel locations for "{book_title}" by {author}.\n\n'
         f"Find cities, landmarks, and author-related sites, "
         f"then group them into practical travel regions."
     )
+    if vibe:
+        prompt += (
+            f"\n\nThe reader has chosen a \"{vibe}\" mood. Among places that are "
+            f"genuinely and verifiably connected to the book, prefer those whose "
+            f"atmosphere best fits a {vibe} feeling, and name that {vibe} "
+            f"atmosphere in each place's connection note. Do NOT include or "
+            f"invent any place that is not truly tied to the book just to match "
+            f"the mood — factual grounding always wins over vibe."
+        )
+    return prompt
 
 
 def build_composition_prompt(

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -103,6 +103,35 @@ class TestDiscoveryCacheKey:
     def test_versioned_prefix(self):
         assert self._key("Dune", "Herbert", None).startswith("discover:v1:")
 
+    def test_absent_vibe_key_is_unchanged(self):
+        # An absent vibe must produce the exact pre-vibe key (cache continuity).
+        from core.executor import WorkflowExecutor
+
+        with_default = WorkflowExecutor._discovery_cache_key("Dune", "Herbert", None)
+        explicit_none = WorkflowExecutor._discovery_cache_key(
+            "Dune", "Herbert", None, None
+        )
+        assert with_default == explicit_none == "discover:v1:dune|herbert|" + (
+            with_default.split("|")[-1]
+        )
+
+    def test_present_vibe_changes_key(self):
+        from core.executor import WorkflowExecutor
+
+        base = WorkflowExecutor._discovery_cache_key("Dune", "Herbert", None)
+        cozy = WorkflowExecutor._discovery_cache_key("Dune", "Herbert", None, "cozy")
+        assert cozy != base
+        assert cozy.endswith("|vibe=cozy")
+
+    def test_different_vibes_differ(self):
+        from core.executor import WorkflowExecutor
+
+        k1 = WorkflowExecutor._discovery_cache_key("Dune", "Herbert", None, "cozy")
+        k2 = WorkflowExecutor._discovery_cache_key(
+            "Dune", "Herbert", None, "hopeful"
+        )
+        assert k1 != k2
+
 
 class TestExecutorConfigCacheDefaults:
     def test_cache_config_defaults(self):

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -288,6 +288,23 @@ class TestPrompts:
         assert "George Orwell" in prompt
         assert "cities" in prompt.lower()
 
+    def test_discovery_prompt_vibe_absent_is_byte_identical(self):
+        # The whole point of the optional vibe: omitting it must not change the
+        # prompt at all (no behavior drift for existing callers).
+        assert build_discovery_prompt("1984", "George Orwell", None) == (
+            build_discovery_prompt("1984", "George Orwell")
+        )
+
+    def test_discovery_prompt_vibe_present_biases_and_names_mood(self):
+        prompt = build_discovery_prompt("1984", "George Orwell", "melancholic")
+        # Still contains the base discovery instruction...
+        assert '"1984"' in prompt
+        assert "cities" in prompt.lower()
+        # ...plus the mood bias, named explicitly for the "why this fits" copy.
+        assert "melancholic" in prompt
+        # ...and an explicit grounding-wins guard so vibe can't invent links.
+        assert "grounding" in prompt.lower()
+
     def test_composition_prompt(self):
         regions = [{"region_id": 1, "region_name": "England"}]
         prompt = build_composition_prompt("1984", "George Orwell", regions)

--- a/tests/unit/test_request_input_limits.py
+++ b/tests/unit/test_request_input_limits.py
@@ -69,3 +69,32 @@ def test_local_atmosphere_accepts_valid_input():
         preferences={"pace": "slow"},
     )
     assert req.book_title == "Wuthering Heights"
+
+
+# --- optional mood/vibe field on DiscoverRequest ---
+
+def test_discover_accepts_known_vibe():
+    req = DiscoverRequest(book_title="1984", author="George Orwell", vibe="Cozy")
+    assert req.vibe == "cozy"  # normalized to canonical lower-case
+
+
+def test_discover_vibe_absent_is_none():
+    req = DiscoverRequest(book_title="1984", author="George Orwell")
+    assert req.vibe is None
+
+
+def test_discover_blank_vibe_is_none():
+    req = DiscoverRequest(book_title="1984", author="George Orwell", vibe="   ")
+    assert req.vibe is None
+
+
+def test_discover_rejects_unknown_vibe():
+    with pytest.raises(ValidationError):
+        DiscoverRequest(book_title="1984", author="George Orwell", vibe="grumpy")
+
+
+def test_discover_accepts_hyphenated_vibe():
+    req = DiscoverRequest(
+        book_title="1984", author="George Orwell", vibe="Slow-Burn"
+    )
+    assert req.vibe == "slow-burn"


### PR DESCRIPTION
# feat: bias discovery on an optional vibe and surface it in the "why this fits"

## What
PR 2 of 3 of the explicit mood/vibe discovery feature. The gateway
(storyland-services, PR 49) already accepts an optional curated `vibe` and
forwards it to this service's discovery call. This PR makes the AI service
actually use it: an optional `vibe` (cozy · melancholic · adventurous ·
slow-burn · atmospheric · hopeful) now threads from `DiscoverRequest` through
the discovery stream and executor into the phase-2 discovery prompt, biasing
place selection toward that mood and naming it in each place's connection note.
When no vibe is sent, behavior is byte-identical to today. PR 3 (storyland-web)
adds the chips that set the field.

## Why
Vibe is already Storyland's implicit differentiator — the discovery engine
infers mood from free text. Making it an explicit, user-selectable input
matches the validated StoryGraph pattern and lets the reader steer discovery
toward the feeling they want. This is the AI half of that: the field is inert
until the prompt consumes it, so PR 1 (gateway) shipped safely ahead of it and
this PR lights it up without a user-visible surface until PR 3.

## How
- `api/models.py`: add an optional `vibe` field to `DiscoverRequest` plus an
  `ALLOWED_VIBES` frozenset and `_validate_vibe` validator mirroring the
  gateway's curated set. Absent/blank ⇒ `None`; a non-string or out-of-set
  value ⇒ `ValueError` (HTTP 422) so an unknown vibe is never silently dropped
  into a prompt (defense in depth — the gateway already validates upstream).
- `api/routes.py` → `api/streaming.py` → `core/executor.py`: pass `vibe`
  through `discover_stream` into `WorkflowExecutor.discover`, keyword-only with
  a `None` default so every existing call site is unaffected.
- `core/prompts.py`: `build_discovery_prompt` takes an optional `vibe`. When
  present it appends an atmosphere-preference clause that re-weights *already
  book-connected* places toward that mood and asks the connection note to name
  it — with an explicit "factual grounding always wins; never include or invent
  a place that isn't truly tied to the book just to match the mood" guard.
  When absent the returned string is byte-identical to before.
- `core/executor.py`: `_discovery_cache_key` appends `|vibe=<token>` only when a
  vibe is present, so a vibe-annotated request never reuses an unannotated (or
  differently-vibed) cached region set, while the absent-vibe key stays exactly
  the pre-vibe `discover:v1:...` format (existing cache entries still hit).

Deliberate tradeoff: the curated agent instructions in `agents/prompts/v2.json`
are left untouched. The vibe constraint travels via the seed discovery prompt in
conversation history, which the researcher/formatter sub-agents already consume —
a single, narrow changed path that keeps the "absent ⇒ identical" guarantee
trivial and minimizes blast radius.

## Review & test
- Focus: the grounding guard in `build_discovery_prompt` — confirm the vibe
  clause biases selection but cannot relax grounding or invent book↔place links.
- Confirm `vibe=None` is byte-identical: prompt string and cache key both
  unchanged from the pre-vibe path.
- New tests: `tests/unit/test_request_input_limits.py` (vibe validation:
  known/normalized, blank⇒None, unknown⇒422, hyphenated `slow-burn`);
  `tests/unit/test_core.py::TestPrompts` (absent byte-identical; present biases +
  names mood + retains grounding guard); `tests/unit/test_cache.py`
  (absent key unchanged, present key appends `|vibe=`, different vibes differ).
- Run: `pytest tests/unit` (full suite) + `ruff check`.
- This PR changes the recommendation/discovery prompt → a scoped QA grounding
  eval (changed discovery path only, ≤4 cases, once) gates the merge; the spend
  was approved by the founder. Do NOT merge until the eval comes back clean.
