### PR TITLE
fix: typed discovery-compose error at the async-TaskGroup boundary (no raw ExceptionGroup leak)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -491,6 +491,17 @@ class SSEErrorEvent(BaseModel):
     phase: Optional[int] = Field(
         default=None, description="Phase where error occurred"
     )
+    reason: Optional[str] = Field(
+        default=None,
+        description=(
+            "Machine-readable failure class for recovery UX "
+            '("transient" | "taste_validation"). Absent for unclassified errors.'
+        ),
+    )
+    offending_title: Optional[str] = Field(
+        default=None,
+        description="taste_context title that failed validation (reason=taste_validation)",
+    )
 
 
 class SSEDoneEvent(BaseModel):

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -100,11 +100,21 @@ def domain_event_to_sse(event: DomainEvent) -> dict:
                     recommendations=r, book_recommendation_count=n
                 ).model_dump_json(),
             )
-        case WorkflowError(message=m, error_type=t, phase=p):
+        case WorkflowError(
+            message=m,
+            error_type=t,
+            phase=p,
+            reason=r,
+            offending_title=ot,
+        ):
             return _sse(
                 "error",
                 SSEErrorEvent(
-                    message=m, error_type=t, phase=int(p) if p is not None else None
+                    message=m,
+                    error_type=t,
+                    phase=int(p) if p is not None else None,
+                    reason=r,
+                    offending_title=ot,
                 ).model_dump_json(),
             )
         case WorkflowComplete(job_id=j, token_usage=u):

--- a/core/discovery_errors.py
+++ b/core/discovery_errors.py
@@ -1,0 +1,138 @@
+"""Typed discovery-compose errors + a classifier for the async-TaskGroup boundary.
+
+The discovery composition runs its parallel work under an async ``TaskGroup``
+(inside the ADK runner). When a child task raises, Python wraps the failure in
+an ``ExceptionGroup`` whose ``str()`` is the opaque
+``"unhandled errors in a TaskGroup (1 sub-exception)"``. That raw string — and
+any other internal async machinery — must never reach a client.
+
+This module collapses any such failure into a single, client-safe
+``DiscoveryComposeError`` classified as one of two kinds:
+
+* ``transient`` — an upstream/timeout/child-crash compose failure (the
+  intermittent case; an immediate retry with another title composes fine).
+* ``taste_validation`` — a ``taste_context`` title genuinely failed validation
+  (the deterministic soft-trap case; re-fails identically on retry). Carries the
+  offending title so the caller can offer a "search without my taste" escape.
+
+This PR *defines the typed-error contract*; the gateway (be) maps ``kind`` →
+HTTP status + a machine-readable ``reason`` in the body, and fe branches on
+``reason`` to pick the right recovery state. Do not over-broaden
+``taste_validation`` — everything that is not a genuine taste-title validation
+failure is ``transient``, so the soft-trap state is never shown spuriously.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator, Optional
+
+try:  # Python 3.11+: ExceptionGroup / BaseExceptionGroup are builtins.
+    _BASE_EXCEPTION_GROUP: type = BaseExceptionGroup  # type: ignore[name-defined]
+except NameError:  # pragma: no cover - py3.10 has no group semantics
+    _BASE_EXCEPTION_GROUP = ()  # type: ignore[assignment]
+
+# Literal kinds the contract exposes. (Kept as a tuple for runtime validation;
+# the gateway/fe treat these as the machine-readable ``reason`` values.)
+DISCOVERY_ERROR_KINDS = ("transient", "taste_validation")
+
+# Client-safe messages. NEVER embed the raw exception / ExceptionGroup string.
+TRANSIENT_MESSAGE = (
+    "We couldn't finish composing your journey this time. This is almost "
+    "always temporary — please try again."
+)
+TASTE_VALIDATION_MESSAGE = (
+    "One of your saved books is tripping up this search."
+)
+
+
+class TasteContextValidationError(ValueError):
+    """A specific ``taste_context`` title failed validation.
+
+    Raised (or forwarded) when a stored/imported taste title cannot be used to
+    shape discovery — deterministic, so the same ``taste_context`` re-fails
+    identically until the offending title is removed. Carries ``offending_title``
+    so the compose boundary can surface a ``taste_validation`` error with an
+    escape hatch instead of an opaque transient failure.
+    """
+
+    def __init__(
+        self, offending_title: Optional[str] = None, message: str = ""
+    ) -> None:
+        self.offending_title = offending_title
+        super().__init__(message or "taste_context title failed validation")
+
+
+class DiscoveryComposeError(Exception):
+    """A single, client-safe error for a failed discovery composition.
+
+    ``kind`` is ``"transient"`` (a retry may succeed) or ``"taste_validation"``
+    (a stored taste_context title is the cause; a plain retry re-fails).
+    ``message`` is always a friendly, internals-free string; the real
+    stacktrace is logged server-side only and never carried here.
+    """
+
+    def __init__(
+        self,
+        kind: str,
+        message: str,
+        offending_title: Optional[str] = None,
+    ) -> None:
+        if kind not in DISCOVERY_ERROR_KINDS:
+            raise ValueError(f"unknown DiscoveryComposeError kind: {kind!r}")
+        self.kind = kind
+        self.message = message
+        self.offending_title = offending_title
+        super().__init__(message)
+
+
+def _iter_leaves(exc: BaseException) -> Iterator[BaseException]:
+    """Yield the leaf exceptions of a (possibly nested) ExceptionGroup.
+
+    A non-group exception yields itself; a group is unwrapped recursively so a
+    ``TaskGroup``-wrapped child failure is inspected directly.
+    """
+    if _BASE_EXCEPTION_GROUP and isinstance(exc, _BASE_EXCEPTION_GROUP):
+        for sub in exc.exceptions:  # type: ignore[attr-defined]
+            yield from _iter_leaves(sub)
+    else:
+        yield exc
+
+
+def _find_taste_validation(
+    exc: BaseException,
+) -> Optional[TasteContextValidationError]:
+    for leaf in _iter_leaves(exc):
+        if isinstance(leaf, TasteContextValidationError):
+            return leaf
+    return None
+
+
+def classify_discovery_failure(
+    exc: BaseException,
+    *,
+    taste_context: Optional[dict] = None,
+) -> DiscoveryComposeError:
+    """Collapse any discovery-compose failure into a typed, client-safe error.
+
+    Unwraps an async-``TaskGroup`` ``ExceptionGroup`` to its leaves and
+    classifies: a ``TasteContextValidationError`` leaf → ``taste_validation``
+    (with the offending title, falling back to the first taste_context title
+    when the leaf did not record one); anything else → ``transient``. The
+    returned error's ``message`` never contains the raw exception text.
+    """
+    if isinstance(exc, DiscoveryComposeError):
+        return exc
+
+    taste_err = _find_taste_validation(exc)
+    if taste_err is not None:
+        offending = taste_err.offending_title
+        if offending is None and taste_context:
+            titles = taste_context.get("titles") or []
+            offending = titles[0] if titles else None
+        return DiscoveryComposeError(
+            kind="taste_validation",
+            message=TASTE_VALIDATION_MESSAGE,
+            offending_title=offending,
+        )
+
+    return DiscoveryComposeError(kind="transient", message=TRANSIENT_MESSAGE)

--- a/core/events.py
+++ b/core/events.py
@@ -84,11 +84,21 @@ class BookRecommendationsReady:
 
 @dataclass(frozen=True)
 class WorkflowError:
-    """An error occurred during workflow execution."""
+    """An error occurred during workflow execution.
+
+    ``reason`` is a machine-readable classification the gateway/fe branch on
+    (currently ``"transient"`` or ``"taste_validation"`` for discovery-compose
+    failures); ``offending_title`` names the specific taste_context title when
+    ``reason == "taste_validation"``. Both are optional so non-classified
+    errors are unchanged. ``message`` is always client-safe — never a raw
+    exception / ExceptionGroup string.
+    """
 
     message: str
     error_type: str
     phase: Optional[Phase] = None
+    reason: Optional[str] = None
+    offending_title: Optional[str] = None
 
 
 @dataclass(frozen=True)

--- a/core/executor.py
+++ b/core/executor.py
@@ -50,6 +50,7 @@ from models.book import BookMetadata
 from plugins.langfuse_plugin import LangfusePlugin
 from services.session_service import create_session_service
 
+from .discovery_errors import classify_discovery_failure
 from .events import (
     DomainEvent,
     Phase,
@@ -505,14 +506,25 @@ class WorkflowExecutor:
             await self._mark_session_failed(job_id, user_id)
             raise
         except Exception as e:
+            # Collapse the async-TaskGroup boundary: a child-task failure
+            # arrives here as an ExceptionGroup whose str() is the opaque
+            # "unhandled errors in a TaskGroup (...)". Classify it into a
+            # single, client-safe typed error and surface only that — the real
+            # exception is logged server-side, never returned to the client.
+            compose_error = classify_discovery_failure(e, taste_context=taste_context)
             logger.error(
-                "discover_error", error=str(e), error_type=type(e).__name__
+                "discover_error",
+                error=str(e),
+                error_type=type(e).__name__,
+                compose_error_kind=compose_error.kind,
             )
             await self._mark_session_failed(job_id, user_id)
             yield WorkflowError(
-                message=str(e),
-                error_type=type(e).__name__,
+                message=compose_error.message,
+                error_type="DiscoveryComposeError",
                 phase=Phase.DISCOVERY,
+                reason=compose_error.kind,
+                offending_title=compose_error.offending_title,
             )
             yield WorkflowComplete(job_id=job_id)
 

--- a/tests/unit/test_discovery_errors.py
+++ b/tests/unit/test_discovery_errors.py
@@ -1,0 +1,224 @@
+"""Unit tests for the discovery-compose typed-error boundary (MYS-124 PR1).
+
+Covers three things:
+  1. ``classify_discovery_failure`` — collapses an async-TaskGroup
+     ``ExceptionGroup`` into a single, client-safe ``DiscoveryComposeError``
+     classified ``transient`` vs ``taste_validation`` (with ``offending_title``),
+     and never leaks the raw exception / "TaskGroup" / "ExceptionGroup" string.
+  2. The wire contract — ``WorkflowError`` / ``SSEErrorEvent`` carry the optional
+     ``reason`` + ``offending_title`` the gateway (be) and fe consume.
+  3. ``WorkflowExecutor.discover()`` surfaces the typed error instead of a raw
+     ExceptionGroup when a discovery child task crashes.
+"""
+
+import json
+
+import pytest
+
+from google.adk.events import Event
+from google.adk.events.event_actions import EventActions
+
+from core.discovery_errors import (
+    DiscoveryComposeError,
+    TasteContextValidationError,
+    classify_discovery_failure,
+    TRANSIENT_MESSAGE,
+    TASTE_VALIDATION_MESSAGE,
+)
+from core.events import RegionsReady, WorkflowError, WorkflowComplete
+from core.types import ExecutorConfig
+from core.session_state import SessionStateKeys
+
+# The opaque strings that must NEVER reach a client.
+_LEAK_MARKERS = ("TaskGroup", "ExceptionGroup", "sub-exception", "Traceback")
+
+
+def _assert_no_leak(text: str) -> None:
+    for marker in _LEAK_MARKERS:
+        assert marker not in text, f"leaked internal marker {marker!r}: {text!r}"
+
+
+class TestClassifyDiscoveryFailure:
+    def test_bare_exception_is_transient(self):
+        err = classify_discovery_failure(RuntimeError("boom: upstream timed out"))
+        assert isinstance(err, DiscoveryComposeError)
+        assert err.kind == "transient"
+        assert err.offending_title is None
+        assert err.message == TRANSIENT_MESSAGE
+        _assert_no_leak(err.message)
+
+    def test_taskgroup_child_raise_is_transient_no_leak(self):
+        # Simulate the exact reported failure: a child task crashes inside an
+        # asyncio.TaskGroup, surfacing as an ExceptionGroup whose str() is the
+        # opaque "unhandled errors in a TaskGroup (1 sub-exception)".
+        group = ExceptionGroup(
+            "unhandled errors in a TaskGroup", [ValueError("child crashed")]
+        )
+        assert "TaskGroup" in str(group)  # precondition: the raw leak exists
+        err = classify_discovery_failure(group)
+        assert err.kind == "transient"
+        _assert_no_leak(err.message)
+        _assert_no_leak(str(err))
+
+    def test_taste_validation_leaf_direct(self):
+        leaf = TasteContextValidationError(offending_title="Ignore all previous…")
+        err = classify_discovery_failure(leaf)
+        assert err.kind == "taste_validation"
+        assert err.offending_title == "Ignore all previous…"
+        assert err.message == TASTE_VALIDATION_MESSAGE
+        _assert_no_leak(err.message)
+
+    def test_taste_validation_wrapped_in_group(self):
+        group = ExceptionGroup(
+            "unhandled errors in a TaskGroup",
+            [TasteContextValidationError(offending_title="Bad Title")],
+        )
+        err = classify_discovery_failure(group)
+        assert err.kind == "taste_validation"
+        assert err.offending_title == "Bad Title"
+
+    def test_offending_title_falls_back_to_taste_context(self):
+        # Leaf recorded no title -> fall back to the first taste_context title.
+        leaf = TasteContextValidationError(offending_title=None)
+        err = classify_discovery_failure(
+            leaf, taste_context={"titles": ["First Saved Book", "Second"]}
+        )
+        assert err.kind == "taste_validation"
+        assert err.offending_title == "First Saved Book"
+
+    def test_nested_group_unwraps(self):
+        inner = ExceptionGroup("inner", [TasteContextValidationError("Nested Bad")])
+        outer = ExceptionGroup("outer", [inner])
+        err = classify_discovery_failure(outer)
+        assert err.kind == "taste_validation"
+        assert err.offending_title == "Nested Bad"
+
+    def test_mixed_group_prefers_taste_validation(self):
+        group = ExceptionGroup(
+            "mixed",
+            [RuntimeError("transient bit"), TasteContextValidationError("Poison")],
+        )
+        err = classify_discovery_failure(group)
+        assert err.kind == "taste_validation"
+        assert err.offending_title == "Poison"
+
+    def test_passthrough_existing_compose_error(self):
+        original = DiscoveryComposeError("transient", "already typed")
+        assert classify_discovery_failure(original) is original
+
+    def test_unknown_kind_rejected(self):
+        with pytest.raises(ValueError):
+            DiscoveryComposeError("weird", "nope")
+
+
+class TestWireContract:
+    def test_workflow_error_defaults_are_backward_compatible(self):
+        err = WorkflowError(message="x", error_type="NoRegions")
+        assert err.reason is None
+        assert err.offending_title is None
+
+    def test_workflow_error_carries_reason_and_title(self):
+        err = WorkflowError(
+            message="friendly",
+            error_type="DiscoveryComposeError",
+            reason="taste_validation",
+            offending_title="Bad Book",
+        )
+        assert err.reason == "taste_validation"
+        assert err.offending_title == "Bad Book"
+
+    def test_sse_error_event_serializes_contract_fields(self):
+        from api.models import SSEErrorEvent
+
+        payload = json.loads(
+            SSEErrorEvent(
+                message="friendly",
+                error_type="DiscoveryComposeError",
+                phase=2,
+                reason="taste_validation",
+                offending_title="Bad Book",
+            ).model_dump_json()
+        )
+        assert payload["reason"] == "taste_validation"
+        assert payload["offending_title"] == "Bad Book"
+        _assert_no_leak(json.dumps(payload))
+
+
+def _make_executor(monkeypatch, raise_exc):
+    """WorkflowExecutor whose stubbed discovery run raises ``raise_exc``."""
+    import core.executor as ex
+    from core.executor import WorkflowExecutor
+    from services.session_service import create_session_service
+
+    monkeypatch.setattr(ex, "create_discovery_workflow", lambda *a, **k: object())
+
+    class _RaisingRunner:
+        def __init__(self, *args, **kwargs):
+            self._session_service = kwargs.get("session_service")
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def run_async(self, user_id, session_id, new_message):
+            raise raise_exc
+            if False:  # keep this an async generator
+                yield None
+
+    monkeypatch.setattr(ex, "Runner", _RaisingRunner)
+
+    config = ExecutorConfig(model_name="gemini-2.0-flash", google_api_key="test-key")
+    return WorkflowExecutor(
+        config=config,
+        session_service=create_session_service(use_database=False),
+        model=object(),
+    )
+
+
+class TestDiscoverSurfacesTypedError:
+    async def test_taskgroup_crash_surfaces_transient_not_raw_group(
+        self, monkeypatch
+    ):
+        group = ExceptionGroup(
+            "unhandled errors in a TaskGroup", [RuntimeError("child crashed")]
+        )
+        executor = _make_executor(monkeypatch, group)
+
+        events = [
+            e async for e in executor.discover(book_title="1984", author="George Orwell")
+        ]
+
+        errors = [e for e in events if isinstance(e, WorkflowError)]
+        assert len(errors) == 1
+        err = errors[0]
+        assert err.error_type == "DiscoveryComposeError"
+        assert err.reason == "transient"
+        _assert_no_leak(err.message)
+        assert not any(isinstance(e, RegionsReady) for e in events)
+        assert any(isinstance(e, WorkflowComplete) for e in events)
+
+    async def test_taste_validation_crash_surfaces_reason_and_title(
+        self, monkeypatch
+    ):
+        group = ExceptionGroup(
+            "unhandled errors in a TaskGroup",
+            [TasteContextValidationError(offending_title="Poison Title")],
+        )
+        executor = _make_executor(monkeypatch, group)
+
+        events = [
+            e
+            async for e in executor.discover(
+                book_title="1984",
+                author="George Orwell",
+                taste_context={"titles": ["Poison Title"]},
+            )
+        ]
+
+        errors = [e for e in events if isinstance(e, WorkflowError)]
+        assert len(errors) == 1
+        assert errors[0].reason == "taste_validation"
+        assert errors[0].offending_title == "Poison Title"
+        _assert_no_leak(errors[0].message)


### PR DESCRIPTION
# fix: typed discovery-compose error at the async-TaskGroup boundary (no raw ExceptionGroup leak)

## What
The `/discover` compose path lets a bare `ExceptionGroup` propagate out of the discovery `TaskGroup`, so a transient child-task crash surfaces to the client as the opaque literal `"unhandled errors in a TaskGroup (1 sub-exception)"`. This change collapses any discovery-compose failure into a single, client-safe **typed** error, classified as `transient` or `taste_validation`, and threads a machine-readable `reason` (+ optional `offending_title`) through the domain event and the SSE error surface. The raw exception is logged server-side only and never returned toward the client.

This PR **defines the typed-error contract** consumed by the follow-up PRs; it is PR **1 of 3** for the discover error-surface fix (PR2 be maps `reason` → HTTP status; PR3 fe branches on `reason` to render the designed recovery states).

## Why
A transient discovery sub-task failure should not surface internal async machinery to users (poor UX + minor info disclosure). Classifying the failure at the compose boundary lets the gateway return a correct status and lets the UI offer the right recovery: a working "Try again" for the intermittent `transient` case, and a "search without my taste" escape for the deterministic `taste_validation` soft-trap (a stored `taste_context` title that keeps failing validation). Classification is intentionally conservative — anything that is not a genuine taste-title validation failure is `transient`, so the soft-trap state is never shown spuriously.

## How
- New `core/discovery_errors.py`:
  - `DiscoveryComposeError(kind, message, offending_title)` — the client-safe typed error; `kind ∈ {"transient","taste_validation"}`; `message` is always friendly/internals-free.
  - `TasteContextValidationError(ValueError)` — the deterministic signal a specific `taste_context` title failed validation; carries `offending_title`. Exported so the discovery path (or a forwarded validation) can raise it.
  - `classify_discovery_failure(exc, *, taste_context=None)` — recursively unwraps a (possibly nested) `ExceptionGroup` to its leaves; a `TasteContextValidationError` leaf → `taste_validation` (offending title from the leaf, else the first `taste_context` title); everything else → `transient`. Idempotent on an existing `DiscoveryComposeError`. A dependency-free fallback (`_BASE_EXCEPTION_GROUP = ()`) keeps it importable on the declared 3.10 floor even though the runtime is 3.12.
- `core/executor.py` — `discover()`'s terminal `except Exception` now classifies via `classify_discovery_failure(...)` and yields `WorkflowError(message=<friendly>, error_type="DiscoveryComposeError", reason=kind, offending_title=...)` instead of `message=str(e)` / the raw type name. The `TimeoutError` and `CancelledError` handlers above are unchanged.
- `core/events.py` — `WorkflowError` gains optional `reason` + `offending_title` (default `None`; fully backward-compatible with the existing NoRegions/timeout errors).
- `api/models.py` + `api/streaming.py` — `SSEErrorEvent` gains the same optional fields and the `WorkflowError → SSE` adapter threads them, so the wire contract (`reason`, `offending_title`) is available to the gateway/fe.

Additive, flagless, independently deployable; rollback = revert. Not G4 (error-handling hardening on an existing deterministic path — no recommendation/agent-logic change, no eval, no spend).

## Review & test
- Focus: the classifier's group-unwrapping and the conservative `transient` default; confirm no raw exception/`ExceptionGroup`/`TaskGroup` string can reach `WorkflowError.message` or the SSE body.
- New `tests/unit/test_discovery_errors.py` covers: bare exception → transient; a `TaskGroup` `ExceptionGroup` child-crash → transient with no leaked marker; `TasteContextValidationError` (direct, group-wrapped, nested, mixed) → `taste_validation` with the right `offending_title`; fallback to the first `taste_context` title; passthrough idempotency; unknown-kind rejection; `WorkflowError`/`SSEErrorEvent` backward-compat + contract-field serialization; and `discover()` surfacing the typed error (not a raw group) via the existing fake-Runner pattern.
- Run: `pytest -q tests/unit/test_discovery_errors.py` (and the full `pytest -q`). Note: the group-semantics tests require the 3.12 runtime — `ExceptionGroup` is not a builtin on 3.10.
