### PR TITLE
MYS-541: ship structlog logs + metrics to Sentry (Logs & Metrics)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,8 +42,12 @@ LANGFUSE_HOST=https://cloud.langfuse.com
 # Sentry error tracking (optional). Unset/empty = fully disabled (local, CI).
 # Errors only by default; SENTRY_TRACES_SAMPLE_RATE opts into performance
 # tracing (0.0-1.0) — leave at 0, agent runs are already traced in Langfuse.
+# SENTRY_ENABLE_LOGS (default true) ships INFO+ logs to Sentry Logs when the
+# DSN is set: structlog error/critical -> Sentry events, info/warning ->
+# Sentry Logs, debug local-only (LLM prompts can appear at debug level).
 SENTRY_DSN=
 SENTRY_TRACES_SAMPLE_RATE=0.0
+SENTRY_ENABLE_LOGS=true
 
 # Result Cache (in-process; caches the Discovery book->regions chain).
 # CACHE_ENABLED is the master switch and defaults to true when unset, so a

--- a/.env.example
+++ b/.env.example
@@ -45,9 +45,12 @@ LANGFUSE_HOST=https://cloud.langfuse.com
 # SENTRY_ENABLE_LOGS (default true) ships INFO+ logs to Sentry Logs when the
 # DSN is set: structlog error/critical -> Sentry events, info/warning ->
 # Sentry Logs, debug local-only (LLM prompts can appear at debug level).
+# SENTRY_ENABLE_METRICS (default true) auto-counts every non-debug structlog
+# event as the `log.events` metric {event, level} — chartable in Sentry.
 SENTRY_DSN=
 SENTRY_TRACES_SAMPLE_RATE=0.0
 SENTRY_ENABLE_LOGS=true
+SENTRY_ENABLE_METRICS=true
 
 # Result Cache (in-process; caches the Discovery book->regions chain).
 # CACHE_ENABLED is the master switch and defaults to true when unset, so a

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ All configuration is via environment variables in `.env`. Copy `.env.example` to
 | `LANGFUSE_HOST` | Langfuse host URL (optional) | — |
 | `SENTRY_DSN` | Sentry error-tracking DSN (optional) — unset means Sentry is fully disabled (local/CI). Errors only by default; performance tracing stays off since agent runs are already traced in Langfuse. | — |
 | `SENTRY_ENABLE_LOGS` | Ship INFO+ logs to Sentry Logs (searchable/alertable). Kill switch — only takes effect when `SENTRY_DSN` is set. structlog error/critical become Sentry events, info/warning become Sentry logs, debug stays local (LLM prompts can appear there). | `true` |
+| `SENTRY_ENABLE_METRICS` | Emit Sentry metrics. Every non-debug structlog event is auto-counted as `log.events` `{event, level}`, making timeouts/cache-hits/failures chartable; new call sites can use `sentry_sdk.metrics` directly (examples in `api/sentry.py`). | `true` |
 | `SENTRY_TRACES_SAMPLE_RATE` | Sentry performance-tracing sample rate (0.0–1.0) | `0.0` |
 | `CORS_ORIGINS` | Allowed CORS origins for API (comma-separated) | `*` |
 | `INTERNAL_API_SECRET` | Shared secret with the gateway service — when set, all itinerary endpoints require an `X-Internal-Secret` header with this value. The health endpoint (`/health`) is always open. Leave empty for standalone/dev use. | — |

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ All configuration is via environment variables in `.env`. Copy `.env.example` to
 | `LANGFUSE_PUBLIC_KEY` | Langfuse public key (optional) | — |
 | `LANGFUSE_HOST` | Langfuse host URL (optional) | — |
 | `SENTRY_DSN` | Sentry error-tracking DSN (optional) — unset means Sentry is fully disabled (local/CI). Errors only by default; performance tracing stays off since agent runs are already traced in Langfuse. | — |
+| `SENTRY_ENABLE_LOGS` | Ship INFO+ logs to Sentry Logs (searchable/alertable). Kill switch — only takes effect when `SENTRY_DSN` is set. structlog error/critical become Sentry events, info/warning become Sentry logs, debug stays local (LLM prompts can appear there). | `true` |
 | `SENTRY_TRACES_SAMPLE_RATE` | Sentry performance-tracing sample rate (0.0–1.0) | `0.0` |
 | `CORS_ORIGINS` | Allowed CORS origins for API (comma-separated) | `*` |
 | `INTERNAL_API_SECRET` | Shared secret with the gateway service — when set, all itinerary endpoints require an `X-Internal-Secret` header with this value. The health endpoint (`/health`) is always open. Leave empty for standalone/dev use. | — |

--- a/api/sentry.py
+++ b/api/sentry.py
@@ -22,6 +22,11 @@ Environment variables:
     SENTRY_DSN                  enable switch; empty/absent = disabled
     SENTRY_ENABLE_LOGS          "true"/"false", default true — ship INFO+
                                 logs to Sentry Logs (searchable, alertable)
+    SENTRY_ENABLE_METRICS       "true"/"false", default true — emit metrics;
+                                every structlog event is auto-counted as
+                                `log.events` {event, level}, so timeouts,
+                                cache hits, and workflow failures are
+                                chartable without per-site instrumentation
     SENTRY_TRACES_SAMPLE_RATE   0.0-1.0, default 0.0 (errors only)
     ENVIRONMENT                 reused as the Sentry environment tag
     SENTRY_RELEASE              optional release tag (read by the SDK itself)
@@ -42,6 +47,20 @@ Logging examples (what reaches Sentry, and how):
     logger.error("workflow_failed", job_id=job_id, phase=phase)
 
     # debug stays local-only by design (LLM prompts can appear there)
+
+Metrics examples (for NEW call sites; existing log events are counted
+automatically as `log.events` by the structlog bridge):
+
+    from sentry_sdk import metrics
+
+    # counter — how often something happens
+    metrics.count("discovery.cache.hit", 1, attributes={"backend": "disk"})
+
+    # distribution — spread of a measured value (p50/p95 in Sentry)
+    metrics.distribution("workflow.discover.duration", elapsed_s, unit="second")
+
+    # gauge — current level of something
+    metrics.gauge("sessions.active", n)
 
 Stdlib loggers (google-adk, urllib3, ...) flow via the SDK's logging
 integration automatically; the structlog bridge in common.logging covers
@@ -74,8 +93,9 @@ def init_sentry() -> bool:
     traces_sample_rate = float(os.getenv("SENTRY_TRACES_SAMPLE_RATE") or "0.0")
     environment = os.getenv("ENVIRONMENT", "local")
     # Default ON when Sentry itself is on: log volume at current traffic is
-    # tiny and searchable prod logs are the point. Kill switch, not opt-in.
+    # tiny and searchable prod logs are the point. Kill switches, not opt-ins.
     enable_logs = (os.getenv("SENTRY_ENABLE_LOGS") or "true").lower() == "true"
+    enable_metrics = (os.getenv("SENTRY_ENABLE_METRICS") or "true").lower() == "true"
 
     # Imported lazily so the module can be imported (and the disabled path
     # unit-tested) even if the SDK were ever absent from a local env.
@@ -96,11 +116,16 @@ def init_sentry() -> bool:
         # events ship via the bridge in common.logging (structlog bypasses
         # stdlib, so without the bridge nothing of ours would appear).
         enable_logs=enable_logs,
+        # Metrics: every structlog event is auto-counted (`log.events`) by the
+        # bridge in common.logging; new call sites can use sentry_sdk.metrics
+        # directly (examples in the module docstring).
+        enable_metrics=enable_metrics,
     )
     logger.info(
         "sentry_enabled",
         environment=environment,
         traces_sample_rate=traces_sample_rate,
         logs_enabled=enable_logs,
+        metrics_enabled=enable_metrics,
     )
     return True

--- a/api/sentry.py
+++ b/api/sentry.py
@@ -20,9 +20,32 @@ so local dev and CI never report.
 
 Environment variables:
     SENTRY_DSN                  enable switch; empty/absent = disabled
+    SENTRY_ENABLE_LOGS          "true"/"false", default true — ship INFO+
+                                logs to Sentry Logs (searchable, alertable)
     SENTRY_TRACES_SAMPLE_RATE   0.0-1.0, default 0.0 (errors only)
     ENVIRONMENT                 reused as the Sentry environment tag
     SENTRY_RELEASE              optional release tag (read by the SDK itself)
+
+Logging examples (what reaches Sentry, and how):
+
+    from common.logging import get_logger
+    logger = get_logger(__name__)
+
+    # -> Sentry Logs entry (level info), with job_id/phase as attributes
+    logger.info("discovery_started", job_id=job_id, phase="discovery")
+
+    # -> Sentry Logs entry (level warn)
+    logger.warning("book_search_thin", results=1, floor=3)
+
+    # -> Sentry EVENT (alerting): inside an except block the live
+    #    exception + traceback is captured, structlog kvs attached
+    logger.error("workflow_failed", job_id=job_id, phase=phase)
+
+    # debug stays local-only by design (LLM prompts can appear there)
+
+Stdlib loggers (google-adk, urllib3, ...) flow via the SDK's logging
+integration automatically; the structlog bridge in common.logging covers
+our own loggers, which bypass stdlib entirely (PrintLoggerFactory).
 """
 
 import os
@@ -50,6 +73,9 @@ def init_sentry() -> bool:
 
     traces_sample_rate = float(os.getenv("SENTRY_TRACES_SAMPLE_RATE") or "0.0")
     environment = os.getenv("ENVIRONMENT", "local")
+    # Default ON when Sentry itself is on: log volume at current traffic is
+    # tiny and searchable prod logs are the point. Kill switch, not opt-in.
+    enable_logs = (os.getenv("SENTRY_ENABLE_LOGS") or "true").lower() == "true"
 
     # Imported lazily so the module can be imported (and the disabled path
     # unit-tested) even if the SDK were ever absent from a local env.
@@ -66,10 +92,15 @@ def init_sentry() -> bool:
         # default ("medium") uploads small failing-request bodies, which here
         # carry book titles, taste context, and local-atmosphere lat/lng.
         max_request_body_size="never",
+        # Sentry Logs: stdlib INFO+ records ship automatically; our structlog
+        # events ship via the bridge in common.logging (structlog bypasses
+        # stdlib, so without the bridge nothing of ours would appear).
+        enable_logs=enable_logs,
     )
     logger.info(
         "sentry_enabled",
         environment=environment,
         traces_sample_rate=traces_sample_rate,
+        logs_enabled=enable_logs,
     )
     return True

--- a/common/logging.py
+++ b/common/logging.py
@@ -17,7 +17,11 @@ import structlog
 def _sentry_error_processor(logger, method_name, event_dict):
     """
     Forward structlog events to Sentry: error/critical as EVENTS (alerting),
-    info/warning as Sentry LOGS (searchable), debug local-only.
+    info/warning as Sentry LOGS (searchable), debug local-only. Every
+    non-debug event is also counted as the `log.events` metric with
+    {event, level} attributes — event names are a fixed vocabulary in code,
+    so cardinality is bounded and timeouts / cache hits / workflow failures
+    become chartable without per-site instrumentation.
 
     structlog here uses PrintLoggerFactory (straight to stdout), so the Sentry
     SDK's stdlib logging integration never sees these events — without this
@@ -50,6 +54,18 @@ def _sentry_error_processor(logger, method_name, event_dict):
         attributes = {k: v for k, v in event_dict.items() if k != "event"}
         log_fn = sentry_logger.info if method_name == "info" else sentry_logger.warning
         log_fn(str(event_dict.get("event")), attributes=attributes)
+
+    if method_name != "debug":
+        from sentry_sdk import metrics
+
+        metrics.count(
+            "log.events",
+            1,
+            attributes={
+                "event": str(event_dict.get("event")),
+                "level": method_name,
+            },
+        )
     return event_dict
 
 

--- a/common/logging.py
+++ b/common/logging.py
@@ -16,14 +16,15 @@ import structlog
 
 def _sentry_error_processor(logger, method_name, event_dict):
     """
-    Forward error-level structlog events to Sentry.
+    Forward structlog events to Sentry: error/critical as EVENTS (alerting),
+    info/warning as Sentry LOGS (searchable), debug local-only.
 
     structlog here uses PrintLoggerFactory (straight to stdout), so the Sentry
     SDK's stdlib logging integration never sees these events — without this
     processor, handled workflow failures (caught + logger.error + streamed as
     a WorkflowError) would stay docker-log-only. When called inside an except
     block the live exception is captured with its traceback; otherwise the
-    event message is captured. Every capture_* call is a no-op unless
+    event message is captured. Every capture_*/logger call is a no-op unless
     init_sentry() actually initialized the SDK (no SENTRY_DSN → no client),
     so local dev and CI still never report.
     """
@@ -39,6 +40,16 @@ def _sentry_error_processor(logger, method_name, event_dict):
             else:
                 level = "critical" if method_name == "critical" else "error"
                 sentry_sdk.capture_message(str(event_dict.get("event")), level=level)
+    elif method_name in ("info", "warning"):
+        # Ship info/warning to Sentry Logs (searchable, no alerting). Same
+        # PrintLoggerFactory rationale as above; no-op unless init_sentry ran
+        # with enable_logs. DEBUG stays local-only by design — full LLM
+        # prompts can appear at that level.
+        from sentry_sdk import logger as sentry_logger
+
+        attributes = {k: v for k, v in event_dict.items() if k != "event"}
+        log_fn = sentry_logger.info if method_name == "info" else sentry_logger.warning
+        log_fn(str(event_dict.get("event")), attributes=attributes)
     return event_dict
 
 

--- a/common/logging.py
+++ b/common/logging.py
@@ -13,6 +13,43 @@ import sys
 
 import structlog
 
+# Attribute keys safe to forward to Sentry Logs. ALLOWLIST, deliberately:
+# info/warning logs carry user-supplied content (book titles/authors,
+# local-atmosphere locations, place queries) and occasionally infra values
+# (connection strings) — the same classes of data api/sentry.py refuses to
+# attach to events (send_default_pii=False, max_request_body_size="never").
+# Unknown keys are DROPPED and recorded in `redacted_keys`, so a new log
+# site can never leak by default; extend this set only with keys that are
+# provably not user content or secrets.
+_SENTRY_SAFE_LOG_ATTR_KEYS = frozenset(
+    {
+        "level",
+        "timestamp",
+        "job_id",
+        "phase",
+        "step",
+        "reason",
+        "type",
+        "backend",
+        "count",
+        "num_regions",
+        "results",
+        "floor",
+        "attempts",
+        "status",
+        "error_type",
+        "compose_error_kind",
+        "ttl_seconds",
+        "max_entries",
+        "interval_seconds",
+        "persistent",
+        "environment",
+        "traces_sample_rate",
+        "logs_enabled",
+        "metrics_enabled",
+    }
+)
+
 
 def _sentry_error_processor(logger, method_name, event_dict):
     """
@@ -51,7 +88,17 @@ def _sentry_error_processor(logger, method_name, event_dict):
         # prompts can appear at that level.
         from sentry_sdk import logger as sentry_logger
 
-        attributes = {k: v for k, v in event_dict.items() if k != "event"}
+        attributes = {}
+        redacted = []
+        for k, v in event_dict.items():
+            if k == "event":
+                continue
+            if k in _SENTRY_SAFE_LOG_ATTR_KEYS:
+                attributes[k] = v
+            else:
+                redacted.append(k)
+        if redacted:
+            attributes["redacted_keys"] = ",".join(sorted(redacted))
         log_fn = sentry_logger.info if method_name == "info" else sentry_logger.warning
         log_fn(str(event_dict.get("event")), attributes=attributes)
 

--- a/tests/unit/test_sentry.py
+++ b/tests/unit/test_sentry.py
@@ -14,6 +14,7 @@ def clean_sentry_env(monkeypatch):
         "SENTRY_DSN",
         "SENTRY_TRACES_SAMPLE_RATE",
         "SENTRY_ENABLE_LOGS",
+        "SENTRY_ENABLE_METRICS",
         "ENVIRONMENT",
     ):
         monkeypatch.delenv(var, raising=False)
@@ -42,14 +43,17 @@ class TestInitSentry:
             send_default_pii=False,
             max_request_body_size="never",
             enable_logs=True,
+            enable_metrics=True,
         )
 
-    def test_logs_kill_switch(self, monkeypatch):
+    def test_logs_and_metrics_kill_switches(self, monkeypatch):
         monkeypatch.setenv("SENTRY_DSN", "https://key@example.ingest.sentry.io/1")
         monkeypatch.setenv("SENTRY_ENABLE_LOGS", "false")
+        monkeypatch.setenv("SENTRY_ENABLE_METRICS", "false")
         with patch("sentry_sdk.init") as mock_init:
             assert init_sentry() is True
         assert mock_init.call_args.kwargs["enable_logs"] is False
+        assert mock_init.call_args.kwargs["enable_metrics"] is False
 
     def test_environment_and_sample_rate_from_env(self, monkeypatch):
         monkeypatch.setenv("SENTRY_DSN", "https://key@example.ingest.sentry.io/1")
@@ -136,10 +140,23 @@ class TestStructlogSentryProcessor:
 
         with patch("sentry_sdk.logger.debug") as mock_debug, patch(
             "sentry_sdk.logger.info"
-        ) as mock_info:
+        ) as mock_info, patch("sentry_sdk.metrics.count") as mock_count:
             _sentry_error_processor(None, "debug", {"event": "llm_prompt"})
         mock_debug.assert_not_called()
         mock_info.assert_not_called()
+        mock_count.assert_not_called()
+
+    @pytest.mark.parametrize("level", ["info", "warning", "error", "critical"])
+    def test_non_debug_events_counted_as_metric(self, level):
+        from common.logging import _sentry_error_processor
+
+        with patch("sentry_sdk.metrics.count") as mock_count:
+            _sentry_error_processor(None, level, {"event": "discover_timeout"})
+        mock_count.assert_called_once_with(
+            "log.events",
+            1,
+            attributes={"event": "discover_timeout", "level": level},
+        )
 
     def test_processor_registered_in_structlog_config(self):
         import structlog

--- a/tests/unit/test_sentry.py
+++ b/tests/unit/test_sentry.py
@@ -128,6 +128,34 @@ class TestStructlogSentryProcessor:
             "discovery_started", attributes={"job_id": "j1"}
         )
 
+    def test_user_content_attributes_redacted_from_logs(self):
+        """Non-allowlisted keys (user content, secrets) never ship — the key
+        NAMES are recorded in redacted_keys, the values dropped (Codex P1 on
+        PR #204: book titles / locations / place queries / connection strings
+        must not be exported by default)."""
+        from common.logging import _sentry_error_processor
+
+        with patch("sentry_sdk.logger.info") as mock_log:
+            _sentry_error_processor(
+                None,
+                "info",
+                {
+                    "event": "search_started",
+                    "job_id": "j1",
+                    "book_title": "1984",
+                    "place": "Paris",
+                    "connection_string": "postgres://secret",
+                },
+            )
+        attrs = mock_log.call_args.kwargs["attributes"]
+        assert attrs["job_id"] == "j1"
+        assert "book_title" not in attrs
+        assert "place" not in attrs
+        assert "connection_string" not in attrs
+        assert attrs["redacted_keys"] == "book_title,connection_string,place"
+        assert "1984" not in str(mock_log.call_args)
+        assert "postgres://secret" not in str(mock_log.call_args)
+
     def test_warning_event_forwarded_to_sentry_logs(self):
         from common.logging import _sentry_error_processor
 

--- a/tests/unit/test_sentry.py
+++ b/tests/unit/test_sentry.py
@@ -10,7 +10,12 @@ from api.sentry import init_sentry
 @pytest.fixture(autouse=True)
 def clean_sentry_env(monkeypatch):
     """Start every test with no Sentry-related environment."""
-    for var in ("SENTRY_DSN", "SENTRY_TRACES_SAMPLE_RATE", "ENVIRONMENT"):
+    for var in (
+        "SENTRY_DSN",
+        "SENTRY_TRACES_SAMPLE_RATE",
+        "SENTRY_ENABLE_LOGS",
+        "ENVIRONMENT",
+    ):
         monkeypatch.delenv(var, raising=False)
 
 
@@ -36,7 +41,15 @@ class TestInitSentry:
             traces_sample_rate=0.0,
             send_default_pii=False,
             max_request_body_size="never",
+            enable_logs=True,
         )
+
+    def test_logs_kill_switch(self, monkeypatch):
+        monkeypatch.setenv("SENTRY_DSN", "https://key@example.ingest.sentry.io/1")
+        monkeypatch.setenv("SENTRY_ENABLE_LOGS", "false")
+        with patch("sentry_sdk.init") as mock_init:
+            assert init_sentry() is True
+        assert mock_init.call_args.kwargs["enable_logs"] is False
 
     def test_environment_and_sample_rate_from_env(self, monkeypatch):
         monkeypatch.setenv("SENTRY_DSN", "https://key@example.ingest.sentry.io/1")
@@ -90,7 +103,7 @@ class TestStructlogSentryProcessor:
         assert isinstance(mock_exc.call_args.args[0], RuntimeError)
         mock_msg.assert_not_called()
 
-    def test_info_event_is_not_captured(self):
+    def test_info_event_is_not_captured_as_event(self):
         from common.logging import _sentry_error_processor
 
         with patch("sentry_sdk.capture_message") as mock_msg, patch(
@@ -99,6 +112,34 @@ class TestStructlogSentryProcessor:
             _sentry_error_processor(None, "info", {"event": "sentry_enabled"})
         mock_msg.assert_not_called()
         mock_exc.assert_not_called()
+
+    def test_info_event_forwarded_to_sentry_logs(self):
+        from common.logging import _sentry_error_processor
+
+        with patch("sentry_sdk.logger.info") as mock_log:
+            _sentry_error_processor(
+                None, "info", {"event": "discovery_started", "job_id": "j1"}
+            )
+        mock_log.assert_called_once_with(
+            "discovery_started", attributes={"job_id": "j1"}
+        )
+
+    def test_warning_event_forwarded_to_sentry_logs(self):
+        from common.logging import _sentry_error_processor
+
+        with patch("sentry_sdk.logger.warning") as mock_log:
+            _sentry_error_processor(None, "warning", {"event": "book_search_thin"})
+        mock_log.assert_called_once_with("book_search_thin", attributes={})
+
+    def test_debug_event_stays_local(self):
+        from common.logging import _sentry_error_processor
+
+        with patch("sentry_sdk.logger.debug") as mock_debug, patch(
+            "sentry_sdk.logger.info"
+        ) as mock_info:
+            _sentry_error_processor(None, "debug", {"event": "llm_prompt"})
+        mock_debug.assert_not_called()
+        mock_info.assert_not_called()
 
     def test_processor_registered_in_structlog_config(self):
         import structlog


### PR DESCRIPTION
## Summary
Follow-up to #203, implementing what `npx @sentry/ai install` would have done — Sentry **Logs** and **Metrics** instrumentation, through the normal flow instead of the wizard:

**Logs**
- `enable_logs=True` gated by `SENTRY_ENABLE_LOGS` (default true; only effective when `SENTRY_DSN` is set — local/CI never report)
- structlog routing: **error/critical → Sentry events** (alerting), **info/warning → Sentry Logs** with key/values as attributes, **debug → local-only** (LLM prompts can appear at debug level — deliberately never shipped)
- stdlib loggers (google-adk, …) flow via the SDK's logging integration automatically

**Metrics**
- `enable_metrics=True` gated by `SENTRY_ENABLE_METRICS` (default true)
- The structlog bridge auto-counts every non-debug event as `log.events` `{event, level}` — bounded cardinality (event names are a fixed code vocabulary), so timeouts, cache hits, and workflow failures chart with zero per-site instrumentation
- Direct `metrics.count/distribution/gauge` examples in `api/sentry.py` for future call sites

No new dependencies (sentry-sdk 2.66 ships both APIs).

## Test plan
- `make test-ci`: 720 passed, coverage 76.34% (ratchet ≥74) ✅
- `make test-integration`: 6 passed, 1 skipped ✅
- Live-verified with `before_send_log` / `before_send_metric` intercepts: logs arrive with attributes, `log.events` counters arrive with `{event, level}`, errors still arrive as events, debug ships nothing ✅

Part of MYS-541

🤖 Generated with [Claude Code](https://claude.com/claude-code)