### PR TITLE
MYS-541: Sentry release tagging + health-probe log filter

### DIFF
--- a/.github/workflows/deploy-ai-prod.yml
+++ b/.github/workflows/deploy-ai-prod.yml
@@ -143,8 +143,12 @@ jobs:
           # Mirrors deploy.sh's per-service compose path exactly (build context +
           # --env-file .env.prod live on the box). Like deploy.sh, this can recreate
           # depends_on services; the `--no-deps` refinement is tracked separately.
+          # SENTRY_RELEASE: tag Sentry events with the deployed commit so
+          # regressions pin to a release. Compose forwards it to the container
+          # (environment: block); empty would mean untagged, never a failure.
           ssh -i ~/.ssh/deploy_key -o ServerAliveInterval=30 "ubuntu@$BOX_IP" \
             "cd ~/storyland/storyland-infrastructure/deploy && \
+             SENTRY_RELEASE=${GITHUB_SHA::7} \
              docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --build storyland-ai && \
              docker compose -f docker-compose.prod.yml ps storyland-ai"
 

--- a/.github/workflows/deploy-ai-prod.yml
+++ b/.github/workflows/deploy-ai-prod.yml
@@ -147,9 +147,13 @@ jobs:
           # SHA) across deploys; every compose call reads it (--env-file), and
           # only ai deploys rewrite it — keep in sync with deploy.sh and
           # infra's deploy-service.yml (the usual two-places JIT-SSH caveat).
+          # Derived from the CHECKED-OUT workspace, not GITHUB_SHA: a manual
+          # dispatch with the `ref` input (rollback/tag deploy) checks out and
+          # deploys that ref, while GITHUB_SHA stays the triggering commit.
+          RELEASE="$(git rev-parse --short HEAD)"
           ssh -i ~/.ssh/deploy_key -o ServerAliveInterval=30 "ubuntu@$BOX_IP" \
             "cd ~/storyland/storyland-infrastructure/deploy && \
-             printf 'SENTRY_RELEASE=%s\n' '${GITHUB_SHA::7}' > .env.release && \
+             printf 'SENTRY_RELEASE=%s\n' \"$RELEASE\" > .env.release && \
              docker compose -f docker-compose.prod.yml --env-file .env.prod --env-file .env.release up -d --build storyland-ai && \
              docker compose -f docker-compose.prod.yml ps storyland-ai"
 

--- a/.github/workflows/deploy-ai-prod.yml
+++ b/.github/workflows/deploy-ai-prod.yml
@@ -143,13 +143,14 @@ jobs:
           # Mirrors deploy.sh's per-service compose path exactly (build context +
           # --env-file .env.prod live on the box). Like deploy.sh, this can recreate
           # depends_on services; the `--no-deps` refinement is tracked separately.
-          # SENTRY_RELEASE: tag Sentry events with the deployed commit so
-          # regressions pin to a release. Compose forwards it to the container
-          # (environment: block); empty would mean untagged, never a failure.
+          # .env.release persists the Sentry release tag (deployed git short
+          # SHA) across deploys; every compose call reads it (--env-file), and
+          # only ai deploys rewrite it — keep in sync with deploy.sh and
+          # infra's deploy-service.yml (the usual two-places JIT-SSH caveat).
           ssh -i ~/.ssh/deploy_key -o ServerAliveInterval=30 "ubuntu@$BOX_IP" \
             "cd ~/storyland/storyland-infrastructure/deploy && \
-             SENTRY_RELEASE=${GITHUB_SHA::7} \
-             docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --build storyland-ai && \
+             printf 'SENTRY_RELEASE=%s\n' '${GITHUB_SHA::7}' > .env.release && \
+             docker compose -f docker-compose.prod.yml --env-file .env.prod --env-file .env.release up -d --build storyland-ai && \
              docker compose -f docker-compose.prod.yml ps storyland-ai"
 
       - name: Close SSH (at-rest state)

--- a/api/sentry.py
+++ b/api/sentry.py
@@ -29,7 +29,10 @@ Environment variables:
                                 chartable without per-site instrumentation
     SENTRY_TRACES_SAMPLE_RATE   0.0-1.0, default 0.0 (errors only)
     ENVIRONMENT                 reused as the Sentry environment tag
-    SENTRY_RELEASE              optional release tag (read by the SDK itself)
+    SENTRY_RELEASE              release tag (read by the SDK itself); the
+                                deploy tooling sets it to the deployed git
+                                SHA so Sentry can pin "first seen in
+                                release X" and auto-resolve on new deploys
 
 Logging examples (what reaches Sentry, and how):
 
@@ -74,6 +77,18 @@ from common.logging import get_logger
 logger = get_logger(__name__)
 
 
+def _drop_health_probe_logs(log, hint):
+    """
+    before_send_log filter: drop the docker healthcheck's uvicorn access-log
+    lines ('GET /api/v1/health ... 200'). They fire every 30s (~3k/day of
+    pure noise in the Logs explorer); the healthcheck's FAILURE signal is the
+    container going unhealthy, not a Sentry log line. Everything else passes.
+    """
+    if "/api/v1/health" in (log.get("body") or ""):
+        return None
+    return log
+
+
 def init_sentry() -> bool:
     """
     Initialize the Sentry SDK if SENTRY_DSN is set.
@@ -116,6 +131,7 @@ def init_sentry() -> bool:
         # events ship via the bridge in common.logging (structlog bypasses
         # stdlib, so without the bridge nothing of ours would appear).
         enable_logs=enable_logs,
+        before_send_log=_drop_health_probe_logs,
         # Metrics: every structlog event is auto-counted (`log.events`) by the
         # bridge in common.logging; new call sites can use sentry_sdk.metrics
         # directly (examples in the module docstring).

--- a/tests/unit/test_sentry.py
+++ b/tests/unit/test_sentry.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from api.sentry import init_sentry
+from api.sentry import _drop_health_probe_logs, init_sentry
 
 
 @pytest.fixture(autouse=True)
@@ -43,6 +43,7 @@ class TestInitSentry:
             send_default_pii=False,
             max_request_body_size="never",
             enable_logs=True,
+            before_send_log=_drop_health_probe_logs,
             enable_metrics=True,
         )
 
@@ -193,6 +194,20 @@ class TestStructlogSentryProcessor:
 
         configure_logging(level="INFO")
         assert _sentry_error_processor in structlog.get_config()["processors"]
+
+
+class TestHealthProbeLogFilter:
+    def test_health_probe_access_log_dropped(self):
+        log = {"body": '172.18.0.4:0 - "GET /api/v1/health HTTP/1.1" 200'}
+        assert _drop_health_probe_logs(log, {}) is None
+
+    def test_regular_log_passes_through(self):
+        log = {"body": "discovery_started"}
+        assert _drop_health_probe_logs(log, {}) is log
+
+    def test_missing_body_passes_through(self):
+        log = {"attributes": {}}
+        assert _drop_health_probe_logs(log, {}) is log
 
 
 class TestCreateAppWiring:


### PR DESCRIPTION
## Summary
Closes the two best-practice gaps from today's Sentry review:

1. **Release tagging** — the CI deploy passes `SENTRY_RELEASE=<short sha>` to compose, so every event/log pins to the deployed commit: regressions show "first seen in release X" and Sentry auto-resolves issues fixed by a newer deploy. The SDK reads `SENTRY_RELEASE` from env natively — no code change needed. (Companion infra PR wires `deploy.sh` + `deploy-service.yml` + the compose passthrough.)
2. **Health-probe noise** — a `before_send_log` filter drops the docker healthcheck's `GET /api/v1/health` access-log lines (every 30s, ~3k/day of pure noise in the Logs explorer). The healthcheck's failure signal is the container going unhealthy, not a Sentry log.

## Test plan
- `make test-ci`: 724 passed, coverage 76.38% (ratchet ≥74) ✅ — 4 new tests (filter drop/pass/missing-body + init wiring)
- Post-deploy: boot log shows the release, health lines stop appearing in Sentry Logs, new events carry the release tag

Part of MYS-541

🤖 Generated with [Claude Code](https://claude.com/claude-code)