### PR TITLE
fix(deploy): rsync --delete so rollbacks reach the box

### DIFF
--- a/.github/workflows/deploy-ai-prod.yml
+++ b/.github/workflows/deploy-ai-prod.yml
@@ -124,7 +124,11 @@ jobs:
           # Excludes mirror deploy.sh; .env/.env.prod are excluded so the box's
           # runtime config (source of truth) is never clobbered. .claude/.mcp.json
           # are excluded so no local agent config / credentials can ride to the box.
-          rsync -az \
+          # --delete propagates file removals/rollbacks to the box (stale files
+          # were otherwise rebaked into the image by `COPY . .`). Safe: the source
+          # is a fresh, complete actions/checkout, and rsync never deletes receiver
+          # files matching an --exclude unless --delete-excluded is set.
+          rsync -az --delete \
             --exclude '.git' --exclude 'node_modules' --exclude '__pycache__' --exclude '*.pyc' \
             --exclude 'dist' --exclude 'build' --exclude '.venv' --exclude 'venv' \
             --exclude '.terraform' --exclude '*.tfstate*' --exclude '.env' --exclude '.env.prod' \


### PR DESCRIPTION
Companion to o-ostrovskiy/storyland-infrastructure#22, which added `--delete` to the laptop `deploy.sh` and the reusable `deploy-service.yml`. This is the storyland-ai copy of the same deploy logic (inlined because a public repo can't call a private reusable workflow), so it needs the same fix or rollbacks still won't propagate on the AI service's deploy path.

Without `--delete`, files removed in a rollback linger in `~/storyland/storyland-ai/` on the box and get rebaked into the image by `COPY . .`.

**Safe:** the rsync source is a fresh, complete `actions/checkout`, and rsync never deletes receiver-side files matching an `--exclude` unless `--delete-excluded` is passed (it isn't) — so `.env.prod`, `.claude`, etc. on the box are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)