### PR TITLE
CI: just-in-time SSH opening for prod deploys (OIDC)

### DIFF
--- a/.github/workflows/deploy-ai-prod.yml
+++ b/.github/workflows/deploy-ai-prod.yml
@@ -35,14 +35,13 @@ name: Deploy AI (prod)
 # also recreate its depends_on services. This mirrors deploy.sh's existing
 # behaviour; the `--no-deps` refinement is tracked separately.
 #
-# JUST-IN-TIME SSH: port 22 on the box is restricted at rest to the home CIDR
+# JUST-IN-TIME SSH: port 22 on the box is CLOSED at rest
 # (storyland-infrastructure/deploy/terraform-lightsail). This workflow assumes
 # the storyland-github-deploy role via OIDC (no long-lived AWS keys), opens
 # port 22 for the runner's IP for the duration of the deploy, and always
-# restores the at-rest CIDR afterwards. Requires the AWS_DEPLOY_ROLE_ARN repo
-# VARIABLE and the SSH_ALLOWED_CIDR repo SECRET (a secret so the home CIDR is
-# masked in this public repo's logs). Mirrors the same steps in the infra
-# repo's deploy-service.yml — keep the two in sync.
+# closes it afterwards. Requires the AWS_DEPLOY_ROLE_ARN repo VARIABLE.
+# Mirrors the same steps in the infra repo's deploy-service.yml — keep the
+# two in sync.
 
 on:
   workflow_dispatch:
@@ -79,10 +78,8 @@ jobs:
       - name: Validate JIT-SSH configuration
         env:
           AWS_DEPLOY_ROLE_ARN: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
-          SSH_ALLOWED_CIDR: ${{ secrets.SSH_ALLOWED_CIDR }}
         run: |
           [ -n "$AWS_DEPLOY_ROLE_ARN" ] || { echo "::error::Repo variable AWS_DEPLOY_ROLE_ARN is not set"; exit 1; }
-          [ -n "$SSH_ALLOWED_CIDR" ] || { echo "::error::Repo secret SSH_ALLOWED_CIDR is not set"; exit 1; }
 
       - name: Assume deploy role (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
@@ -91,16 +88,13 @@ jobs:
           aws-region: us-east-1
 
       - name: Open SSH for this runner (just-in-time)
-        env:
-          SSH_ALLOWED_CIDR: ${{ secrets.SSH_ALLOWED_CIDR }}
         run: |
           RUNNER_IP="$(curl -sf https://checkip.amazonaws.com)"
-          # OpenInstancePublicPorts REPLACES the port-22 entry, so the home CIDR
-          # is included to keep laptop access during the deploy. ipv6Cidrs must
-          # be explicitly empty — Lightsail defaults it to ::/0 when omitted.
+          # ipv6Cidrs must be explicitly empty — Lightsail defaults it to ::/0
+          # when omitted (open to the whole IPv6 internet).
           aws lightsail open-instance-public-ports \
             --instance-name storyland \
-            --port-info "{\"fromPort\":22,\"toPort\":22,\"protocol\":\"tcp\",\"cidrs\":[\"$RUNNER_IP/32\",\"$SSH_ALLOWED_CIDR\"],\"ipv6Cidrs\":[]}"
+            --port-info "{\"fromPort\":22,\"toPort\":22,\"protocol\":\"tcp\",\"cidrs\":[\"$RUNNER_IP/32\"],\"ipv6Cidrs\":[]}"
 
       - name: Set up SSH key + pinned known_hosts
         env:
@@ -150,13 +144,11 @@ jobs:
              docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --build storyland-ai && \
              docker compose -f docker-compose.prod.yml ps storyland-ai"
 
-      - name: Restore at-rest SSH firewall (home CIDR only)
+      - name: Close SSH (at-rest state)
         if: always()
-        env:
-          SSH_ALLOWED_CIDR: ${{ secrets.SSH_ALLOWED_CIDR }}
         run: |
-          # Runs even on failure/cancel so the runner IP never lingers in the
-          # firewall. Converges to exactly what terraform manages, so no drift.
-          aws lightsail open-instance-public-ports \
+          # Runs even on failure/cancel so port 22 never lingers open.
+          # Converges to exactly what terraform manages (no port-22 entry).
+          aws lightsail close-instance-public-ports \
             --instance-name storyland \
-            --port-info "{\"fromPort\":22,\"toPort\":22,\"protocol\":\"tcp\",\"cidrs\":[\"$SSH_ALLOWED_CIDR\"],\"ipv6Cidrs\":[]}"
+            --port-info "fromPort=22,toPort=22,protocol=tcp"

--- a/.github/workflows/deploy-ai-prod.yml
+++ b/.github/workflows/deploy-ai-prod.yml
@@ -34,6 +34,15 @@ name: Deploy AI (prod)
 # DEPENDENCY NOTE: on the box, restarting `storyland-ai` via docker compose can
 # also recreate its depends_on services. This mirrors deploy.sh's existing
 # behaviour; the `--no-deps` refinement is tracked separately.
+#
+# JUST-IN-TIME SSH: port 22 on the box is restricted at rest to the home CIDR
+# (storyland-infrastructure/deploy/terraform-lightsail). This workflow assumes
+# the storyland-github-deploy role via OIDC (no long-lived AWS keys), opens
+# port 22 for the runner's IP for the duration of the deploy, and always
+# restores the at-rest CIDR afterwards. Requires the AWS_DEPLOY_ROLE_ARN repo
+# VARIABLE and the SSH_ALLOWED_CIDR repo SECRET (a secret so the home CIDR is
+# masked in this public repo's logs). Mirrors the same steps in the infra
+# repo's deploy-service.yml — keep the two in sync.
 
 on:
   workflow_dispatch:
@@ -49,6 +58,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write # OIDC token for the just-in-time SSH role
 
 jobs:
   deploy:
@@ -65,6 +75,32 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+
+      - name: Validate JIT-SSH configuration
+        env:
+          AWS_DEPLOY_ROLE_ARN: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          SSH_ALLOWED_CIDR: ${{ secrets.SSH_ALLOWED_CIDR }}
+        run: |
+          [ -n "$AWS_DEPLOY_ROLE_ARN" ] || { echo "::error::Repo variable AWS_DEPLOY_ROLE_ARN is not set"; exit 1; }
+          [ -n "$SSH_ALLOWED_CIDR" ] || { echo "::error::Repo secret SSH_ALLOWED_CIDR is not set"; exit 1; }
+
+      - name: Assume deploy role (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Open SSH for this runner (just-in-time)
+        env:
+          SSH_ALLOWED_CIDR: ${{ secrets.SSH_ALLOWED_CIDR }}
+        run: |
+          RUNNER_IP="$(curl -sf https://checkip.amazonaws.com)"
+          # OpenInstancePublicPorts REPLACES the port-22 entry, so the home CIDR
+          # is included to keep laptop access during the deploy. ipv6Cidrs must
+          # be explicitly empty — Lightsail defaults it to ::/0 when omitted.
+          aws lightsail open-instance-public-ports \
+            --instance-name storyland \
+            --port-info "{\"fromPort\":22,\"toPort\":22,\"protocol\":\"tcp\",\"cidrs\":[\"$RUNNER_IP/32\",\"$SSH_ALLOWED_CIDR\"],\"ipv6Cidrs\":[]}"
 
       - name: Set up SSH key + pinned known_hosts
         env:
@@ -84,8 +120,13 @@ jobs:
           BOX_IP: ${{ secrets.BOX_IP }}
         run: |
           # storyland-ai source -> ~/storyland/storyland-ai/ (the compose build context).
-          SSH_CMD="ssh -i ~/.ssh/deploy_key -o ServerAliveInterval=30"
-          $SSH_CMD "ubuntu@$BOX_IP" "mkdir -p ~/storyland/storyland-ai"
+          SSH_CMD="ssh -i ~/.ssh/deploy_key -o ServerAliveInterval=30 -o ConnectTimeout=10"
+          # The just-in-time firewall change can take a few seconds to propagate.
+          for i in $(seq 1 6); do
+            $SSH_CMD "ubuntu@$BOX_IP" "mkdir -p ~/storyland/storyland-ai" && break
+            [ "$i" = 6 ] && { echo "::error::Box unreachable over SSH after JIT port opening"; exit 1; }
+            sleep 5
+          done
           # Excludes mirror deploy.sh; .env/.env.prod are excluded so the box's
           # runtime config (source of truth) is never clobbered. .claude/.mcp.json
           # are excluded so no local agent config / credentials can ride to the box.
@@ -108,3 +149,14 @@ jobs:
             "cd ~/storyland/storyland-infrastructure/deploy && \
              docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --build storyland-ai && \
              docker compose -f docker-compose.prod.yml ps storyland-ai"
+
+      - name: Restore at-rest SSH firewall (home CIDR only)
+        if: always()
+        env:
+          SSH_ALLOWED_CIDR: ${{ secrets.SSH_ALLOWED_CIDR }}
+        run: |
+          # Runs even on failure/cancel so the runner IP never lingers in the
+          # firewall. Converges to exactly what terraform manages, so no drift.
+          aws lightsail open-instance-public-ports \
+            --instance-name storyland \
+            --port-info "{\"fromPort\":22,\"toPort\":22,\"protocol\":\"tcp\",\"cidrs\":[\"$SSH_ALLOWED_CIDR\"],\"ipv6Cidrs\":[]}"


### PR DESCRIPTION
Companion to o-ostrovskiy/storyland-infrastructure#19: prod SSH (port 22) is now **fully closed at rest**. This workflow (inlined mirror of the infra repo's deploy-service.yml) assumes the `storyland-github-deploy` AWS role via OIDC, opens port 22 for the runner's IP just for the deploy, and always closes it afterwards (`if: always()`). Adds an SSH readiness retry. The `AWS_DEPLOY_ROLE_ARN` repo variable is already provisioned. Merge before the next prod deploy dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)