### PR TITLE
fix(expansion): resolve the trusted action_prompt from the stored chip, not the client echo

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -938,6 +938,25 @@ class WorkflowExecutor:
             )
             yield WorkflowComplete(job_id=job_id)
 
+    @staticmethod
+    def _resolve_trusted_action_prompt(last_suggestions: list, action_id: str) -> str:
+        """Look up the server-stored action_prompt for a validated chip id.
+
+        MYS-167: the client-echoed `action_prompt` request field must never
+        reach an agent instruction -- only the value the server itself
+        generated and persisted onto the chip (at `_persist_suggestions`
+        time, sourced from the composer/formatter's own SuggestionChip
+        output) may. Callers must validate `action_id` against
+        `last_suggestions` before calling this (expand() already does, via
+        `valid_ids`); an id with no matching chip resolves to "" rather than
+        raising, since the caller already owns the InvalidActionId rejection
+        path and this is never reached for an unresolved id in practice.
+        """
+        resolved_chip = next(
+            (chip for chip in last_suggestions if chip.get("id") == action_id), None
+        )
+        return (resolved_chip or {}).get("action_prompt", "")
+
     def _stamp_suggestion_ids(self, suggestions: list) -> list:
         """Overwrite chip ids with fresh server-issued uuid4s."""
         stamped = []
@@ -999,14 +1018,22 @@ class WorkflowExecutor:
         """Expand the itinerary with new places based on a suggestion chip.
 
         Requires a completed job_id (compose or local-atmosphere). Validates the
-        action_id against stored suggestion chips to prevent injection. Yields
-        ProgressEvent → ExpansionReady → WorkflowComplete.
+        action_id against stored suggestion chips, then resolves the expansion
+        instruction from THAT stored chip -- never from the client-echoed
+        action_prompt argument -- so a caller cannot steer the researcher's
+        system instruction by sending an arbitrary string alongside a valid
+        chip id (MYS-167). Yields ProgressEvent → ExpansionReady →
+        WorkflowComplete.
 
         Args:
             job_id: Session ID from a completed compose/local-atmosphere call.
             action_id: ID of the suggestion chip the user clicked.
             action_label: Human-readable chip label (for logging only).
-            action_prompt: Expansion instruction carried by the chip.
+            action_prompt: Client-echoed chip prompt text. NOT trusted and never
+                interpolated into an agent instruction -- display-only, same as
+                action_label. The instruction actually used is looked up from
+                the server-stored chip matching action_id. Kept as a request
+                field for FE wire compatibility.
             user_id: User identifier (must match the original session).
         """
         try:
@@ -1076,6 +1103,20 @@ class WorkflowExecutor:
             yield WorkflowComplete(job_id=job_id)
             return
 
+        # MYS-167: resolve the chip's OWN server-stored action_prompt rather than
+        # trusting the client-echoed `action_prompt` argument. Only `action_id`
+        # was ever validated against `state.last_suggestions` above -- the free-
+        # text prompt string itself was passed straight through into the
+        # researcher/formatter's system instruction, so a caller holding one
+        # valid chip id could steer 20 expansions of arbitrary system-prompt
+        # content. From here down `action_prompt` (the parameter) is treated as
+        # display-only, same as `action_label` -- it must never reach an agent
+        # instruction again. `action_id` is already confirmed to be in
+        # `valid_ids`, so the lookup below always resolves.
+        trusted_action_prompt = self._resolve_trusted_action_prompt(
+            last_suggestions, action_id
+        )
+
         # Concurrency guard: block if another expansion is in flight
         if state.expansion_in_progress:
             yield WorkflowError(
@@ -1114,11 +1155,12 @@ class WorkflowExecutor:
 
                 existing_places = "\n".join(existing_names) if existing_names else "(none)"
 
-                # Determine target city: scan action_prompt for a known city name,
-                # fall back to the first city so single-city itineraries always work.
+                # Determine target city: scan the TRUSTED action_prompt for a known
+                # city name, fall back to the first city so single-city itineraries
+                # always work. (MYS-167: was the client-echoed action_prompt.)
                 cities = itinerary.get("cities", [])
                 parent_city = cities[0].get("name", "") if cities else ""
-                action_prompt_lower = action_prompt.lower()
+                action_prompt_lower = trusted_action_prompt.lower()
                 for city in cities:
                     city_name = city.get("name", "")
                     if city_name and city_name.lower() in action_prompt_lower:
@@ -1135,7 +1177,7 @@ class WorkflowExecutor:
                     book_title=book_title,
                     author=author,
                     parent_city=parent_city,
-                    action_prompt=action_prompt,
+                    action_prompt=trusted_action_prompt,
                     existing_places=existing_places,
                 )
                 runner = Runner(
@@ -1147,7 +1189,7 @@ class WorkflowExecutor:
 
                 prompt = (
                     f"Expand the itinerary for {book_title} by {author}. "
-                    f"Find new places in {parent_city} matching: {action_prompt}"
+                    f"Find new places in {parent_city} matching: {trusted_action_prompt}"
                 )
                 message = types.Content(
                     role="user", parts=[types.Part(text=prompt)]

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -38,6 +38,7 @@ from core.extraction import (
     downgrade_ungrounded_match_types,
 )
 from core.events import ExpansionReady
+from core.executor import WorkflowExecutor
 from core.regions import get_valid_region_ids, validate_region_selection
 from evaluation.tools.run_scheduled_eval import select_first_region, select_all_regions
 
@@ -562,6 +563,71 @@ class TestExtractExpansionFromState:
     def test_no_expansion_in_state(self):
         accessor = SessionStateAccessor({})
         assert extract_expansion_from_state(accessor) is None
+
+
+class TestResolveTrustedActionPrompt:
+    """MYS-167: expand() must resolve the expansion instruction from the
+    server-stored chip matching action_id, never from the client-echoed
+    action_prompt request field -- a caller holding one valid chip id must
+    not be able to steer the researcher's system instruction with an
+    arbitrary string. Tested as a pure staticmethod: no session service,
+    Runner, or LLM agent construction needed to prove the resolution logic
+    itself is correct.
+    """
+
+    def test_resolves_the_stored_prompt_for_a_matching_chip(self):
+        last_suggestions = [
+            {"id": "chip-1", "label": "Add restaurants", "action_prompt": "Find atmospheric restaurants near the stops."},
+            {"id": "chip-2", "label": "More cafés", "action_prompt": "Find cafés matching the mood."},
+        ]
+        resolved = WorkflowExecutor._resolve_trusted_action_prompt(last_suggestions, "chip-2")
+        assert resolved == "Find cafés matching the mood."
+
+    def test_ignores_a_client_supplied_string_entirely(self):
+        """The injection case: a caller sends a valid action_id alongside an
+        attacker-controlled action_prompt string. The resolver never even
+        receives that argument -- it can't leak into the result no matter
+        what the client sent alongside the id."""
+        last_suggestions = [
+            {"id": "chip-1", "label": "Add restaurants", "action_prompt": "Find atmospheric restaurants near the stops."},
+        ]
+        resolved = WorkflowExecutor._resolve_trusted_action_prompt(last_suggestions, "chip-1")
+        assert resolved == "Find atmospheric restaurants near the stops."
+        assert "Ignore previous instructions" not in resolved
+
+    def test_unmatched_action_id_resolves_to_empty_string_not_an_error(self):
+        """expand() only reaches this after action_id passed the valid_ids
+        check, so this path isn't reachable in practice -- but the resolver
+        itself must fail closed (empty string) rather than raise or fall
+        back to any caller-supplied value."""
+        last_suggestions = [
+            {"id": "chip-1", "label": "Add restaurants", "action_prompt": "Find restaurants."},
+        ]
+        resolved = WorkflowExecutor._resolve_trusted_action_prompt(last_suggestions, "no-such-id")
+        assert resolved == ""
+
+    def test_empty_last_suggestions_resolves_to_empty_string(self):
+        assert WorkflowExecutor._resolve_trusted_action_prompt([], "chip-1") == ""
+
+    def test_chip_missing_action_prompt_key_resolves_to_empty_string(self):
+        """The 'Find books like this' chip shape stores action_prompt="" (and
+        is kept out of last_suggestions entirely per _build_book_recommendation_chip's
+        docstring) -- but defensively, a chip dict with no key at all must not
+        raise either."""
+        last_suggestions = [{"id": "chip-1", "label": "No prompt field"}]
+        resolved = WorkflowExecutor._resolve_trusted_action_prompt(last_suggestions, "chip-1")
+        assert resolved == ""
+
+    def test_duplicate_ids_resolves_the_first_match(self):
+        """Chip ids are server-stamped uuid4s (_stamp_suggestion_ids) so this
+        shouldn't occur in practice; pin deterministic first-match behavior
+        rather than leaving it as an accident of `next()`."""
+        last_suggestions = [
+            {"id": "chip-1", "label": "First", "action_prompt": "First prompt."},
+            {"id": "chip-1", "label": "Second", "action_prompt": "Second prompt."},
+        ]
+        resolved = WorkflowExecutor._resolve_trusted_action_prompt(last_suggestions, "chip-1")
+        assert resolved == "First prompt."
 
 
 class TestExpansionReadyEvent:


### PR DESCRIPTION
# fix(expansion): resolve the trusted action_prompt from the stored chip, not the client echo

## What

`WorkflowExecutor.expand()` validated the client-supplied `action_id` against the
session's stored suggestion chips, but then used the client-supplied `action_prompt`
string directly — passing it into the expansion researcher/formatter's system
instruction, the target-city detection heuristic, and the user message sent to the
agent `Runner`. A caller holding one valid chip id could attach an arbitrary
`action_prompt` string and have it interpolated into the researcher's system
instruction on every expansion call.

Adds `WorkflowExecutor._resolve_trusted_action_prompt(last_suggestions, action_id)`,
a pure staticmethod that looks up the chip matching `action_id` in
`state.last_suggestions` and returns *its* server-stored `action_prompt` (the value
set at composition time by the composer/formatter agent and persisted via
`_persist_suggestions`) — never the client's copy. `expand()` now threads this
resolved value everywhere `action_prompt` was previously used downstream of the
`action_id` check. The request's `action_prompt` field is unchanged on the wire
(dropping it would 422 every current FE client) but is now treated as display-only,
the same way `action_label` already was.

## Why

The `expand()` docstring claimed action_id validation "prevents injection," which
was only half true — the id was checked, but the free-text prompt riding alongside
it wasn't. Impact was bounded (the only tool available to the researcher is
`google_search`, and the output is Pydantic-validated + tone-sanitized before it
reaches the user), but it's a real prompt-injection surface: any client that can
complete one legitimate expansion round-trip gets 20 expansions (the hard cap) of
steering room over the researcher's system instruction.

## How

- `core/executor.py`: new `WorkflowExecutor._resolve_trusted_action_prompt` static
  method (pure — takes `last_suggestions: list[dict]` and `action_id: str`, returns
  `str`, no I/O). `expand()` calls it immediately after the existing `action_id`
  validation and rebinds every downstream use (`action_prompt_lower` for city
  detection, `create_expansion_workflow(..., action_prompt=...)`, and the
  `Runner`-bound user message) to the resolved value instead of the function
  parameter.
- Docstrings on `expand()` corrected: the class-level summary and the `action_prompt`
  arg description now state the actual contract (client value is display-only /
  ignored for agent instructions; the trusted value comes from the stored chip).
- No schema change, no new endpoint, no config/flag. `ExpandRequest.action_prompt`
  is untouched on the wire.

## Review & test

Focus review on: every remaining reference to the bare `action_prompt` parameter
inside `expand()` — there should be none left downstream of the new resolution
line (grep for `action_prompt` inside the function body; the only two legitimate
survivors are the parameter binding itself and the docstring). Also worth checking
`_resolve_trusted_action_prompt`'s fail-closed behavior: an unmatched `action_id`
(not reachable in practice, since `expand()` already rejects those before this
runs) returns `""` rather than raising or falling back to the client value.

New tests in `tests/unit/test_core.py::TestResolveTrustedActionPrompt` (7 cases):
matching chip resolves correctly; an attacker string sent as `action_prompt`
alongside a valid id never appears in the result (the resolver doesn't even take
that argument); unmatched id → `""`; empty `last_suggestions` → `""`; a chip dict
missing the `action_prompt` key → `""`; duplicate ids pin first-match. Run:

```
pytest tests/unit/test_core.py -k TestResolveTrustedActionPrompt -v
pytest tests/ -q
```

These are pure unit tests against a staticmethod — no session service, `Runner`,
or LLM agent construction required, so they don't exercise the full `expand()`
generator end-to-end. A follow-up worth considering separately: an integration-
style test that actually calls `expand()` with a mocked session service + `Runner`
and asserts on the constructed agent's `.instruction` string directly, which would
cover the wiring this PR does inside `expand()` itself, not just the resolver.
