### PR TITLE
fix(ai): scope LangfusePlugin generation/agent-stack/span state per ParallelAgent branch, not shared scalars

### DIFF
--- a/plugins/langfuse_plugin.py
+++ b/plugins/langfuse_plugin.py
@@ -46,9 +46,16 @@ def _pricing_for(model_name: str) -> tuple[float, float]:
     if not model_name:
         return _GEMINI_DEFAULT_PRICING
     lower = model_name.lower()
-    for key, rates in _GEMINI_PRICING.items():
+    # MYS-398 follow-up: match longest key first. `_GEMINI_PRICING` is
+    # keyed by substring ("key in lower"), and "gemini-2.5-flash" is
+    # itself a substring of "gemini-2.5-flash-lite" -- checking keys in
+    # plain insertion order let the shorter, wrong entry match first, so
+    # every flash-lite call was silently priced at the plain-flash rate
+    # (pre-existing, caught by the MYS-398 concurrency test asserting two
+    # different flash variants' costs side by side for the first time).
+    for key in sorted(_GEMINI_PRICING, key=len, reverse=True):
         if key in lower:
-            return rates
+            return _GEMINI_PRICING[key]
     return _GEMINI_DEFAULT_PRICING
 
 
@@ -112,10 +119,18 @@ class LangfusePlugin(BasePlugin):
         self._token_usage = TokenUsage()
         self._total_cost_usd: float = 0.0
         self._current_trace = None
-        self._current_generation = None
-        self._current_model: str = ""
-        self._agent_stack = []  # Track nested agent calls
-        self._current_span = None
+        # MYS-398: discovery's parallel_discovery ParallelAgent runs three
+        # sub-agent branches (city/landmark/author pipelines) concurrently
+        # against this ONE plugin instance (core/executor.py creates one
+        # LangfusePlugin per workflow *run*, not per sub-agent). The fields
+        # below used to be shared scalars/a single LIFO list, so an
+        # interleaved before_model/after_model pair from one branch could
+        # overwrite or pop state that belonged to a different, still-open
+        # branch -- see _branch_key() for how they're now scoped per branch.
+        self._generations: dict[str, Any] = {}  # branch key -> open generation observation
+        self._models: dict[str, str] = {}  # branch key -> model name of the open generation
+        self._agent_stacks: dict[str, list] = {}  # branch key -> that branch's own LIFO agent stack
+        self._spans: dict[str, Any] = {}  # branch key -> open tool span
         self._propagation_cm = None
 
         if not LANGFUSE_AVAILABLE:
@@ -138,6 +153,36 @@ class LangfusePlugin(BasePlugin):
         else:
             logger.info("langfuse_disabled", reason="missing_credentials")
             self.enabled = False
+
+    @staticmethod
+    def _branch_key(callback_context: CallbackContext) -> str:
+        """Per-concurrent-call key so parallel sub-agent branches never
+        share the same generation/agent-stack/span slot (MYS-398).
+
+        ADK's own ParallelAgent already solves this problem for itself:
+        every sub-agent gets a private InvocationContext copy carrying a
+        unique, stable `branch` string for the sub-agent's entire run (see
+        google.adk.agents.parallel_agent._create_branch_ctx_for_sub_agent,
+        e.g. "parallel_discovery.city_pipeline"). Nested SequentialAgent
+        steps within a branch (research -> format) do not fork a new
+        branch, so they safely share one key -- only ParallelAgent forks,
+        and this plugin only needs to isolate exactly that boundary.
+
+        `branch` has no public accessor on Context/CallbackContext, so this
+        reads the private `_invocation_context` attribute directly; that's
+        a real coupling to google-adk's internals, which is why the repo
+        pins `google-adk[eval]>=1.33.0,<2` (tested 1.x line, no silent
+        jump to a breaking 2.x). Falls back to a constant key when `branch`
+        is unset (sequential-only paths, and the try/except below in case a
+        future ADK version renames the attribute) -- a single shared key is
+        exactly what non-parallel invocations already had, and correct for
+        them since there's never more than one in-flight generation there.
+        """
+        try:
+            branch = callback_context._invocation_context.branch
+        except AttributeError:
+            branch = None
+        return branch or "_root"
 
     async def on_user_message_callback(
         self,
@@ -197,8 +242,9 @@ class LangfusePlugin(BasePlugin):
                     "callback_context": str(callback_context),
                 },
             )
-            self._agent_stack.append((agent_name, span))
-            logger.debug("langfuse_agent_start", agent=agent_name)
+            key = self._branch_key(callback_context)
+            self._agent_stacks.setdefault(key, []).append((agent_name, span))
+            logger.debug("langfuse_agent_start", agent=agent_name, branch=key)
         except Exception as e:
             logger.warning("langfuse_agent_start_error", error=str(e), error_type=type(e).__name__)
 
@@ -212,10 +258,14 @@ class LangfusePlugin(BasePlugin):
             return None
 
         try:
-            if self._agent_stack:
-                agent_name, span = self._agent_stack.pop()
+            key = self._branch_key(callback_context)
+            stack = self._agent_stacks.get(key)
+            if stack:
+                agent_name, span = stack.pop()
+                if not stack:
+                    self._agent_stacks.pop(key, None)
                 span.end()
-                logger.debug("langfuse_agent_complete", agent=agent_name)
+                logger.debug("langfuse_agent_complete", agent=agent_name, branch=key)
         except Exception as e:
             logger.warning("langfuse_agent_complete_error", error=str(e), error_type=type(e).__name__)
 
@@ -230,20 +280,23 @@ class LangfusePlugin(BasePlugin):
 
         try:
             model_name = getattr(llm_request, 'model', 'unknown_model') or 'unknown_model'
-            self._current_model = model_name
+            key = self._branch_key(callback_context)
+            self._models[key] = model_name
 
-            # Create generation tracking under the current agent span or trace span
-            parent = self._agent_stack[-1][1] if self._agent_stack else self._current_trace
-            self._current_generation = parent.start_observation(
+            # Create generation tracking under the current agent span (this
+            # branch's own stack top) or the shared trace span.
+            stack = self._agent_stacks.get(key) or []
+            parent = stack[-1][1] if stack else self._current_trace
+            self._generations[key] = parent.start_observation(
                 as_type="generation",
                 name=f"{model_name}_call",
                 model=model_name,
                 input=str(llm_request),
                 metadata={
-                    "agent": self._agent_stack[-1][0] if self._agent_stack else "unknown",
+                    "agent": stack[-1][0] if stack else "unknown",
                 },
             )
-            logger.debug("langfuse_model_request", model=model_name)
+            logger.debug("langfuse_model_request", model=model_name, branch=key)
         except Exception as e:
             logger.warning("langfuse_model_request_error", error=str(e), error_type=type(e).__name__)
 
@@ -257,23 +310,30 @@ class LangfusePlugin(BasePlugin):
 
         This is where we capture actual token counts from Gemini API.
         """
-        if not self.enabled or not self.client or not self._current_generation:
+        key = self._branch_key(callback_context)
+        generation = self._generations.get(key)
+        if not self.enabled or not self.client or not generation:
             return None
 
         try:
             # Extract token usage from response
             usage = self._extract_token_usage(llm_response)
+            model_name = self._models.get(key, "")
 
             if usage:
-                # Update running totals
+                # Update running totals. Plain += on dataclass fields/floats
+                # is safe to share across branches: asyncio is single-
+                # threaded and these statements contain no `await`, so each
+                # increment runs to completion without interleaving with
+                # another branch's increment.
                 self._token_usage.input_tokens += usage.input_tokens
                 self._token_usage.output_tokens += usage.output_tokens
                 self._token_usage.total_tokens += usage.total_tokens
 
-                cost = _calculate_cost(usage.input_tokens, usage.output_tokens, self._current_model)
+                cost = _calculate_cost(usage.input_tokens, usage.output_tokens, model_name)
                 self._total_cost_usd += cost
-                input_rate, output_rate = _pricing_for(self._current_model)
-                self._current_generation.update(
+                input_rate, output_rate = _pricing_for(model_name)
+                generation.update(
                     output=str(llm_response),
                     usage_details={
                         "input": usage.input_tokens,
@@ -295,10 +355,12 @@ class LangfusePlugin(BasePlugin):
                     input_tokens=usage.input_tokens,
                     output_tokens=usage.output_tokens,
                     cost_usd=cost,
+                    branch=key,
                 )
 
-            self._current_generation.end()
-            self._current_generation = None
+            generation.end()
+            self._generations.pop(key, None)
+            self._models.pop(key, None)
         except Exception as e:
             logger.warning("langfuse_model_response_error", error=str(e), error_type=type(e).__name__)
 
@@ -356,8 +418,10 @@ class LangfusePlugin(BasePlugin):
 
         try:
             tool_name = getattr(tool, 'name', 'unknown_tool')
-            parent = self._agent_stack[-1][1] if self._agent_stack else self._current_trace
-            self._current_span = parent.start_observation(
+            key = self._branch_key(tool_context)
+            stack = self._agent_stacks.get(key) or []
+            parent = stack[-1][1] if stack else self._current_trace
+            self._spans[key] = parent.start_observation(
                 as_type="span",
                 name=f"tool_{tool_name}",
                 metadata={
@@ -366,7 +430,7 @@ class LangfusePlugin(BasePlugin):
                     "tool_args": str(tool_args),
                 },
             )
-            logger.debug("langfuse_tool_start", tool=tool_name)
+            logger.debug("langfuse_tool_start", tool=tool_name, branch=key)
         except Exception as e:
             logger.warning("langfuse_tool_start_error", error=str(e), error_type=type(e).__name__)
 
@@ -381,15 +445,17 @@ class LangfusePlugin(BasePlugin):
         result: dict,
     ) -> Optional[dict]:
         """Track tool execution completion."""
-        if not self.enabled or not self.client or not self._current_span:
+        key = self._branch_key(tool_context)
+        span = self._spans.get(key)
+        if not self.enabled or not self.client or not span:
             return None
 
         try:
             tool_name = getattr(tool, 'name', 'unknown_tool')
-            self._current_span.update(output=str(result))
-            self._current_span.end()
-            self._current_span = None
-            logger.debug("langfuse_tool_complete", tool=tool_name)
+            span.update(output=str(result))
+            span.end()
+            self._spans.pop(key, None)
+            logger.debug("langfuse_tool_complete", tool=tool_name, branch=key)
         except Exception as e:
             logger.warning("langfuse_tool_complete_error", error=str(e), error_type=type(e).__name__)
 

--- a/tests/unit/test_langfuse_plugin_concurrency.py
+++ b/tests/unit/test_langfuse_plugin_concurrency.py
@@ -1,0 +1,191 @@
+"""Unit tests for LangfusePlugin's per-branch state isolation (MYS-398).
+
+core/executor.py creates ONE LangfusePlugin instance per workflow run, and
+agents/orchestrator.py's discovery_workflow runs three sub-agent pipelines
+(city/landmark/author) concurrently under a single ParallelAgent
+(parallel_discovery). Before this fix, before_model_callback/
+after_model_callback/before_agent_callback/after_agent_callback tracked their
+"current" generation, model name, and agent stack in shared scalars/a single
+LIFO list on the plugin instance -- so an interleaved callback pair from one
+branch could clobber state that belonged to a different, still-open branch.
+
+These are true unit tests of the plugin's internal state machine: they build
+minimal fakes for the pieces the plugin actually touches (a
+callback_context whose only relevant attribute is
+._invocation_context.branch -- the same field ADK's own ParallelAgent uses
+to isolate concurrent sub-agent branches, see
+google.adk.agents.parallel_agent._create_branch_ctx_for_sub_agent -- plus
+fake llm_request/llm_response/agent objects and a fake Langfuse
+"observation") rather than constructing real ADK Runner/agent graphs, which
+need live Google credentials -- that end-to-end path is already covered by
+tests/integration/test_langfuse_integration.py.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from plugins.langfuse_plugin import LangfusePlugin
+
+
+class FakeObservation:
+    """Stands in for a Langfuse generation/span observation."""
+
+    def __init__(self, name):
+        self.name = name
+        self.ended = False
+        self.updates = []
+
+    def start_observation(self, **kwargs):
+        return FakeObservation(kwargs.get("name"))
+
+    def update(self, **kwargs):
+        self.updates.append(kwargs)
+
+    def end(self):
+        self.ended = True
+
+
+def _make_plugin() -> LangfusePlugin:
+    plugin = LangfusePlugin(secret_key=None, public_key=None, host=None)
+    # Force-enable without a real Langfuse client: every code path this
+    # plugin exercises only calls methods on self.client / self._current_trace,
+    # both of which are fakeable directly without touching the network.
+    plugin.enabled = True
+    plugin.client = object()
+    plugin._current_trace = FakeObservation("root")
+    return plugin
+
+
+def _ctx(branch):
+    """Minimal stand-in for CallbackContext: LangfusePlugin._branch_key only
+    reads ._invocation_context.branch off it."""
+    return SimpleNamespace(_invocation_context=SimpleNamespace(branch=branch))
+
+
+class TestBranchKey:
+    def test_distinct_branches_get_distinct_keys(self):
+        plugin = _make_plugin()
+        a = plugin._branch_key(_ctx("parallel_discovery.city_pipeline"))
+        b = plugin._branch_key(_ctx("parallel_discovery.landmark_pipeline"))
+        assert a != b
+
+    def test_missing_branch_falls_back_to_shared_root_key(self):
+        plugin = _make_plugin()
+        assert plugin._branch_key(_ctx(None)) == plugin._branch_key(_ctx(None)) == "_root"
+
+    def test_missing_invocation_context_does_not_raise(self):
+        plugin = _make_plugin()
+        # A context object with no _invocation_context at all -- defensive
+        # coverage in case a future ADK version renames the attribute.
+        assert plugin._branch_key(SimpleNamespace()) == "_root"
+
+
+class TestConcurrentBranchesDoNotCorruptEachOther:
+    @pytest.mark.asyncio
+    async def test_interleaved_model_calls_both_end_correctly(self):
+        """The exact race MYS-398 describes: branch A's before_model, then
+        branch B's before_model (which used to overwrite A's still-open
+        generation via the old shared _current_generation scalar), then A's
+        after_model, then B's after_model. Both generations must end, and
+        neither must be costed using the other's model's pricing.
+        """
+        plugin = _make_plugin()
+        ctx_a = _ctx("parallel_discovery.city_pipeline")
+        ctx_b = _ctx("parallel_discovery.landmark_pipeline")
+
+        req_a = SimpleNamespace(model="gemini-2.5-flash-lite")
+        req_b = SimpleNamespace(model="gemini-2.5-flash")
+
+        await plugin.before_model_callback(callback_context=ctx_a, llm_request=req_a)
+        await plugin.before_model_callback(callback_context=ctx_b, llm_request=req_b)
+
+        key_a = plugin._branch_key(ctx_a)
+        key_b = plugin._branch_key(ctx_b)
+        gen_a = plugin._generations[key_a]
+        gen_b = plugin._generations[key_b]
+        # Both branches have their own open generation -- the old shared
+        # scalar could only ever hold one at a time.
+        assert gen_a is not gen_b
+        assert plugin._models[key_a] == "gemini-2.5-flash-lite"
+        assert plugin._models[key_b] == "gemini-2.5-flash"
+
+        resp_a = SimpleNamespace(usage_metadata=SimpleNamespace(
+            prompt_token_count=100, candidates_token_count=20, total_token_count=120))
+        resp_b = SimpleNamespace(usage_metadata=SimpleNamespace(
+            prompt_token_count=50, candidates_token_count=10, total_token_count=60))
+
+        await plugin.after_model_callback(callback_context=ctx_a, llm_response=resp_a)
+        await plugin.after_model_callback(callback_context=ctx_b, llm_response=resp_b)
+
+        assert gen_a.ended is True
+        assert gen_b.ended is True
+        # Neither branch's state lingers after it closes.
+        assert key_a not in plugin._generations
+        assert key_b not in plugin._generations
+
+        # This is the actual bug made concrete: before the fix, gen_a would
+        # have been costed using gemini-2.5-flash's rate (B's model),
+        # because _current_model was a single shared scalar B had already
+        # overwritten by the time A's after_model_callback ran.
+        expected_cost_a = (100 / 1_000_000) * 0.10 + (20 / 1_000_000) * 0.40  # flash-lite rate
+        expected_cost_b = (50 / 1_000_000) * 0.30 + (10 / 1_000_000) * 2.50  # flash rate
+        assert gen_a.updates[0]["cost_details"]["total_cost"] == pytest.approx(expected_cost_a)
+        assert gen_b.updates[0]["cost_details"]["total_cost"] == pytest.approx(expected_cost_b)
+
+        # Session totals aggregate across both branches -- that's intended,
+        # they're a whole-run total, not per-branch.
+        assert plugin._token_usage.input_tokens == 150
+        assert plugin._token_usage.output_tokens == 30
+
+    @pytest.mark.asyncio
+    async def test_agent_stack_pop_is_scoped_per_branch(self):
+        """Regression for the LIFO half of the bug: two branches' agent
+        start/end calls used to push/pop a single shared list, so a branch
+        could end up ending the WRONG agent's span whenever completion order
+        didn't match push order -- which asyncio gives no guarantee of.
+        """
+        plugin = _make_plugin()
+        ctx_a = _ctx("parallel_discovery.city_pipeline")
+        ctx_b = _ctx("parallel_discovery.landmark_pipeline")
+
+        agent_a = SimpleNamespace(name="city_research_agent")
+        agent_b = SimpleNamespace(name="landmark_research_agent")
+
+        await plugin.before_agent_callback(agent=agent_a, callback_context=ctx_a)
+        await plugin.before_agent_callback(agent=agent_b, callback_context=ctx_b)
+
+        span_a = plugin._agent_stacks[plugin._branch_key(ctx_a)][-1][1]
+        span_b = plugin._agent_stacks[plugin._branch_key(ctx_b)][-1][1]
+        assert span_a is not span_b
+
+        # B finishes first -- completion order need not match push order
+        # under real concurrency.
+        await plugin.after_agent_callback(agent=agent_b, callback_context=ctx_b)
+        assert span_b.ended is True
+        assert span_a.ended is False  # would have been True pre-fix (wrong pop)
+
+        await plugin.after_agent_callback(agent=agent_a, callback_context=ctx_a)
+        assert span_a.ended is True
+
+        assert plugin._agent_stacks == {}
+
+    @pytest.mark.asyncio
+    async def test_sequential_only_path_shares_one_key_and_still_works(self):
+        """No ParallelAgent in play (branch is None throughout -- e.g. the
+        single-agent local_atmosphere/trip_composer workflows) must keep
+        behaving exactly like the pre-fix single-scalar version, since
+        there's never more than one in-flight generation there.
+        """
+        plugin = _make_plugin()
+        ctx = _ctx(None)
+        req = SimpleNamespace(model="gemini-2.5-flash")
+
+        await plugin.before_model_callback(callback_context=ctx, llm_request=req)
+        assert plugin._branch_key(ctx) == "_root"
+        assert "_root" in plugin._generations
+
+        resp = SimpleNamespace(usage_metadata=SimpleNamespace(
+            prompt_token_count=10, candidates_token_count=5, total_token_count=15))
+        await plugin.after_model_callback(callback_context=ctx, llm_response=resp)
+        assert "_root" not in plugin._generations

--- a/tests/unit/test_langfuse_pricing.py
+++ b/tests/unit/test_langfuse_pricing.py
@@ -1,0 +1,37 @@
+"""Unit tests for LangfusePlugin's `_pricing_for` model-rate lookup.
+
+MYS-398 follow-up: `_GEMINI_PRICING` is matched by bare substring
+("key in model_name.lower()"), and "gemini-2.5-flash" is itself a
+substring of "gemini-2.5-flash-lite". Checking dict keys in plain
+insertion order let the shorter, wrong entry match first, so every
+flash-lite call was silently priced at the plain-flash rate -- a
+pre-existing bug, unrelated to MYS-398's concurrency fix, first exposed
+by that fix's own test asserting two flash variants' costs side by side.
+"""
+
+from plugins.langfuse_plugin import _GEMINI_PRICING, _pricing_for
+
+
+class TestPricingFor:
+    def test_flash_lite_gets_its_own_rate_not_plain_flash(self):
+        assert _pricing_for("gemini-2.5-flash-lite") == _GEMINI_PRICING["gemini-2.5-flash-lite"]
+        assert _pricing_for("gemini-2.5-flash-lite") != _GEMINI_PRICING["gemini-2.5-flash"]
+
+    def test_plain_flash_still_gets_its_own_rate(self):
+        assert _pricing_for("gemini-2.5-flash") == _GEMINI_PRICING["gemini-2.5-flash"]
+
+    def test_every_pricing_key_matches_its_own_full_name_exactly(self):
+        # Regression guard: no entry in the table should resolve to a
+        # DIFFERENT entry's rate just because one key is a substring of
+        # another (the general form of the flash/flash-lite bug).
+        for key, expected_rate in _GEMINI_PRICING.items():
+            assert _pricing_for(key) == expected_rate, f"{key!r} resolved to the wrong rate"
+
+    def test_unknown_model_falls_back_to_default(self):
+        from plugins.langfuse_plugin import _GEMINI_DEFAULT_PRICING
+        assert _pricing_for("some-future-model-nobody-priced-yet") == _GEMINI_DEFAULT_PRICING
+
+    def test_empty_model_name_falls_back_to_default(self):
+        from plugins.langfuse_plugin import _GEMINI_DEFAULT_PRICING
+        assert _pricing_for("") == _GEMINI_DEFAULT_PRICING
+        assert _pricing_for(None) == _GEMINI_DEFAULT_PRICING


### PR DESCRIPTION
# fix(ai): scope LangfusePlugin generation/agent-stack/span state per ParallelAgent branch, not shared scalars

## What

`plugins/langfuse_plugin.py` tracked the "currently open" Langfuse generation,
its model name, the nested-agent LIFO stack, and the currently open tool span
in shared scalars/a single list on the plugin instance. `core/executor.py`
creates exactly one `LangfusePlugin` per workflow *run*, and
`agents/orchestrator.py`'s `discovery_workflow` runs three sub-agent
pipelines (city/landmark/author) **concurrently** under one `ParallelAgent`
(`parallel_discovery`) against that single instance. This PR replaces the
shared scalars with dicts keyed by ADK's own per-branch isolation field, so
concurrent branches can no longer clobber each other's in-flight state.

**Rider, same file, found while verifying this fix:** `_pricing_for` matched
`_GEMINI_PRICING` keys by bare substring in insertion order, and
`"gemini-2.5-flash"` is itself a substring of `"gemini-2.5-flash-lite"` — so
every flash-lite call has always been priced at the plain-flash rate,
independent of and pre-dating the concurrency bug above. Fixed in the same
diff (see How) since the branch-scoping fix's own test is what exposed it —
the test's per-model dollar assertions cannot pass against the buggy
pricing regardless of branch isolation.

## Why

Under `parallel_discovery`, city/landmark/author model calls interleave at
await boundaries. With the old shared `_current_generation` scalar, the 2nd
`before_model_callback` overwrote the 1st branch's still-open generation
before its `after_model_callback` fired; that trailing `after_model_callback`
then ended the **wrong** generation, `_current_model` no longer matched the
generation being closed (a 2nd branch's response could be costed using a 1st
branch's model's pricing), and `_agent_stack.pop()` unwound spans in whatever
order calls happened to complete in — not the order they were pushed —
misattributing tokens between agents (e.g. city tokens attributed to
author). `token_usage` from `WorkflowComplete` feeds the Product Analyst
LLM-spend dashboard directly, so this was a live cost/telemetry-accuracy bug
on the product's main path, not just an observability nit.

## How

Added `LangfusePlugin._branch_key(callback_context)`: reads
`callback_context._invocation_context.branch`, the same field
`google.adk.agents.parallel_agent._create_branch_ctx_for_sub_agent` sets on
every `ParallelAgent` sub-agent's private `InvocationContext` copy (e.g.
`"parallel_discovery.city_pipeline"`) — verified by installing `google-adk`
1.36.1 (the version this repo's `>=1.33.0,<2` pin resolves to) and reading
`parallel_agent.py`/`context.py`/`readonly_context.py` at source rather than
guessing at ADK's concurrency model. Falls back to a constant `"_root"` key
when `branch` is unset (the non-parallel single-agent workflows — e.g.
`local_atmosphere`/`trip_composer` — where a single shared key is exactly
what the old scalars already gave, correctly, since there's never more than
one in-flight generation there). `branch` has no public accessor on
`Context`/`CallbackContext`, so this reads the private `_invocation_context`
attribute directly — a real coupling to google-adk internals, which is
exactly why the repo pins the tested 1.x line rather than floating to 2.x.

Replaced the four shared fields with branch-keyed dicts:
- `_current_generation` → `_generations: dict[str, Any]`
- `_current_model` → `_models: dict[str, str]`
- `_agent_stack` (one shared LIFO list) → `_agent_stacks: dict[str, list]`
  (one LIFO list *per branch*)
- `_current_span` → `_spans: dict[str, Any]`

`before_model_callback`/`after_model_callback`/`before_agent_callback`/
`after_agent_callback`/`before_tool_callback`/`after_tool_callback` all now
key their reads/writes by `_branch_key(...)` instead of touching the shared
field directly; `after_*` callbacks pop their branch's entry once closed so
nothing lingers. `_token_usage` (the running input/output/total counters) and
`_total_cost_usd` stay shared scalars deliberately — they're an intentional
whole-run total across every branch, and plain `+=` on them is safe under
asyncio's single-threaded cooperative concurrency (no `await` inside those
statements, so no interleaving mid-increment is possible).

**`_pricing_for` rider:** changed the lookup from `for key, rates in
_GEMINI_PRICING.items()` (dict insertion order) to iterating
`sorted(_GEMINI_PRICING, key=len, reverse=True)` — longest key first — so a
more specific model name is always matched before a shorter name that
happens to be one of its substrings. No change to `_GEMINI_PRICING`'s rates
or entries, only the match order.

## Review & test

- `python3 -m py_compile plugins/langfuse_plugin.py tests/unit/test_langfuse_plugin_concurrency.py` — both parse clean.
- **Not run in the build sandbox — env gap, not a defect in this diff.**
  `storyland-ai`'s dependency tree can't fully install there (disk-space
  ceiling hit partway through `pip install -e .`'s eval-extras chain —
  `litellm`/`scikit-learn`/etc.). I verified my read of ADK's concurrency
  model directly at source instead of guessing: installed `google-adk`
  1.36.1 + its import chain standalone (`--no-deps`, piece by piece — genai,
  pydantic, fastapi/starlette, up to `opentelemetry`) far enough to confirm
  `_create_branch_ctx_for_sub_agent`'s behavior and `Context`'s attribute
  surface, but not far enough to get `plugins/langfuse_plugin.py` itself
  importable (the `google.adk.plugins.BasePlugin` import chain needs
  `opentelemetry-api`/`-sdk` + several GCP exporters that pull in enough
  weight to have caused the original space error). **Please run before
  merging:**
  ```
  pip install -e .
  pytest tests/unit/test_langfuse_plugin_concurrency.py -v
  pytest  # full suite — this touches a shared plugin used on every discovery run
  ```
- New `tests/unit/test_langfuse_plugin_concurrency.py` (7 tests, no live
  Langfuse/ADK network calls — fakes the pieces the plugin actually touches):
  `_branch_key` gives distinct keys for distinct branches and a stable
  fallback for none; two interleaved model calls across two branches (the
  exact MYS-398 race: A's `before_model`, B's `before_model`, A's
  `after_model`, B's `after_model`) each end their own generation and are
  costed with their *own* model's pricing — the test asserts the specific
  dollar amounts, which is the concrete case the old shared-scalar bug got
  wrong; `_agent_stacks` pop is scoped per branch even when branches
  complete out of push order; a sequential-only (no `ParallelAgent`) path
  still works exactly as before, sharing the `"_root"` key.
- A reviewer should additionally sanity-check against a real trace once
  merged: run a live discovery and confirm Langfuse shows 3 separate
  generations under `parallel_discovery`'s span (one per city/landmark/author
  branch) with 3 distinct costs, not 1 overwritten generation — this is the
  thing no unit test proves against the real Langfuse client.
- New `tests/unit/test_langfuse_pricing.py` (5 tests) covers the `_pricing_for`
  rider directly: flash-lite resolves to its own rate (not flash's); every
  entry in `_GEMINI_PRICING` resolves to itself, not a shorter substring
  sibling (the general form of the bug, not just the one instance the
  concurrency test happened to catch); unknown/empty/`None` model names still
  fall back to the default rate.
