### PR TITLE
feat: bias discovery on an optional imported taste_context (PR 2 of 4 — reading-history import)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -76,6 +76,64 @@ def _validate_vibe(value):
     return normalized
 
 
+# Bounds for the optional imported-reading-history taste signal (StoryGraph /
+# Goodreads CSV import, PR1). The gateway (storyland-services) already parses +
+# bounds it, but the AI service re-bounds here so an unbounded history can never
+# inflate the discovery prompt (cost + prompt-injection surface). We TRUNCATE
+# rather than 422: a large legitimate reading history is normal input, not an
+# attack, and rejecting it would needlessly fail discovery.
+MAX_TASTE_TITLES = 20
+MAX_TASTE_MOODS = 12
+MAX_TASTE_STRING_LENGTH = 200
+
+
+def _bound_taste_context(value):
+    """Normalize + bound an optional ``{"titles": [...], "moods": [...]}`` block.
+
+    Strings are stripped and length-capped; blanks dropped; each list is
+    de-duplicated case-insensitively (first occurrence wins, order preserved)
+    and truncated to its cap. Returns a normalized dict, or None when
+    absent/empty so the prompt + cache key stay byte-identical to a no-taste
+    request. Raises ValueError (→ 422) only for a structurally wrong type.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError("taste_context must be an object")
+
+    def _clean(items, cap):
+        if items is None:
+            return []
+        if not isinstance(items, (list, tuple)):
+            raise ValueError("taste_context titles/moods must be lists")
+        out, seen = [], set()
+        for item in items:
+            if not isinstance(item, str):
+                continue
+            normalized = item.strip()[:MAX_TASTE_STRING_LENGTH].strip()
+            if not normalized:
+                continue
+            key = normalized.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(normalized)
+            if len(out) >= cap:
+                break
+        return out
+
+    titles = _clean(value.get("titles"), MAX_TASTE_TITLES)
+    moods = _clean(value.get("moods"), MAX_TASTE_MOODS)
+    if not titles and not moods:
+        return None
+    result = {}
+    if titles:
+        result["titles"] = titles
+    if moods:
+        result["moods"] = moods
+    return result
+
+
 class DiscoverRequest(BaseModel):
     """Request body for POST /api/v1/itinerary/discover."""
 
@@ -112,6 +170,15 @@ class DiscoverRequest(BaseModel):
             "Absent ⇒ unchanged behavior."
         ),
     )
+    taste_context: Optional[dict] = Field(
+        default=None,
+        description=(
+            "Optional imported reading-history taste signal "
+            '({"titles": [...], "moods": [...]}) used to bias discovery toward '
+            "grounded places that resonate with the reader's demonstrated taste. "
+            "Bounded + de-duplicated server-side; absent ⇒ unchanged behavior."
+        ),
+    )
 
     @field_validator("book_title")
     @classmethod
@@ -142,6 +209,12 @@ class DiscoverRequest(BaseModel):
     def validate_vibe(cls, value):
         """Validate/normalize the optional mood/vibe token before the prompt."""
         return _validate_vibe(value)
+
+    @field_validator("taste_context")
+    @classmethod
+    def validate_taste_context(cls, value):
+        """Normalize + bound the optional imported taste signal before the prompt."""
+        return _bound_taste_context(value)
 
 
 class ComposeRequest(BaseModel):

--- a/api/routes.py
+++ b/api/routes.py
@@ -126,6 +126,7 @@ async def discover(request: DiscoverRequest, user_id: str = Depends(get_gateway_
         author=request.author,
         preferences=request.preferences,
         vibe=request.vibe,
+        taste_context=request.taste_context,
         user_id=user_id,
         executor=app_state.executor,
     )

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -128,6 +128,7 @@ async def discover_stream(
     user_id: str,
     executor: WorkflowExecutor,
     vibe: Optional[str] = None,
+    taste_context: Optional[dict] = None,
 ) -> AsyncGenerator[dict, None]:
     """Run phases 1-2 via executor and yield SSE events."""
     async for event in executor.discover(
@@ -135,6 +136,7 @@ async def discover_stream(
         author=author,
         preferences=preferences,
         vibe=vibe,
+        taste_context=taste_context,
         user_id=user_id,
     ):
         yield domain_event_to_sse(event)

--- a/core/executor.py
+++ b/core/executor.py
@@ -248,6 +248,7 @@ class WorkflowExecutor:
         author: str,
         preferences: Optional[dict],
         vibe: Optional[str] = None,
+        taste_context: Optional[dict] = None,
     ) -> str:
         """Build a normalized, versioned cache key for a discovery request.
 
@@ -267,6 +268,19 @@ class WorkflowExecutor:
         norm_vibe = (vibe or "").strip().lower()
         if norm_vibe:
             key += f"|vibe={norm_vibe}"
+        # A present taste_context must not reuse an unannotated (or
+        # differently-tasted) cached region set; a stable fingerprint over the
+        # normalized titles/moods keeps an absent taste_context byte-identical.
+        if taste_context:
+            taste_sig = hashlib.sha1(
+                repr(
+                    (
+                        tuple(taste_context.get("titles") or ()),
+                        tuple(taste_context.get("moods") or ()),
+                    )
+                ).encode("utf-8")
+            ).hexdigest()[:12]
+            key += f"|taste={taste_sig}"
         return key
 
     async def discover(
@@ -276,6 +290,7 @@ class WorkflowExecutor:
         preferences: Optional[dict] = None,
         user_id: str = "default",
         vibe: Optional[str] = None,
+        taste_context: Optional[dict] = None,
     ) -> AsyncGenerator[DomainEvent, None]:
         """Run phases 1-2: confirm book metadata + location discovery.
 
@@ -323,7 +338,9 @@ class WorkflowExecutor:
         # the previously computed (already validated) regions and makes ZERO
         # Gemini calls. Only non-empty region sets are ever cached, so a hit
         # cannot introduce a new fabrication; staleness is bounded by the TTL.
-        cache_key = self._discovery_cache_key(book_title, author, preferences, vibe)
+        cache_key = self._discovery_cache_key(
+            book_title, author, preferences, vibe, taste_context
+        )
         cached_region_analysis = await self._discovery_cache.get(cache_key)
         if cached_region_analysis:
             logger.info("discovery_cache_hit", job_id=job_id[:8])
@@ -374,7 +391,9 @@ class WorkflowExecutor:
                     plugins=[LoggingPlugin(), langfuse_plugin],
                 )
 
-                prompt = build_discovery_prompt(exact_title, exact_author, vibe)
+                prompt = build_discovery_prompt(
+                    exact_title, exact_author, vibe, taste_context
+                )
                 message = types.Content(
                     role="user", parts=[types.Part(text=prompt)]
                 )

--- a/core/prompts.py
+++ b/core/prompts.py
@@ -10,7 +10,10 @@ from typing import List
 
 
 def build_discovery_prompt(
-    book_title: str, author: str, vibe: str | None = None
+    book_title: str,
+    author: str,
+    vibe: str | None = None,
+    taste_context: dict | None = None,
 ) -> str:
     """Build the user prompt for the discovery phase (phase 2).
 
@@ -20,6 +23,16 @@ def build_discovery_prompt(
     grounding requirement: places must still be genuinely connected to the book,
     so the vibe can only tilt selection among honest candidates, never invent a
     link. When ``vibe`` is None the returned prompt is byte-identical to before.
+
+    When ``taste_context`` (an optional, already-bounded
+    ``{"titles": [...], "moods": [...]}`` block derived from a reader's
+    imported reading history) is provided, it is appended as a second,
+    independent bias clause that prefers grounded places whose atmosphere
+    resonates with that demonstrated taste and lets the connection note
+    name the resonance. Like ``vibe`` it NEVER relaxes grounding. ``vibe``
+    and ``taste_context`` compose independently; absent/empty
+    ``taste_context`` leaves the prompt byte-identical to a no-taste
+    request.
     """
     prompt = (
         f'Discover travel locations for "{book_title}" by {author}.\n\n'
@@ -35,6 +48,25 @@ def build_discovery_prompt(
             f"invent any place that is not truly tied to the book just to match "
             f"the mood — factual grounding always wins over vibe."
         )
+    if taste_context:
+        titles = [t for t in (taste_context.get("titles") or []) if t]
+        moods = [m for m in (taste_context.get("moods") or []) if m]
+        descriptors = []
+        if titles:
+            descriptors.append("books such as " + ", ".join(titles))
+        if moods:
+            descriptors.append("moods like " + ", ".join(moods))
+        if descriptors:
+            taste_desc = "; ".join(descriptors)
+            prompt += (
+                f"\n\nThe reader's own reading history leans toward {taste_desc}. "
+                f"Among places that are genuinely and verifiably connected to the "
+                f"book, prefer those whose atmosphere resonates with that taste, and "
+                f"you may name that resonance in the place's connection note. Do NOT "
+                f"include or invent any place that is not truly tied to the book just "
+                f"to match the reader's taste — factual grounding always wins over "
+                f"taste."
+            )
     return prompt
 
 

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -123,6 +123,45 @@ class TestDiscoveryCacheKey:
         assert cozy != base
         assert cozy.endswith("|vibe=cozy")
 
+    def test_absent_taste_key_is_unchanged(self):
+        from core.executor import WorkflowExecutor
+
+        base = WorkflowExecutor._discovery_cache_key("Dune", "Herbert", None)
+        with_none = WorkflowExecutor._discovery_cache_key(
+            "Dune", "Herbert", None, None, None
+        )
+        assert base == with_none
+
+    def test_present_taste_changes_key(self):
+        from core.executor import WorkflowExecutor
+
+        base = WorkflowExecutor._discovery_cache_key("Dune", "Herbert", None)
+        tasted = WorkflowExecutor._discovery_cache_key(
+            "Dune", "Herbert", None, None, {"titles": ["1984"], "moods": ["bleak"]}
+        )
+        assert tasted != base
+        assert "|taste=" in tasted
+
+    def test_different_taste_differ(self):
+        from core.executor import WorkflowExecutor
+
+        k1 = WorkflowExecutor._discovery_cache_key(
+            "Dune", "Herbert", None, None, {"titles": ["1984"]}
+        )
+        k2 = WorkflowExecutor._discovery_cache_key(
+            "Dune", "Herbert", None, None, {"titles": ["Beloved"]}
+        )
+        assert k1 != k2
+
+    def test_vibe_and_taste_compose_in_key(self):
+        from core.executor import WorkflowExecutor
+
+        key = WorkflowExecutor._discovery_cache_key(
+            "Dune", "Herbert", None, "cozy", {"moods": ["warm"]}
+        )
+        assert "|vibe=cozy" in key
+        assert "|taste=" in key
+
     def test_different_vibes_differ(self):
         from core.executor import WorkflowExecutor
 
@@ -147,7 +186,7 @@ class TestExecutorCacheHit:
 
     async def test_cache_hit_skips_discovery_chain(self, monkeypatch):
         import core.executor as ex
-        from core.executor import WorkflowExecutor, APP_NAME
+        from core.executor import WorkflowExecutor
         from core.events import RegionsReady, WorkflowComplete
         from services.session_service import create_session_service
 

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -305,6 +305,47 @@ class TestPrompts:
         # ...and an explicit grounding-wins guard so vibe can't invent links.
         assert "grounding" in prompt.lower()
 
+    def test_discovery_prompt_taste_absent_is_byte_identical(self):
+        # Omitting taste_context must not change the prompt at all.
+        assert build_discovery_prompt("1984", "George Orwell", None, None) == (
+            build_discovery_prompt("1984", "George Orwell")
+        )
+
+    def test_discovery_prompt_empty_taste_is_byte_identical(self):
+        # A structurally-empty taste block is treated as absent.
+        assert build_discovery_prompt(
+            "1984", "George Orwell", None, {"titles": [], "moods": []}
+        ) == build_discovery_prompt("1984", "George Orwell")
+
+    def test_discovery_prompt_taste_present_biases_and_keeps_grounding(self):
+        prompt = build_discovery_prompt(
+            "1984",
+            "George Orwell",
+            None,
+            {"titles": ["Wuthering Heights"], "moods": ["melancholic"]},
+        )
+        assert '"1984"' in prompt
+        assert "cities" in prompt.lower()
+        # The reader's titles + moods surface in the bias clause...
+        assert "Wuthering Heights" in prompt
+        assert "melancholic" in prompt
+        assert "reading history" in prompt.lower()
+        # ...with the same grounding-wins guard as vibe.
+        assert "grounding" in prompt.lower()
+
+    def test_discovery_prompt_vibe_and_taste_compose(self):
+        # Both biases append independently; neither replaces the other.
+        prompt = build_discovery_prompt(
+            "1984",
+            "George Orwell",
+            "cozy",
+            {"titles": ["Dune"], "moods": ["adventurous"]},
+        )
+        assert "cozy" in prompt
+        assert "Dune" in prompt
+        assert "adventurous" in prompt
+        assert prompt.count("grounding") >= 2
+
     def test_composition_prompt(self):
         regions = [{"region_id": 1, "region_name": "England"}]
         prompt = build_composition_prompt("1984", "George Orwell", regions)

--- a/tests/unit/test_request_input_limits.py
+++ b/tests/unit/test_request_input_limits.py
@@ -98,3 +98,65 @@ def test_discover_accepts_hyphenated_vibe():
         book_title="1984", author="George Orwell", vibe="Slow-Burn"
     )
     assert req.vibe == "slow-burn"
+
+
+# --- optional taste_context (imported reading history) on DiscoverRequest ---
+
+def test_discover_taste_context_absent_is_none():
+    req = DiscoverRequest(book_title="1984", author="George Orwell")
+    assert req.taste_context is None
+
+
+def test_discover_taste_context_normalizes_and_dedups():
+    req = DiscoverRequest(
+        book_title="1984",
+        author="George Orwell",
+        taste_context={
+            "titles": ["  Dune ", "dune", "Beloved", ""],
+            "moods": ["Bleak", "bleak", "  "],
+        },
+    )
+    assert req.taste_context["titles"] == ["Dune", "Beloved"]
+    assert req.taste_context["moods"] == ["Bleak"]
+
+
+def test_discover_taste_context_empty_lists_become_none():
+    req = DiscoverRequest(
+        book_title="1984",
+        author="George Orwell",
+        taste_context={"titles": [], "moods": []},
+    )
+    assert req.taste_context is None
+
+
+def test_discover_taste_context_truncates_to_caps():
+    from api.models import MAX_TASTE_TITLES, MAX_TASTE_MOODS
+
+    req = DiscoverRequest(
+        book_title="1984",
+        author="George Orwell",
+        taste_context={
+            "titles": [f"Book {i}" for i in range(MAX_TASTE_TITLES + 25)],
+            "moods": [f"mood{i}" for i in range(MAX_TASTE_MOODS + 25)],
+        },
+    )
+    assert len(req.taste_context["titles"]) == MAX_TASTE_TITLES
+    assert len(req.taste_context["moods"]) == MAX_TASTE_MOODS
+
+
+def test_discover_taste_context_bounds_string_length():
+    from api.models import MAX_TASTE_STRING_LENGTH
+
+    req = DiscoverRequest(
+        book_title="1984",
+        author="George Orwell",
+        taste_context={"titles": ["x" * (MAX_TASTE_STRING_LENGTH + 500)]},
+    )
+    assert len(req.taste_context["titles"][0]) <= MAX_TASTE_STRING_LENGTH
+
+
+def test_discover_taste_context_rejects_wrong_type():
+    with pytest.raises(ValidationError):
+        DiscoverRequest(
+            book_title="1984", author="George Orwell", taste_context="not-an-object"
+        )


### PR DESCRIPTION
# feat: bias discovery on an optional imported `taste_context` (PR 2 of 4 — reading-history import)

## What
Adds an optional `taste_context` input to the phase-2 discovery path. When a
request carries a reader's imported reading-history signal
(`{"titles": [...], "moods": [...]}`), discovery prefers grounded places whose
atmosphere resonates with that demonstrated taste and may name the resonance in
each place's connection note. Absent (or empty) `taste_context` leaves the
prompt, cache key, and behavior byte-identical to today. This is the AI-side
capability only — it is not yet wired to a user-facing path (the gateway threads
it in PR 3).

## Why
A new visitor arrives cold, so the first discovery result is weakest exactly when
first impressions matter most. PR 1 (`POST /api/v1/import`, already merged) parses
a Goodreads/StoryGraph CSV export into a bounded taste signal. This PR lets that
signal bias the *existing* grounded discovery pass so imported readers get
recommendations tilted toward their real taste — without a new model, a new paid
API, or any relaxation of grounding. It mirrors the just-merged `vibe` bias
(#181): `vibe` and `taste_context` compose independently in one discovery prompt.

## How
- `core/prompts.build_discovery_prompt(book_title, author, vibe=None, taste_context=None)`
  appends a second, independent bias clause after the vibe clause. It lists the
  reader's titles/moods and instructs the model to prefer grounded, genuinely
  book-connected places that resonate — with an explicit "factual grounding always
  wins; never include or invent a place not truly tied to the book just to match
  the reader's taste" guard, identical in spirit to the vibe guard. Empty/absent
  ⇒ byte-identical prompt.
- `api/models.DiscoverRequest` gains an optional `taste_context: dict` field plus
  `_bound_taste_context()`: strings stripped + length-capped
  (`MAX_TASTE_STRING_LENGTH=200`), blanks dropped, each list de-duplicated
  case-insensitively (order preserved) and truncated to its cap
  (`MAX_TASTE_TITLES=20`, `MAX_TASTE_MOODS=12`). A structurally empty block
  normalizes to `None`. We **truncate rather than 422** — a large legitimate
  reading history is normal input, not an attack — but a wrong *type* is a 422
  (defense-in-depth so an unbounded value never inflates the prompt; the gateway
  already bounds it once).
- `core/executor.discover(..., taste_context=None)` threads it into both
  `build_discovery_prompt` and `_discovery_cache_key`. The cache key appends a
  stable `|taste=<sha1[:12]>` fingerprint over the normalized titles/moods so a
  taste-annotated request never reuses an unannotated (or differently-tasted)
  cached region set; absent ⇒ key unchanged.
- `api/routes.discover` and `api/streaming.discover_stream` pass
  `taste_context=request.taste_context` through, mirroring the existing `vibe`
  wiring.
- Additive, flagless; rollback = revert. The existing grounding guardrail is
  unchanged and still runs on every candidate — `taste_context` can only tilt
  selection among already-grounded places, never invent a link.

## Review & test
Focus on: (1) the absent/empty `taste_context` path is provably unchanged
(prompt + cache key byte-identical); (2) the prompt clause keeps grounding
authoritative; (3) input bounding (truncation + de-dup + length caps) cannot let
an oversized history through. New tests cover all three:
- `tests/unit/test_core.py` — absent/empty byte-identical, present biases + keeps
  the grounding guard, vibe+taste compose.
- `tests/unit/test_request_input_limits.py` — normalize/dedup, empty→None,
  truncate-to-caps, per-string length bound, wrong-type rejected.
- `tests/unit/test_cache.py` — absent key unchanged, present appends `|taste=`,
  different taste differs, vibe+taste compose in the key.

Verify: `ruff check api/ core/ tests/unit` and `pytest tests/unit -q` (the
`test_cache.py` cases import `WorkflowExecutor` → google.adk, so the full suite
needs the installed dep tree).

PR 2 of 4 — reading-history import. Still to follow: PR 3 (gateway threads the
parsed taste signal into the discovery call) and PR 4 (FE onboarding affordance,
after the Design dep). This PR changes the discovery/grounding prompt, so it must
not merge until the scoped factual-grounding eval comes back clean.
