### PR TITLE
feat(cache): explicit CACHE_ENABLED switch + boot-time effective-config log

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,8 +39,12 @@ LANGFUSE_SECRET_KEY=sk-lf-xxx
 LANGFUSE_PUBLIC_KEY=pk-lf-xxx
 LANGFUSE_HOST=https://cloud.langfuse.com
 
-# Result Cache (in-process; caches the Discovery book->regions chain)
-# Always on. Tune the TTL / max entries below.
+# Result Cache (in-process; caches the Discovery book->regions chain).
+# CACHE_ENABLED is the master switch and defaults to true when unset, so a
+# dropped var can never silently turn caching off (it degrades to on). Set
+# false only to deliberately disable. The effective config (enabled/ttl/
+# max_entries) is logged once at boot. Tune the TTL / max entries below.
+CACHE_ENABLED=true
 CACHE_TTL_SECONDS=86400
 CACHE_MAX_ENTRIES=500
 

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -59,6 +59,27 @@ async def initialize() -> AppState:
         inflight_limiter=inflight_limiter,
     )
 
+    # Boot-time visibility of the EFFECTIVE cache config so a dropped/
+    # misconfigured setting is immediately obvious in prod logs (rather than
+    # silently serving with caching off). Warn loudly if a cache expected-on
+    # resolved to disabled.
+    logger.info(
+        "cache_config_effective",
+        enabled=config.cache_enabled,
+        ttl_seconds=config.cache_ttl_seconds,
+        max_entries=config.cache_max_entries,
+        backend="in-memory",
+    )
+    if not config.cache_enabled:
+        logger.warning(
+            "cache_disabled",
+            detail=(
+                "Discovery result cache is DISABLED (CACHE_ENABLED=false): "
+                "every discover re-pays live Gemini + Google Books cost. "
+                "Unset CACHE_ENABLED to fall back to on."
+            ),
+        )
+
     logger.info("api_initialized", model=config.model_name)
     return _app_state
 

--- a/common/config.py
+++ b/common/config.py
@@ -37,7 +37,11 @@ class Config:
     # 'dev_user'. Default false so non-local deploys fail closed (403)
     # instead of silently collapsing callers into one session namespace.
     allow_dev_user: bool
-    # Result cache for the Discovery chain (always on; validated in prod 2026-06-17).
+    # Result cache for the Discovery chain. cache_enabled is the master
+    # switch: default TRUE so a missing/dropped CACHE_ENABLED env var degrades
+    # to *on with a sane default*, never silently off (the silent-config-drop
+    # correctness bug). Set CACHE_ENABLED=false to deliberately disable.
+    cache_enabled: bool
     cache_ttl_seconds: int
     cache_max_entries: int
     # Bounded Gemini retry backoff (keeps worst-case schedule < workflow_timeout).
@@ -132,6 +136,9 @@ def load_config() -> Config:
         - ALLOW_DEV_USER: local-dev only; when "true", a request with no
           trusted X-User-ID header resolves to the shared "dev_user".
           Default false (production fails closed with 403). (default: false)
+        - CACHE_ENABLED: master switch for the Discovery result cache;
+          a missing var falls back to true (on), never silently off.
+          Set "false" to deliberately disable caching. (default: true)
         - RATE_LIMIT_REQUESTS: max requests per window per user/IP on the
           expensive endpoints; 0 disables (default: 0)
         - RATE_LIMIT_WINDOW_SECONDS: rate-limit window length (default: 60)
@@ -167,6 +174,7 @@ def load_config() -> Config:
         environment=os.getenv("ENVIRONMENT", "local"),
         internal_api_secret=os.getenv("INTERNAL_API_SECRET", ""),
         allow_dev_user=_env_bool("ALLOW_DEV_USER", False),
+        cache_enabled=_env_bool("CACHE_ENABLED", True),
         cache_ttl_seconds=_env_int("CACHE_TTL_SECONDS", 86400),
         cache_max_entries=_env_int("CACHE_MAX_ENTRIES", 500),
         retry_exp_base=_env_float("RETRY_EXP_BASE", 2.0),

--- a/core/executor.py
+++ b/core/executor.py
@@ -153,9 +153,12 @@ class WorkflowExecutor:
             use_database=config.use_database,
         )
         self._model = model or self._create_model()
-        # In-process result cache for the Discovery chain (always on;
-        # validated in prod 2026-06-17). Replays prior validated discovery
-        # results verbatim, so it cannot introduce new hallucinations.
+        # In-process result cache for the Discovery chain. Replays prior
+        # validated discovery results verbatim, so it cannot introduce new
+        # hallucinations. Gated by cache_enabled (default True): when disabled
+        # the fast-path and the store are both skipped, so caching is off
+        # deliberately (and logged at boot), never silently.
+        self._cache_enabled = config.cache_enabled
         self._discovery_cache = TTLCache(
             ttl_seconds=config.cache_ttl_seconds,
             max_entries=config.cache_max_entries,
@@ -341,7 +344,11 @@ class WorkflowExecutor:
         cache_key = self._discovery_cache_key(
             book_title, author, preferences, vibe, taste_context
         )
-        cached_region_analysis = await self._discovery_cache.get(cache_key)
+        cached_region_analysis = (
+            await self._discovery_cache.get(cache_key)
+            if self._cache_enabled
+            else None
+        )
         if cached_region_analysis:
             logger.info("discovery_cache_hit", job_id=job_id[:8])
             async for ev in self._emit_cached_discovery(
@@ -451,7 +458,7 @@ class WorkflowExecutor:
 
                 # Store on miss: cache only non-empty, schema-validated region
                 # sets so a future hit can safely short-circuit the chain.
-                if state.regions:
+                if self._cache_enabled and state.regions:
                     await self._discovery_cache.set(cache_key, state.region_analysis)
 
                 yield RegionsReady(

--- a/core/types.py
+++ b/core/types.py
@@ -27,6 +27,9 @@ class ExecutorConfig:
     langfuse_host: Optional[str] = None
     environment: str = "local"
     # Result cache settings (carried through from common.config.Config).
+    # cache_enabled defaults True so an absent value never silently disables
+    # caching (matches common.config.Config's CACHE_ENABLED default).
+    cache_enabled: bool = True
     cache_ttl_seconds: int = 86400
     cache_max_entries: int = 500
     # Bounded Gemini retry backoff (parity with the eval runner).
@@ -49,6 +52,7 @@ class ExecutorConfig:
             langfuse_public_key=config.langfuse_public_key,
             langfuse_host=config.langfuse_host,
             environment=config.environment,
+            cache_enabled=getattr(config, "cache_enabled", True),
             cache_ttl_seconds=getattr(config, "cache_ttl_seconds", 86400),
             cache_max_entries=getattr(config, "cache_max_entries", 500),
             retry_exp_base=getattr(config, "retry_exp_base", 2.0),

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -241,3 +241,112 @@ class TestExecutorCacheHit:
             model=object(),
         )
         assert isinstance(executor._discovery_cache, TTLCache)
+
+
+# =============================================================================
+# Cache master-switch config (MYS-153 / MYS-9 PR1)
+#
+# The Discovery result cache must NEVER be silently disabled by a dropped env
+# var: an absent CACHE_ENABLED falls back to on. These tests pin that contract
+# and the flag's propagation Config -> ExecutorConfig -> WorkflowExecutor.
+# =============================================================================
+
+import os
+from unittest.mock import MagicMock
+
+from common.config import _env_bool, load_config
+
+
+def _base_env(monkeypatch) -> None:
+    """Set the minimal REQUIRED env so load_config() succeeds; leave the
+    optional cache vars to each test."""
+    required = {
+        "GOOGLE_API_KEY": "test-key",
+        "USE_DATABASE": "false",
+        "SESSION_MAX_EVENTS": "20",
+        "MAX_CONTEXT_TOKENS": "30000",
+        "MODEL_NAME": "gemini-test",
+        "WORKFLOW_TIMEOUT": "600",
+        "AGENT_TIMEOUT": "120",
+        "LOG_LEVEL": "INFO",
+        "ENABLE_ADK_DEBUG": "false",
+    }
+    for k, v in required.items():
+        monkeypatch.setenv(k, v)
+    # Ensure the optional switch starts unset for the fallback tests.
+    monkeypatch.delenv("CACHE_ENABLED", raising=False)
+
+
+class TestCacheEnabledFallback:
+    def test_env_bool_missing_defaults_true(self, monkeypatch):
+        monkeypatch.delenv("CACHE_ENABLED", raising=False)
+        assert _env_bool("CACHE_ENABLED", True) is True
+
+    def test_env_bool_false_is_false(self, monkeypatch):
+        monkeypatch.setenv("CACHE_ENABLED", "false")
+        assert _env_bool("CACHE_ENABLED", True) is False
+
+    def test_env_bool_true_is_true(self, monkeypatch):
+        monkeypatch.setenv("CACHE_ENABLED", "true")
+        assert _env_bool("CACHE_ENABLED", True) is True
+
+    def test_load_config_missing_var_stays_on(self, monkeypatch):
+        """A dropped CACHE_ENABLED must degrade to ON, never silently off."""
+        _base_env(monkeypatch)
+        assert load_config().cache_enabled is True
+
+    def test_load_config_explicit_false_disables(self, monkeypatch):
+        _base_env(monkeypatch)
+        monkeypatch.setenv("CACHE_ENABLED", "false")
+        assert load_config().cache_enabled is False
+
+
+class TestExecutorConfigCacheEnabled:
+    def test_default_is_enabled(self):
+        cfg = ExecutorConfig(model_name="gemini-test", google_api_key="k")
+        assert cfg.cache_enabled is True
+
+    def test_from_config_carries_flag(self):
+        mock_config = MagicMock()
+        mock_config.cache_enabled = False
+        assert ExecutorConfig.from_config(mock_config).cache_enabled is False
+
+    def test_from_config_defaults_true_when_absent(self):
+        # A source config object that predates the flag (no cache_enabled
+        # attribute) must resolve to the getattr default of True.
+        from types import SimpleNamespace
+
+        legacy = SimpleNamespace(
+            model_name="gemini-test",
+            google_api_key="k",
+            workflow_timeout=600,
+            database_url=None,
+            use_database=False,
+            langfuse_secret_key=None,
+            langfuse_public_key=None,
+            langfuse_host=None,
+            environment="local",
+        )
+        assert ExecutorConfig.from_config(legacy).cache_enabled is True
+
+
+class TestExecutorCacheGating:
+    """The executor must honor cache_enabled without touching Gemini."""
+
+    def _executor(self, enabled: bool):
+        from core.executor import WorkflowExecutor
+
+        cfg = ExecutorConfig(
+            model_name="gemini-test",
+            google_api_key="k",
+            cache_enabled=enabled,
+            use_database=False,
+        )
+        # Inject a fake model so no real Gemini client is created.
+        return WorkflowExecutor(cfg, model=MagicMock())
+
+    def test_flag_propagates_enabled(self):
+        assert self._executor(True)._cache_enabled is True
+
+    def test_flag_propagates_disabled(self):
+        assert self._executor(False)._cache_enabled is False


### PR DESCRIPTION
# feat(cache): explicit CACHE_ENABLED switch + boot-time effective-config log

## What
Adds a first-class `cache_enabled` master switch (default **true**) for the
in-process Discovery result cache, and logs the **effective** cache config once
at boot. The flag is threaded `Config` → `ExecutorConfig` → `WorkflowExecutor`,
where it gates both the cache fast-path lookup and the store-on-miss. Default-on
means behavior is unchanged unless an operator explicitly sets `CACHE_ENABLED=false`.

PR 1 of 2 for the MYS-9 cache-persistence feature (kills failure mode: *silent
config drop*). The companion infra PR commits the matching compose default.
PR 2 (diskcache-on-volume, version-keyed persistence) follows on merge.

## Why
The Discovery cache config previously lived only on the box + a local clone.
Caching was implicitly "always on" with no way to see, at runtime, whether it
was actually active — so a redeploy that dropped the config could come back with
caching effectively off and nobody would notice (each cold request re-pays live
Gemini + Google Books cost). Making `enabled` an explicit, committed,
default-on config with a loud boot-time log turns a silent correctness bug into
something immediately visible.

## How
- `common/config.py`: new `cache_enabled: bool` on `Config`, loaded via
  `_env_bool("CACHE_ENABLED", True)` — a missing var falls back to **on**, never
  silently off. Docstring updated.
- `core/types.py`: `ExecutorConfig.cache_enabled` (default `True`), carried in
  `from_config` via `getattr(config, "cache_enabled", True)` (legacy-safe).
- `core/executor.py`: store `self._cache_enabled`; guard the fast-path
  (`get` only when enabled) and the store (`if self._cache_enabled and state.regions`).
  No behavior change when enabled.
- `api/dependencies.py`: at startup, `logger.info("cache_config_effective", enabled=…,
  ttl_seconds=…, max_entries=…, backend="in-memory")`, plus a `logger.warning`
  ("cache_disabled") if it resolved off.
- `.env.example`: document `CACHE_ENABLED` and the never-silently-off contract.

No cache hit/miss behavior change (default on). No grounding/agent-logic change
(caching only) → no eval. Rollback = revert.

## Review & test
Focus: the default-on fallback (a dropped `CACHE_ENABLED` must NOT disable
caching) and that the flag propagates to the executor.
- Run: `pip install -e .[dev] && pytest -q`
- New tests in `tests/unit/test_cache.py`:
  `TestCacheEnabledFallback` (missing var → on; `false` → off; `_env_bool`),
  `TestExecutorConfigCacheEnabled` (default true, carried, legacy getattr default),
  `TestExecutorCacheGating` (flag reaches `WorkflowExecutor._cache_enabled`, fake
  model — no Gemini call).
- Edge cases: `CACHE_ENABLED` unset, `=false`, `=true`; a legacy config object
  with no `cache_enabled` attribute.
