### PR TITLE
feat(cache): persist Discovery cache on disk (diskcache) + version-keyed invalidation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ RUN pip install --no-cache-dir .
 
 # Run as an unprivileged user (least privilege; shrinks RCE/SSRF blast radius).
 # uvicorn binds 8080 (>1024), so no root is required at runtime.
+# Discovery cache dir (mounted on a docker volume in prod). Created before the
+# chown so a named volume mounted here inherits appuser ownership on first use
+# and the unprivileged runtime user can write the SQLite store.
+RUN mkdir -p /app/.cache/discovery
 RUN useradd --create-home --uid 10001 appuser \
     && chown -R appuser:appuser /app
 USER appuser

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -68,7 +68,8 @@ async def initialize() -> AppState:
         enabled=config.cache_enabled,
         ttl_seconds=config.cache_ttl_seconds,
         max_entries=config.cache_max_entries,
-        backend="in-memory",
+        backend=config.cache_backend,
+        cache_dir=config.cache_dir if config.cache_backend == "disk" else None,
     )
     if not config.cache_enabled:
         logger.warning(

--- a/common/config.py
+++ b/common/config.py
@@ -44,6 +44,13 @@ class Config:
     cache_enabled: bool
     cache_ttl_seconds: int
     cache_max_entries: int
+    # Cache backend for the Discovery result cache. "disk" (default) persists to
+    # a SQLite store under cache_dir (mounted on a docker volume) so entries
+    # survive restart/redeploy; "memory" is the legacy in-process cache. A
+    # missing var defaults to "disk" — the persistent behaviour — and the
+    # effective backend is logged at boot.
+    cache_backend: str
+    cache_dir: str
     # Bounded Gemini retry backoff (keeps worst-case schedule < workflow_timeout).
     retry_exp_base: float
     retry_max_delay: float
@@ -139,6 +146,10 @@ def load_config() -> Config:
         - CACHE_ENABLED: master switch for the Discovery result cache;
           a missing var falls back to true (on), never silently off.
           Set "false" to deliberately disable caching. (default: true)
+        - CACHE_BACKEND: "disk" (persistent SQLite on a docker volume, survives
+          restart/redeploy) or "memory" (legacy in-process). (default: disk)
+        - CACHE_DIR: directory for the disk backend's store, mounted on a
+          docker volume in prod. (default: /app/.cache/discovery)
         - RATE_LIMIT_REQUESTS: max requests per window per user/IP on the
           expensive endpoints; 0 disables (default: 0)
         - RATE_LIMIT_WINDOW_SECONDS: rate-limit window length (default: 60)
@@ -177,6 +188,8 @@ def load_config() -> Config:
         cache_enabled=_env_bool("CACHE_ENABLED", True),
         cache_ttl_seconds=_env_int("CACHE_TTL_SECONDS", 86400),
         cache_max_entries=_env_int("CACHE_MAX_ENTRIES", 500),
+        cache_backend=os.getenv("CACHE_BACKEND", "disk"),
+        cache_dir=os.getenv("CACHE_DIR", "/app/.cache/discovery"),
         retry_exp_base=_env_float("RETRY_EXP_BASE", 2.0),
         retry_max_delay=_env_float("RETRY_MAX_DELAY", 12.0),
         retry_attempts=_env_int("RETRY_ATTEMPTS", 4),

--- a/core/cache.py
+++ b/core/cache.py
@@ -25,6 +25,11 @@ import time
 from collections import OrderedDict
 from typing import Any, Optional
 
+from common.logging import get_logger
+
+
+logger = get_logger("storyland.core.cache")
+
 
 class TTLCache:
     """An async-safe, bounded TTL cache with oldest-first eviction.
@@ -87,5 +92,63 @@ class TTLCache:
         async with self._lock:
             self._store.clear()
 
+    def close(self) -> None:
+        """No-op close so the in-memory cache matches the disk cache interface.
+
+        The disk backend releases a SQLite handle here; the in-memory store has
+        nothing to release. Lets the executor call ``close()`` uniformly.
+        """
+        return None
+
     def __len__(self) -> int:
         return len(self._store)
+
+
+def build_discovery_cache(config):
+    """Construct the Discovery result cache for the configured backend.
+
+    ``config`` is an ``ExecutorConfig`` (or anything exposing ``cache_backend``,
+    ``cache_dir``, ``cache_ttl_seconds`` and ``cache_max_entries``).
+
+    * ``cache_backend == "disk"`` -> a persistent :class:`~core.disk_cache.DiskTTLCache`
+      under ``cache_dir`` (mounted on a docker volume in prod), so entries
+      survive restart/redeploy.
+    * anything else (default ``"memory"``) -> the in-process :class:`TTLCache`.
+
+    Disk construction is best-effort: if ``diskcache`` is missing or the
+    directory can't be opened (permissions, read-only fs, disk full), we log and
+    fall back to the in-memory cache rather than breaking discovery. The full
+    rollback is still just reverting the commit (which restores the in-memory
+    default), but this fallback keeps a misconfigured volume from taking the
+    service down.
+    """
+    ttl = config.cache_ttl_seconds
+    max_entries = config.cache_max_entries
+    backend = (getattr(config, "cache_backend", "memory") or "memory").lower()
+
+    if backend == "disk":
+        directory = getattr(config, "cache_dir", None)
+        if not directory:
+            logger.warning(
+                "cache_disk_dir_missing",
+                detail="cache_backend=disk but cache_dir is empty; using in-memory cache.",
+            )
+            return TTLCache(ttl_seconds=ttl, max_entries=max_entries)
+        try:
+            from core.disk_cache import DiskTTLCache
+
+            cache = DiskTTLCache(
+                directory=directory, ttl_seconds=ttl, max_entries=max_entries
+            )
+            logger.info("cache_backend_selected", backend="disk", directory=directory)
+            return cache
+        except Exception as exc:  # noqa: BLE001 - never let cache setup break boot
+            logger.warning(
+                "cache_disk_init_failed",
+                directory=directory,
+                error=str(exc),
+                detail="Falling back to in-memory Discovery cache.",
+            )
+            return TTLCache(ttl_seconds=ttl, max_entries=max_entries)
+
+    return TTLCache(ttl_seconds=ttl, max_entries=max_entries)

--- a/core/cache_version.py
+++ b/core/cache_version.py
@@ -1,0 +1,58 @@
+"""Content fingerprint used to auto-invalidate the Discovery result cache.
+
+The Discovery cache (``core.cache`` / ``core.disk_cache``) now persists across
+process restarts and redeploys (SQLite on a docker volume). A persistent store
+introduces a new hazard the old process-local dict never had: after a model or
+prompt change, stale-but-still-live entries computed by the *previous* logic
+would keep being served.
+
+To make that impossible, every cache key is namespaced by a **version hash**
+derived from the inputs that determine the recommendation output:
+
+* the active model name, and
+* the source text of the prompt modules that build the discovery request and
+  the agent instructions.
+
+Any change to the model or those prompts changes the hash, so all prior entries
+simply stop matching (they are ignored and eventually TTL-evicted) and fresh
+results are computed under the new key. This is what lets us drop post-deploy
+cache warmup entirely: a deploy that changes nothing recomputes nothing, and a
+deploy that changes the model/prompts self-invalidates.
+
+The fingerprint is best-effort: if a prompt module's source can't be read
+(e.g. a frozen/stripped build), that input contributes an empty string rather
+than raising, so cache versioning degrades to "keyed by model name only" and
+never breaks discovery.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import inspect
+
+# Prompt modules whose text determines the discovered region set. A change to
+# any of these should invalidate cached discovery results.
+_PROMPT_MODULES = ("core.prompts", "agents.prompts")
+
+
+def _module_source(module_name: str) -> str:
+    """Return a module's source text, or '' if it can't be read."""
+    try:
+        module = importlib.import_module(module_name)
+        return inspect.getsource(module)
+    except Exception:
+        return ""
+
+
+def compute_cache_version(model_name: str, prompt_modules=_PROMPT_MODULES) -> str:
+    """A short, stable hash over the model name + prompt module sources.
+
+    Deterministic for a given (model, prompt-source) pair and 12 hex chars long
+    so it stays readable in logs and keys. Changing the model name or editing
+    any prompt module changes the result.
+    """
+    parts = [model_name or ""]
+    parts.extend(_module_source(name) for name in prompt_modules)
+    digest = hashlib.sha1("\x00".join(parts).encode("utf-8")).hexdigest()
+    return digest[:12]

--- a/core/disk_cache.py
+++ b/core/disk_cache.py
@@ -1,0 +1,104 @@
+"""Persistent, async-safe TTL cache backed by ``diskcache`` (SQLite on disk).
+
+This is the persistent sibling of the in-process :class:`core.cache.TTLCache`.
+It exposes the *same* async interface (``get`` / ``set`` / ``clear`` /
+``close`` / ``len``) so it is a drop-in replacement for the Discovery result
+cache, but stores entries in a SQLite database under a directory that is mounted
+on a docker volume. Entries therefore survive:
+
+* container restart, and
+* redeploy (image rebuild),
+
+which fixes the cold-on-restart failure mode where every deploy re-paid live
+Gemini + Google Books cost. A single on-disk store is also shared across worker
+processes on the box, so a hit computed by one worker serves them all.
+
+Design notes:
+
+* ``diskcache`` is synchronous, so every operation is dispatched to a worker
+  thread via ``asyncio.to_thread`` to avoid blocking the event loop.
+* TTL is enforced by diskcache's per-entry ``expire``; staleness is bounded by
+  the TTL exactly as before.
+* Growth is bounded by a byte ``size_limit`` derived from ``max_entries`` with
+  least-recently-used eviction. The bound moves from an exact entry *count* (the
+  old process-local dict) to an equivalent on-disk *byte budget* — the right
+  primitive for a shared, persistent store. Region-analysis entries are small
+  (a few KB), so the budget comfortably holds ``max_entries`` of them.
+* Values are returned as-is; callers cache only already-validated data, so a hit
+  can never introduce a new fabrication (identical guarantee to TTLCache).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Optional
+
+# Byte budget assumed per cached region-analysis entry when deriving the on-disk
+# size limit from the configured entry count. Generous headroom over a typical
+# few-KB region set.
+_BYTES_PER_ENTRY = 32 * 1024
+_MIN_SIZE_LIMIT = 8 * 1024 * 1024  # never smaller than 8 MB
+
+
+class DiskTTLCache:
+    """An async-safe, persistent TTL cache with LRU + byte-bounded eviction.
+
+    Args:
+        directory: On-disk directory for the SQLite store (created if absent);
+            mount this on a docker volume for cross-restart persistence.
+        ttl_seconds: Time-to-live for each entry, in seconds.
+        max_entries: Approximate entry budget; converted to an on-disk byte
+            ``size_limit`` with LRU eviction.
+        size_limit: Explicit byte size limit (overrides the ``max_entries``
+            derivation; mainly for tests).
+    """
+
+    def __init__(
+        self,
+        directory: str,
+        ttl_seconds: int,
+        max_entries: int,
+        size_limit: Optional[int] = None,
+    ) -> None:
+        if ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be positive")
+        if max_entries <= 0:
+            raise ValueError("max_entries must be positive")
+        # Lazy import so environments that never select the disk backend don't
+        # need the dependency importable at module load.
+        import diskcache
+
+        self._ttl = ttl_seconds
+        self._max = max_entries
+        self._size_limit = size_limit or max(max_entries * _BYTES_PER_ENTRY, _MIN_SIZE_LIMIT)
+        self._cache = diskcache.Cache(
+            directory=str(directory),
+            size_limit=self._size_limit,
+            eviction_policy="least-recently-used",
+        )
+
+    @property
+    def directory(self) -> str:
+        return self._cache.directory
+
+    async def get(self, key: str) -> Optional[Any]:
+        """Return the cached value for ``key`` or ``None`` on miss/expiry."""
+        return await asyncio.to_thread(self._cache.get, key)
+
+    async def set(self, key: str, value: Any) -> None:
+        """Store ``value`` under ``key`` with the configured TTL."""
+        await asyncio.to_thread(self._cache.set, key, value, self._ttl)
+
+    async def clear(self) -> None:
+        """Drop all entries (used by tests and the rollback path)."""
+        await asyncio.to_thread(self._cache.clear)
+
+    def close(self) -> None:
+        """Release the SQLite handle. Safe to call more than once."""
+        try:
+            self._cache.close()
+        except Exception:
+            pass
+
+    def __len__(self) -> int:
+        return len(self._cache)

--- a/core/executor.py
+++ b/core/executor.py
@@ -74,7 +74,8 @@ from .prompts import (
     build_composition_prompt,
     build_local_atmosphere_prompt,
 )
-from .cache import TTLCache
+from .cache import TTLCache, build_discovery_cache
+from .cache_version import compute_cache_version
 from .regions import get_valid_region_ids, validate_region_selection
 from .session_state import SessionStateAccessor, SessionStateKeys
 from .types import ExecutorConfig
@@ -159,10 +160,14 @@ class WorkflowExecutor:
         # the fast-path and the store are both skipped, so caching is off
         # deliberately (and logged at boot), never silently.
         self._cache_enabled = config.cache_enabled
-        self._discovery_cache = TTLCache(
-            ttl_seconds=config.cache_ttl_seconds,
-            max_entries=config.cache_max_entries,
-        )
+        # Persistent-or-in-memory Discovery cache, chosen by config.cache_backend
+        # (disk in prod: survives restart/redeploy; memory for tests/library use).
+        self._discovery_cache = build_discovery_cache(config)
+        # Version namespace mixed into every cache key so a model or prompt
+        # change auto-invalidates all prior entries (essential now that the disk
+        # backend persists them across deploys — no stale grounded recs, and no
+        # post-deploy warmup needed).
+        self._cache_version = compute_cache_version(config.model_name)
 
     @property
     def session_service(self):
@@ -244,6 +249,15 @@ class WorkflowExecutor:
             analysis_note=region_analysis.get("analysis_note", ""),
         )
         yield WorkflowComplete(job_id=job_id)
+
+    def _versioned_key(self, base_key: str) -> str:
+        """Namespace a logical cache key with the model/prompt version hash.
+
+        Applied at the cache boundary (not inside ``_discovery_cache_key``) so
+        the logical key contract is unchanged; a model/prompt change flips the
+        namespace and all prior (persisted) entries stop matching.
+        """
+        return f"dv:{self._cache_version}:{base_key}"
 
     @staticmethod
     def _discovery_cache_key(
@@ -341,8 +355,10 @@ class WorkflowExecutor:
         # the previously computed (already validated) regions and makes ZERO
         # Gemini calls. Only non-empty region sets are ever cached, so a hit
         # cannot introduce a new fabrication; staleness is bounded by the TTL.
-        cache_key = self._discovery_cache_key(
-            book_title, author, preferences, vibe, taste_context
+        cache_key = self._versioned_key(
+            self._discovery_cache_key(
+                book_title, author, preferences, vibe, taste_context
+            )
         )
         cached_region_analysis = (
             await self._discovery_cache.get(cache_key)
@@ -1597,4 +1613,6 @@ class WorkflowExecutor:
 
     async def close(self) -> None:
         """Cleanup resources."""
-        pass
+        close = getattr(self._discovery_cache, "close", None)
+        if callable(close):
+            close()

--- a/core/types.py
+++ b/core/types.py
@@ -32,6 +32,14 @@ class ExecutorConfig:
     cache_enabled: bool = True
     cache_ttl_seconds: int = 86400
     cache_max_entries: int = 500
+    # Cache backend: "memory" (in-process, default for direct/library use and
+    # tests) or "disk" (persistent SQLite on a docker volume, survives
+    # restart/redeploy). The deployed app sets this to "disk" via CACHE_BACKEND;
+    # the dataclass default stays "memory" so unit tests are hermetic.
+    cache_backend: str = "memory"
+    # On-disk directory for the "disk" backend (mounted on a docker volume in
+    # prod). Ignored by the memory backend.
+    cache_dir: Optional[str] = None
     # Bounded Gemini retry backoff (parity with the eval runner).
     retry_exp_base: float = 2.0
     retry_max_delay: float = 12.0
@@ -55,6 +63,8 @@ class ExecutorConfig:
             cache_enabled=getattr(config, "cache_enabled", True),
             cache_ttl_seconds=getattr(config, "cache_ttl_seconds", 86400),
             cache_max_entries=getattr(config, "cache_max_entries", 500),
+            cache_backend=getattr(config, "cache_backend", "memory"),
+            cache_dir=getattr(config, "cache_dir", None),
             retry_exp_base=getattr(config, "retry_exp_base", 2.0),
             retry_max_delay=getattr(config, "retry_max_delay", 12.0),
             retry_attempts=getattr(config, "retry_attempts", 4),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.30.0",
     "sse-starlette>=2.0.0",
+    "diskcache>=5.6.0",  # persistent SQLite-backed Discovery result cache (survives restart/redeploy)
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -211,7 +211,11 @@ class TestExecutorCacheHit:
             "regions": [{"region_id": 1, "name": "Atlanta, United States"}],
             "analysis_note": "cached note",
         }
-        key = WorkflowExecutor._discovery_cache_key("1984", "George Orwell", None)
+        # The executor namespaces keys with the model/prompt version, so prime
+        # the store through the same helper discover() uses.
+        key = executor._versioned_key(
+            WorkflowExecutor._discovery_cache_key("1984", "George Orwell", None)
+        )
         await executor._discovery_cache.set(key, cached)
 
         events = [

--- a/tests/unit/test_cache_version.py
+++ b/tests/unit/test_cache_version.py
@@ -1,0 +1,41 @@
+"""Unit tests for the cache version fingerprint (core/cache_version.py)."""
+
+from core.cache_version import compute_cache_version
+
+
+class TestComputeCacheVersion:
+    def test_deterministic_for_same_inputs(self):
+        a = compute_cache_version("gemini-2.0-flash")
+        b = compute_cache_version("gemini-2.0-flash")
+        assert a == b
+
+    def test_twelve_hex_chars(self):
+        v = compute_cache_version("gemini-2.0-flash")
+        assert len(v) == 12
+        int(v, 16)  # parses as hex
+
+    def test_model_name_changes_version(self):
+        assert compute_cache_version("gemini-2.0-flash") != compute_cache_version(
+            "gemini-3.1-flash-lite-preview"
+        )
+
+    def test_prompt_source_changes_version(self):
+        # Two different sets of prompt modules produce different fingerprints,
+        # proving the prompt source feeds the hash (a real prompt edit changes
+        # the module source and therefore the version).
+        base = compute_cache_version("m", prompt_modules=("core.prompts",))
+        other = compute_cache_version(
+            "m", prompt_modules=("core.prompts", "agents.prompts")
+        )
+        assert base != other
+
+    def test_unreadable_module_degrades_gracefully(self):
+        # An unknown module contributes "" instead of raising, so versioning
+        # never breaks discovery — it just falls back to model-name-only keying.
+        v = compute_cache_version("m", prompt_modules=("does.not.exist",))
+        assert len(v) == 12
+        # Same as hashing model + one empty part deterministically.
+        assert v == compute_cache_version("m", prompt_modules=("does.not.exist",))
+
+    def test_empty_model_name_is_stable(self):
+        assert compute_cache_version("") == compute_cache_version("")

--- a/tests/unit/test_disk_cache.py
+++ b/tests/unit/test_disk_cache.py
@@ -1,0 +1,113 @@
+"""Unit tests for the persistent disk-backed Discovery cache (core/disk_cache.py)
+and the backend factory (core.cache.build_discovery_cache)."""
+
+import asyncio
+
+import pytest
+
+from core.cache import TTLCache, build_discovery_cache
+from core.disk_cache import DiskTTLCache
+from core.types import ExecutorConfig
+
+
+class TestDiskTTLCacheBasics:
+    async def test_set_then_get_hit(self, tmp_path):
+        cache = DiskTTLCache(str(tmp_path / "d"), ttl_seconds=100, max_entries=10)
+        try:
+            await cache.set("k", {"regions": [1, 2]})
+            assert await cache.get("k") == {"regions": [1, 2]}
+        finally:
+            cache.close()
+
+    async def test_missing_key_returns_none(self, tmp_path):
+        cache = DiskTTLCache(str(tmp_path / "d"), ttl_seconds=100, max_entries=10)
+        try:
+            assert await cache.get("absent") is None
+        finally:
+            cache.close()
+
+    async def test_rejects_nonpositive_config(self, tmp_path):
+        with pytest.raises(ValueError):
+            DiskTTLCache(str(tmp_path / "d"), ttl_seconds=0, max_entries=10)
+        with pytest.raises(ValueError):
+            DiskTTLCache(str(tmp_path / "d"), ttl_seconds=10, max_entries=0)
+
+    async def test_clear_empties_cache(self, tmp_path):
+        cache = DiskTTLCache(str(tmp_path / "d"), ttl_seconds=100, max_entries=10)
+        try:
+            await cache.set("a", 1)
+            await cache.set("b", 2)
+            await cache.clear()
+            assert await cache.get("a") is None
+            assert len(cache) == 0
+        finally:
+            cache.close()
+
+
+class TestDiskTTLCachePersistence:
+    async def test_survives_a_simulated_restart(self, tmp_path):
+        """The whole point: a fresh cache object pointed at the same directory
+        (a process restart / redeploy) still serves entries written before."""
+        directory = str(tmp_path / "store")
+        first = DiskTTLCache(directory, ttl_seconds=100, max_entries=10)
+        try:
+            await first.set("book|orwell", {"regions": ["London"]})
+        finally:
+            first.close()  # simulate process exit
+
+        # New object, same directory == restarted process.
+        second = DiskTTLCache(directory, ttl_seconds=100, max_entries=10)
+        try:
+            assert await second.get("book|orwell") == {"regions": ["London"]}
+        finally:
+            second.close()
+
+
+class TestDiskTTLCacheExpiry:
+    async def test_entry_expires_after_ttl(self, tmp_path):
+        cache = DiskTTLCache(str(tmp_path / "d"), ttl_seconds=1, max_entries=10)
+        try:
+            await cache.set("k", "v")
+            assert await cache.get("k") == "v"  # live
+            await asyncio.sleep(1.2)  # past the 1s TTL
+            assert await cache.get("k") is None  # expired
+        finally:
+            cache.close()
+
+
+class TestBuildDiscoveryCache:
+    def _cfg(self, **kw):
+        base = dict(model_name="gemini-test", google_api_key="k")
+        base.update(kw)
+        return ExecutorConfig(**base)
+
+    def test_memory_backend_is_ttlcache(self):
+        cache = build_discovery_cache(self._cfg(cache_backend="memory"))
+        assert isinstance(cache, TTLCache)
+
+    def test_default_backend_is_memory_for_library_use(self):
+        # ExecutorConfig's dataclass default keeps direct/library construction
+        # (and unit tests) hermetic — no disk unless explicitly selected.
+        cache = build_discovery_cache(self._cfg())
+        assert isinstance(cache, TTLCache)
+
+    def test_disk_backend_is_diskcache(self, tmp_path):
+        cache = build_discovery_cache(
+            self._cfg(cache_backend="disk", cache_dir=str(tmp_path / "d"))
+        )
+        try:
+            assert isinstance(cache, DiskTTLCache)
+        finally:
+            cache.close()
+
+    def test_disk_backend_without_dir_falls_back_to_memory(self):
+        cache = build_discovery_cache(self._cfg(cache_backend="disk", cache_dir=None))
+        assert isinstance(cache, TTLCache)
+
+    def test_disk_backend_bad_dir_falls_back_to_memory(self):
+        # A directory that can't be created (a path under a regular file) must
+        # not break boot — the factory degrades to in-memory.
+        cache = build_discovery_cache(
+            self._cfg(cache_backend="disk", cache_dir="/dev/null/cannot/exist")
+        )
+        assert isinstance(cache, TTLCache)


### PR DESCRIPTION
# feat(cache): persist the Discovery cache on disk + version-keyed invalidation

## What
Replaces the in-process `TTLCache` used for the Discovery chain (book → regions) with a persistent, SQLite-backed `diskcache` store selected by a new `CACHE_BACKEND` setting (`disk` in prod, `memory` for library/tests). The store lives under `CACHE_DIR` (mounted on a docker volume), so cache entries survive container restart **and** redeploy. Every cache key is additionally namespaced by a model/prompt **version hash**, so a model or prompt change auto-invalidates all prior entries.

PR 2 of 2 of the MYS-9 cache-persistence feature (PR1 = the `CACHE_ENABLED` master switch + boot-time effective-config log, already merged). This is the final PR of the feature.

## Why
Today's cache is process-local and in-memory, so it is wiped cold on every restart/redeploy — each deploy re-pays live Gemini + Google Books cost to recompute identical Discovery results, and multiple workers can't share a hit. Moving the store to disk on a docker volume fixes the cold-on-restart failure mode and gives a single shared store across workers on the box.

Because a persistent store now outlives a deploy, it introduces a new hazard the ephemeral cache never had: after a model or prompt change, stale-but-live entries computed by the *previous* logic would keep being served. Version-keying the entries makes that impossible — a model/prompt change flips the namespace and all prior entries stop matching — which is what lets us drop post-deploy cache warmup entirely.

## How
- **`core/disk_cache.py` (new):** `DiskTTLCache`, a persistent sibling of `TTLCache` exposing the identical async interface (`get`/`set`/`clear`/`close`/`__len__`). Backed by `diskcache.Cache` (SQLite); synchronous ops are dispatched via `asyncio.to_thread` so the event loop never blocks. TTL uses diskcache's per-entry `expire`; growth is bounded by a byte `size_limit` derived from `cache_max_entries` with LRU eviction (the bound moves from an exact entry *count* to an equivalent on-disk *byte budget* — the right primitive for a shared persistent store; region entries are a few KB so the budget comfortably holds `max_entries`).
- **`core/cache_version.py` (new):** `compute_cache_version(model_name)` — a stable 12-hex-char SHA-1 over the model name + the *source text* of the prompt modules (`core.prompts`, `agents.prompts`). Any model or prompt edit changes the hash. Best-effort: an unreadable module contributes `""` rather than raising, so versioning degrades to model-name-only keying and never breaks discovery.
- **`core/cache.py`:** adds a no-op `close()` to `TTLCache` (interface parity) and a `build_discovery_cache(config)` factory that returns a `DiskTTLCache` for `cache_backend == "disk"` (falling back to in-memory, with a logged warning, if `diskcache` is missing or the directory can't be opened) or a `TTLCache` otherwise.
- **`core/executor.py`:** builds the cache via the factory; computes `self._cache_version` once at init; wraps the logical cache key with the version namespace at the cache boundary via a new `_versioned_key(...)` helper (the pure `_discovery_cache_key(...)` contract is unchanged); closes the cache in `close()`.
- **`core/types.py` / `common/config.py`:** add `cache_backend` + `cache_dir`. The `ExecutorConfig` dataclass defaults to `memory` (hermetic library/test default); the deployed app defaults to `disk` via `CACHE_BACKEND` (`CACHE_DIR=/app/.cache/discovery`).
- **`api/dependencies.py`:** the boot-time `cache_config_effective` log now reports the effective `backend` (+ `cache_dir` on disk).
- **`Dockerfile`:** pre-creates `/app/.cache/discovery` before the `chown`, so a named volume mounted at `/app/.cache` inherits `appuser` ownership and the unprivileged runtime user can write the SQLite store.
- **`pyproject.toml`:** adds `diskcache>=5.6.0`.

The hit/miss keying contract is otherwise unchanged; the cache still only replays prior schema-validated region sets, so no new hallucination path is introduced. Additive, flagless-by-default, rollback = revert the commit (restores the in-memory cache). The docker-volume mount is provisioned at deploy time (see the paired infra PR); building against the config path does not depend on it.

## Review & test
- Focus on `core/disk_cache.py` (async wrapping, TTL, byte-bound eviction), the version-namespacing in `core/executor.py` (`_versioned_key`, applied on both `get` and `set`), and the graceful disk→memory fallback in `build_discovery_cache`.
- New unit tests: `tests/unit/test_disk_cache.py` (roundtrip, miss, clear, **persistence across a fresh cache object at the same directory = simulated restart**, TTL expiry, factory backend selection + fallbacks) and `tests/unit/test_cache_version.py` (determinism, 12-hex, model-change sensitivity, prompt-source sensitivity, graceful unreadable-module handling). `tests/unit/test_cache.py`'s cache-hit test now primes through `_versioned_key` (matches how `discover()` keys).
- Run: `pip install -e '.[dev]' && pytest -q`. Expect green (the pre-existing `test_cache_real_api` live-Gemini and `test_langfuse_integration` DNS integration tests fail identically on `origin/main` — not a regression).
- Manual persistence check: set `CACHE_BACKEND=disk`, run a discover, restart the process (same `CACHE_DIR`), repeat the same discover → served from cache (`discovery_cache_hit`), zero Gemini calls. Bump `MODEL_NAME` (or edit a prompt) → prior entries no longer hit.
