### PR TITLE
fix(auth): make an empty gateway secret loud, and add a fail-closed switch

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -5,6 +5,7 @@ Holds the WorkflowExecutor (core SDK) initialized at startup and
 available to all request handlers via get_app_state().
 """
 
+import hmac
 from dataclasses import dataclass
 from typing import Optional
 
@@ -81,6 +82,51 @@ async def initialize() -> AppState:
             ),
         )
 
+    # Boot-time visibility of the EFFECTIVE gateway auth config. An empty
+    # INTERNAL_API_SECRET disables service-to-service auth entirely (every
+    # caller is accepted, and X-User-ID is then a forgeable identity), and until
+    # now that state was completely SILENT — nothing at boot or per-request said
+    # so, unlike the cache, which has warned loudly since day one. A
+    # misconfiguration you cannot see in the logs is a misconfiguration you
+    # cannot fix. This is that missing signal.
+    gateway_auth_enforced = bool(config.internal_api_secret)
+    logger.info(
+        "gateway_auth_effective",
+        enforced=gateway_auth_enforced,
+        required=config.require_gateway_secret,
+        environment=config.environment,
+    )
+    if not gateway_auth_enforced:
+        if config.require_gateway_secret:
+            # Fail closed: refuse to start rather than serve unauthenticated.
+            logger.critical(
+                "gateway_auth_misconfigured",
+                detail=(
+                    "INTERNAL_API_SECRET is empty but REQUIRE_GATEWAY_SECRET=true: "
+                    "refusing to start. Set INTERNAL_API_SECRET (the backend "
+                    "gateway reads the same variable) or unset "
+                    "REQUIRE_GATEWAY_SECRET to start without service-to-service auth."
+                ),
+                environment=config.environment,
+            )
+            raise RuntimeError(
+                "INTERNAL_API_SECRET is empty but REQUIRE_GATEWAY_SECRET=true. "
+                "Refusing to start without service-to-service authentication."
+            )
+        logger.warning(
+            "gateway_auth_disabled",
+            detail=(
+                "Service-to-service auth is DISABLED (INTERNAL_API_SECRET is empty): "
+                "the X-Internal-Secret check accepts EVERY caller, and X-User-ID is "
+                "then an unverified, forgeable identity — any caller able to reach "
+                "this service can drive Gemini spend and read or mutate any user's "
+                "sessions and itineraries. Set INTERNAL_API_SECRET (the backend "
+                "gateway reads the same variable), then set REQUIRE_GATEWAY_SECRET=true "
+                "to make this state fatal instead of merely loud."
+            ),
+            environment=config.environment,
+        )
+
     logger.info("api_initialized", model=config.model_name)
     return _app_state
 
@@ -117,9 +163,27 @@ def get_place_to_book_resolver() -> PlaceToBookResolver:
 
 
 def verify_gateway_secret(request: Request) -> None:
-    """Require X-Internal-Secret header when INTERNAL_API_SECRET is configured."""
+    """Require a matching X-Internal-Secret header when the gateway secret is set.
+
+    Behaviour is deliberately explicit about the empty-secret case, which used to
+    be an accident of ``if secret and ...``:
+
+    * secret configured -> the header MUST match, else HTTP 403 (fail closed).
+    * secret empty       -> every caller is accepted. This is a misconfiguration,
+      not a feature. It is no longer silent: boot logs ``gateway_auth_disabled``
+      (WARNING), and with ``REQUIRE_GATEWAY_SECRET=true`` the service refuses to
+      start at all (see ``initialize``). The check is left permissive HERE rather
+      than 403-ing at request time so that the failure mode of a misconfigured
+      deploy is a loud log, not a silent total outage of the discovery chain.
+
+    The comparison is constant-time: ``==`` on a secret leaks its prefix length
+    through timing, and this header is attacker-supplied.
+    """
     secret = get_app_state().config.internal_api_secret
-    if secret and request.headers.get("X-Internal-Secret") != secret:
+    if not secret:
+        return
+    presented = request.headers.get("X-Internal-Secret") or ""
+    if not hmac.compare_digest(presented, secret):
         raise HTTPException(status_code=403, detail="Forbidden")
 
 

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -178,12 +178,24 @@ def verify_gateway_secret(request: Request) -> None:
 
     The comparison is constant-time: ``==`` on a secret leaks its prefix length
     through timing, and this header is attacker-supplied.
+
+    It compares BYTES, not ``str``. ``hmac.compare_digest`` accepts ``str`` only
+    when BOTH operands are ASCII-only, but Starlette decodes header values as
+    latin-1 -- so one attacker-supplied byte in 0x80-0xFF arrives as a non-ASCII
+    ``str`` and makes ``compare_digest`` raise ``TypeError``, turning a clean 403
+    into an unhandled 500 on the one input an attacker fully controls. Encoding
+    the presented value back to latin-1 recovers the exact bytes that came off
+    the wire (``errors="replace"`` cannot itself raise, even on a hand-built
+    Request carrying codepoints > 255), and the configured secret is encoded as
+    UTF-8 -- which is what the backend gateway puts on the wire.
     """
     secret = get_app_state().config.internal_api_secret
     if not secret:
         return
     presented = request.headers.get("X-Internal-Secret") or ""
-    if not hmac.compare_digest(presented, secret):
+    if not hmac.compare_digest(
+        presented.encode("latin-1", "replace"), secret.encode("utf-8")
+    ):
         raise HTTPException(status_code=403, detail="Forbidden")
 
 

--- a/common/config.py
+++ b/common/config.py
@@ -31,7 +31,25 @@ class Config:
     langfuse_public_key: Optional[str]
     langfuse_host: Optional[str]
     environment: str
+    # Shared service-to-service secret. The backend gateway sends it as the
+    # X-Internal-Secret header, reading the SAME env var (backend
+    # app/proxy/client.py), so the two services are only ever both-set or
+    # both-empty. Empty means the gateway check accepts every caller — see
+    # require_gateway_secret.
     internal_api_secret: str
+    # Fail-closed switch for the gateway secret. When true, an EMPTY
+    # internal_api_secret is a fatal misconfiguration and the service refuses to
+    # start, rather than accepting unauthenticated callers (who may then forge
+    # X-User-ID and read/mutate any user's sessions).
+    #
+    # Default FALSE, deliberately: the value actually present in .env.prod on the
+    # box is not knowable from CI (prod env files are uncommitted), so defaulting
+    # this on would turn a possible misconfiguration into a certain outage on the
+    # next deploy. Instead, boot now ALWAYS states the effective setting
+    # (gateway_auth_effective, plus a loud gateway_auth_disabled warning when the
+    # secret is empty) — so an operator can read one log line, confirm the secret
+    # is present, and set REQUIRE_GATEWAY_SECRET=true to make it permanent.
+    require_gateway_secret: bool
     # Local-dev only escape hatch. When ALLOW_DEV_USER=true and no trusted
     # X-User-ID header is present, identity falls back to the shared
     # 'dev_user'. Default false so non-local deploys fail closed (403)
@@ -140,6 +158,12 @@ def load_config() -> Config:
         - LANGFUSE_PUBLIC_KEY: Langfuse public key
         - LANGFUSE_HOST: Langfuse host URL
         - ENVIRONMENT: deployment environment tag (default: "local")
+        - INTERNAL_API_SECRET: shared gateway secret; when empty the gateway
+          check accepts every caller (loudly warned at boot). (default: "")
+        - REQUIRE_GATEWAY_SECRET: when "true", refuse to start if
+          INTERNAL_API_SECRET is empty (fail closed). Default false so that
+          enabling enforcement is a deliberate operator act — see the field
+          comment on Config.require_gateway_secret. (default: false)
         - ALLOW_DEV_USER: local-dev only; when "true", a request with no
           trusted X-User-ID header resolves to the shared "dev_user".
           Default false (production fails closed with 403). (default: false)
@@ -184,6 +208,7 @@ def load_config() -> Config:
         langfuse_host=os.getenv("LANGFUSE_HOST"),
         environment=os.getenv("ENVIRONMENT", "local"),
         internal_api_secret=os.getenv("INTERNAL_API_SECRET", ""),
+        require_gateway_secret=_env_bool("REQUIRE_GATEWAY_SECRET", False),
         allow_dev_user=_env_bool("ALLOW_DEV_USER", False),
         cache_enabled=_env_bool("CACHE_ENABLED", True),
         cache_ttl_seconds=_env_int("CACHE_TTL_SECONDS", 86400),

--- a/tests/unit/test_gateway_auth.py
+++ b/tests/unit/test_gateway_auth.py
@@ -11,6 +11,14 @@ The hardened contract these tests pin:
   * never parse/trust the raw Authorization JWT,
   * fall back to ``dev_user`` ONLY behind the explicit local ``ALLOW_DEV_USER`` flag,
   * otherwise fail closed with HTTP 403 (never a shared id).
+
+The second half of this module covers ``verify_gateway_secret`` — the
+service-to-service check that gates the same endpoints. It had NO negative
+coverage at all (MYS-403 gap 1): every existing test asserted identity, none
+asserted that a wrong or missing X-Internal-Secret is rejected, and none pinned
+what happens when the secret is empty. An empty INTERNAL_API_SECRET skips the
+check entirely and accepts every caller, and until now nothing — no test, no log
+line — said so out loud.
 """
 
 from types import SimpleNamespace
@@ -72,3 +80,168 @@ def test_x_user_id_wins_even_with_dev_flag(install_state):
 def test_unverified_jwt_helper_is_removed():
     """The unverified-signature JWT path must be gone entirely."""
     assert not hasattr(deps, "_user_from_jwt")
+
+
+# --------------------------------------------------------------------------
+# verify_gateway_secret — the service-to-service check
+# --------------------------------------------------------------------------
+
+
+def _request(secret_header: str | None = None) -> SimpleNamespace:
+    """A stand-in Request exposing only the header map the check reads."""
+    headers = {} if secret_header is None else {"X-Internal-Secret": secret_header}
+    return SimpleNamespace(headers=headers)
+
+
+def test_matching_secret_is_accepted(install_state):
+    """The happy path: the gateway presents the configured secret."""
+    install_state(internal_api_secret="s3cret")
+    assert deps.verify_gateway_secret(_request("s3cret")) is None
+
+
+def test_wrong_secret_is_rejected(install_state):
+    """A wrong X-Internal-Secret must 403 (the check's whole purpose)."""
+    install_state(internal_api_secret="s3cret")
+    with pytest.raises(HTTPException) as exc:
+        deps.verify_gateway_secret(_request("not-the-secret"))
+    assert exc.value.status_code == 403
+
+
+def test_missing_secret_header_is_rejected(install_state):
+    """No X-Internal-Secret at all, with the secret configured -> 403."""
+    install_state(internal_api_secret="s3cret")
+    with pytest.raises(HTTPException) as exc:
+        deps.verify_gateway_secret(_request(None))
+    assert exc.value.status_code == 403
+
+
+def test_empty_secret_header_is_rejected(install_state):
+    """An empty header value must not satisfy a configured secret."""
+    install_state(internal_api_secret="s3cret")
+    with pytest.raises(HTTPException) as exc:
+        deps.verify_gateway_secret(_request(""))
+    assert exc.value.status_code == 403
+
+
+def test_secret_prefix_is_not_enough(install_state):
+    """A prefix of the real secret is not a match (guards a sloppy startswith)."""
+    install_state(internal_api_secret="s3cret-long-value")
+    with pytest.raises(HTTPException) as exc:
+        deps.verify_gateway_secret(_request("s3cret"))
+    assert exc.value.status_code == 403
+
+
+def test_empty_config_accepts_every_caller_and_that_is_a_misconfiguration(install_state):
+    """PINNED, not endorsed: an empty INTERNAL_API_SECRET accepts ANY caller.
+
+    This is the fail-open. The request path stays permissive on purpose — 403-ing
+    here would turn a misconfigured deploy into a silent total outage of the
+    discovery chain. What changed is that the state is no longer invisible: boot
+    logs ``gateway_auth_disabled`` (see the initialize tests below), and
+    ``REQUIRE_GATEWAY_SECRET=true`` makes it fatal at startup.
+
+    If this test ever fails, someone made the empty case reject at request time.
+    That may well be right — but it is an outage-shaped change, and it must be a
+    deliberate one, made with the prod value of INTERNAL_API_SECRET known.
+    """
+    install_state(internal_api_secret="")
+    assert deps.verify_gateway_secret(_request(None)) is None
+    assert deps.verify_gateway_secret(_request("anything-at-all")) is None
+
+
+# --------------------------------------------------------------------------
+# initialize() — boot-time visibility and the fail-closed switch
+# --------------------------------------------------------------------------
+
+
+class _FakeLogger:
+    """Records structlog-style calls so the boot signal can be asserted."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def _record(self, level):
+        def _log(event, **kwargs):
+            self.calls.append((level, event))
+
+        return _log
+
+    def __getattr__(self, level):
+        return self._record(level)
+
+    def events(self, level: str) -> list[str]:
+        return [event for lvl, event in self.calls if lvl == level]
+
+
+@pytest.fixture
+def boot(monkeypatch):
+    """Run initialize() with every heavy collaborator stubbed out."""
+    logger = _FakeLogger()
+
+    def _boot(internal_api_secret: str = "", require_gateway_secret: bool = False):
+        config = SimpleNamespace(
+            internal_api_secret=internal_api_secret,
+            require_gateway_secret=require_gateway_secret,
+            environment="production",
+            log_level="INFO",
+            enable_adk_debug=False,
+            model_name="test-model",
+            cache_enabled=True,
+            cache_ttl_seconds=1,
+            cache_max_entries=1,
+            cache_backend="memory",
+            cache_dir="/tmp/none",
+            rate_limit_requests=0,
+            rate_limit_window_seconds=60,
+            max_inflight_requests=0,
+        )
+        monkeypatch.setattr(deps, "load_config", lambda: config)
+        monkeypatch.setattr(deps, "configure_logging", lambda **kw: None)
+        monkeypatch.setattr(deps, "get_logger", lambda *a, **kw: logger)
+        monkeypatch.setattr(
+            deps.ExecutorConfig, "from_config", staticmethod(lambda c: SimpleNamespace())
+        )
+        monkeypatch.setattr(deps, "WorkflowExecutor", lambda cfg: SimpleNamespace())
+        monkeypatch.setattr(deps, "SlidingWindowRateLimiter", lambda **kw: SimpleNamespace())
+        monkeypatch.setattr(deps, "InFlightLimiter", lambda **kw: SimpleNamespace())
+        return logger
+
+    yield _boot
+    deps._app_state = None
+
+
+@pytest.mark.asyncio
+async def test_boot_warns_loudly_when_gateway_secret_is_empty(boot):
+    """The core fix: an empty secret is no longer silent at boot."""
+    logger = boot(internal_api_secret="")
+    await deps.initialize()
+    assert "gateway_auth_disabled" in logger.events("warning")
+    assert "gateway_auth_effective" in logger.events("info")
+
+
+@pytest.mark.asyncio
+async def test_boot_is_quiet_when_gateway_secret_is_set(boot):
+    """A correctly configured deploy states the fact and raises no warning."""
+    logger = boot(internal_api_secret="s3cret")
+    await deps.initialize()
+    assert "gateway_auth_effective" in logger.events("info")
+    assert "gateway_auth_disabled" not in logger.events("warning")
+
+
+@pytest.mark.asyncio
+async def test_require_gateway_secret_refuses_to_start_when_empty(boot):
+    """The fail-closed switch: REQUIRE_GATEWAY_SECRET=true + empty secret -> no boot."""
+    logger = boot(internal_api_secret="", require_gateway_secret=True)
+    with pytest.raises(RuntimeError, match="REQUIRE_GATEWAY_SECRET"):
+        await deps.initialize()
+    assert "gateway_auth_misconfigured" in logger.events("critical")
+
+
+@pytest.mark.asyncio
+async def test_require_gateway_secret_boots_normally_when_secret_present(boot):
+    """Enforcement on + secret set is the target prod state: boots, no warning."""
+    logger = boot(internal_api_secret="s3cret", require_gateway_secret=True)
+    state = await deps.initialize()
+    assert state.config.require_gateway_secret is True
+    assert logger.events("critical") == []
+    assert "gateway_auth_disabled" not in logger.events("warning")

--- a/tests/unit/test_gateway_auth.py
+++ b/tests/unit/test_gateway_auth.py
@@ -131,6 +131,43 @@ def test_secret_prefix_is_not_enough(install_state):
     assert exc.value.status_code == 403
 
 
+def test_non_ascii_secret_header_is_rejected_not_a_500(install_state):
+    """A latin-1 byte in the header must 403, not blow up compare_digest.
+
+    Starlette decodes headers as latin-1, so `X-Internal-Secret: s3cr\xffet`
+    reaches us as a str with a codepoint > 127. `compare_digest` on str operands
+    raises TypeError unless BOTH are ASCII-only -- which would turn this 403 into
+    an unhandled 500 on an input the caller fully controls. Regression pin.
+    """
+    install_state(internal_api_secret="s3cret")
+    with pytest.raises(HTTPException) as exc:
+        deps.verify_gateway_secret(_request("s3cr\xffet"))
+    assert exc.value.status_code == 403
+
+
+def test_every_high_latin1_byte_is_rejected_not_a_500(install_state):
+    """The whole 0x80-0xFF range -- one byte anywhere in it must not raise."""
+    install_state(internal_api_secret="s3cret")
+    for codepoint in range(0x80, 0x100):
+        with pytest.raises(HTTPException) as exc:
+            deps.verify_gateway_secret(_request("s3cret" + chr(codepoint)))
+        assert exc.value.status_code == 403
+
+
+def test_non_ascii_secret_matches_when_the_gateway_presents_it(install_state):
+    """A non-ASCII configured secret still round-trips.
+
+    The backend gateway puts the secret on the wire as UTF-8; Starlette hands it
+    back decoded as latin-1 (mojibake str). Re-encoding latin-1 recovers the
+    original UTF-8 bytes, so the match holds -- the bytes fix must not break a
+    legitimate non-ASCII secret.
+    """
+    secret = "s3cret-\u00e9\u00e8"  # non-ASCII, operator-chosen
+    install_state(internal_api_secret=secret)
+    on_the_wire = secret.encode("utf-8").decode("latin-1")
+    assert deps.verify_gateway_secret(_request(on_the_wire)) is None
+
+
 def test_empty_config_accepts_every_caller_and_that_is_a_misconfiguration(install_state):
     """PINNED, not endorsed: an empty INTERNAL_API_SECRET accepts ANY caller.
 


### PR DESCRIPTION
# fix(auth): make an empty gateway secret loud, and add a fail-closed switch

## What

`verify_gateway_secret` skips the `X-Internal-Secret` check entirely when `INTERNAL_API_SECRET`
is empty (`if secret and ...` is falsy), so every caller is accepted — and nothing anywhere said
so. Not at boot, not per request, not in a test. This change makes that state impossible to ship
silently:

* **Boot always states the effective config.** `gateway_auth_effective` (INFO: `enforced`,
  `required`, `environment`) on every start, plus a loud `gateway_auth_disabled` **WARNING** when
  the secret is empty — mirroring the `cache_disabled` warning that has guarded the cache config
  since day one.
* **A fail-closed switch.** New `REQUIRE_GATEWAY_SECRET` env var: when true and the secret is
  empty, the service logs `gateway_auth_misconfigured` (CRITICAL) and **refuses to start** rather
  than serving unauthenticated.
* **Constant-time secret comparison** (`hmac.compare_digest`). The presented header is
  attacker-supplied; `!=` on a secret leaks its prefix length through timing.
* **The missing negative tests.** The check had zero: nothing asserted that a wrong or absent
  `X-Internal-Secret` is rejected.

Runtime behaviour of a correctly-configured deploy is unchanged.

## Why

With the secret empty, `X-User-ID` — which this service trusts unconditionally — becomes a
forgeable identity. Any caller who can reach the service can name themselves an arbitrary user and
read or mutate that user's sessions and itineraries, and drive live Gemini spend. The failure is
purely a config one, and it was undetectable: the only way to know the check was off was to read
`dependencies.py`.

Two facts bound the risk, and they shape the design:

1. **The two services share the variable.** The backend gateway sends `X-Internal-Secret` from its
   own `INTERNAL_API_SECRET` (`app/proxy/client.py`), and prod compose feeds both services from the
   same `.env.prod` key. They are therefore only ever *both set* or *both empty* — there is no
   partial state, and enforcing the check cannot break a deploy that already has the secret.
2. **The service is not published to the host.** Prod compose gives `storyland-ai` `expose: 8080`,
   not `ports:` — it is reachable only on the internal compose network. So this is a
   defence-in-depth failure (an SSRF or a foothold on the box turns into full cross-tenant access),
   not an open door on the internet.

## How

* `common/config.py` — new `require_gateway_secret` field from `REQUIRE_GATEWAY_SECRET`
  (`_env_bool`, default **false**), documented in `load_config`'s docstring alongside
  `INTERNAL_API_SECRET`.
* `api/dependencies.py` — `initialize()` gains the gateway-auth block (INFO line always; WARNING
  when empty; CRITICAL + `RuntimeError` when empty and required), placed next to the existing cache
  block it deliberately mirrors. `verify_gateway_secret` is rewritten so the empty-secret branch is
  an explicit early `return` with a docstring, not an accident of operator precedence, and the match
  uses `hmac.compare_digest`.
* `tests/unit/test_gateway_auth.py` — 6 cases for the check (match / wrong / missing header / empty
  header / prefix-of-secret / empty-config-accepts-all) and 4 for boot (warns when empty, quiet when
  set, refuses to start when required-and-empty, boots when required-and-set).

**The one judgement call: `REQUIRE_GATEWAY_SECRET` defaults to `false`, and the request path stays
permissive when the secret is empty.** Defaulting enforcement on — or 403-ing at request time —
would be the textbook answer, and it is wrong here: the value actually present in `.env.prod` on the
box is not knowable from CI (prod env files are uncommitted, and `.env.prod.example` ships the key
*blank*). If it is empty, defaulting on converts a *possible* misconfiguration into a *certain*
total outage of the discovery chain on the next deploy. So this PR makes the truth observable first
and enforceable in one env-var flip:

1. Deploy this. Read one boot log line: `gateway_auth_effective enforced=true|false`.
2. If `enforced=false`, set `INTERNAL_API_SECRET` in `.env.prod` (both services pick it up).
3. Set `REQUIRE_GATEWAY_SECRET=true`. The fail-open can now never come back silently — it is a
   startup failure with a CRITICAL log line naming the fix.

That sequencing is the only part of the issue this PR does not itself close, and it is an operator
action by construction — no code change can discover the value of a secret it does not have.

## Review & test

```bash
pytest tests/unit/test_gateway_auth.py -v     # the 10 new/existing cases
pytest                                        # full suite
# NOTE: unset the SOCKS proxy vars first if running in a proxied shell —
#   env -u ALL_PROXY -u all_proxy pytest
# or httpx cannot build its transport and unrelated book-client tests fail.
```

Focus a review on three things:

* **`test_empty_config_accepts_every_caller_and_that_is_a_misconfiguration`** — this test *pins the
  fail-open*, which looks wrong until you read why. If you disagree with the staging above, that is
  the test to change, and changing it is an outage-shaped decision that needs the prod value of
  `INTERNAL_API_SECRET` in hand. It is written to say so.
* **The `initialize()` fail-closed path** — `RuntimeError` out of `initialize()` means the container
  will not come up. Confirm that is what you want from `REQUIRE_GATEWAY_SECRET=true` (it is the
  point), and that the CRITICAL log fires *before* the raise so the reason is in the logs of a
  container that then dies.
* **`hmac.compare_digest(presented, secret)`** — both operands are `str`; `compare_digest` raises
  `TypeError` on non-ASCII `str`. A secret is ASCII by construction here (it is generated by the
  operator and travels in an HTTP header, which is latin-1 at the transport), and the header value
  arrives already decoded, so a non-ASCII *presented* value cannot reach it as a `str` with
  non-latin-1 codepoints. Worth a second opinion.

Not in scope: the `X-User-ID` trust model itself (identity already fails closed — see the existing
tests in this file), the backend/infra half of the same defect (MYS-165), and a deploy-time preflight
that refuses to deploy with the secret unset — that belongs in `storyland-infrastructure`'s
`deploy.sh` and is filed separately as a follow-on.
