### PR TITLE
feat(agents): graph-runtime orchestration + book_to_place naming — PR 3 of the ADK 2 migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ flowchart TB
     end
 
     subgraph Phase1["Phase 1: Discovery"]
-        BC[book_context_pipeline<br/>🔍 Setting & themes]
+        BC[book_context researcher→formatter<br/>🔍 Setting & themes]
 
-        subgraph PD["Parallel Discovery ⚡"]
+        subgraph PD["Parallel graph branches ⚡ (fan-out → join)"]
             CP[City Agent<br/>🏙️]
             LP[Landmark Agent<br/>🏛️]
             AP[Author Agent<br/>✍️]

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -8,38 +8,42 @@ This package contains agent factory functions for:
 - Workflow orchestration
 """
 
-from .book_context_agent import create_book_context_pipeline
+from .book_context_agent import create_book_context_agents
 from .discovery_agents import (
-    create_city_pipeline,
-    create_landmark_pipeline,
-    create_author_pipeline,
+    create_city_agents,
+    create_landmark_agents,
+    create_author_agents,
 )
-from .local_atmosphere_agent import create_local_atmosphere_pipeline
+from .expansion_agent import create_expansion_agents
+from .local_atmosphere_agent import create_local_atmosphere_agents
 from .trip_composer_agent import create_trip_composer_agent
 from .region_analyzer_agent import create_region_analyzer_agent
-from .book_recommendation_agent import create_book_recommendation_pipeline
-from .place_to_book_agent import create_place_to_book_pipeline
+from .book_recommendation_agent import create_book_recommendation_agents
+from .place_to_book_agent import create_place_to_book_agents
 from .orchestrator import (
     create_book_recommendation_workflow,
+    create_expansion_workflow,
     create_place_to_book_workflow,
-    create_discovery_workflow,
-    create_composition_workflow,
+    create_book_to_place_discovery_workflow,
+    create_book_to_place_composition_workflow,
     create_local_atmosphere_workflow,
 )
 
 __all__ = [
-    "create_book_context_pipeline",
-    "create_city_pipeline",
-    "create_landmark_pipeline",
-    "create_author_pipeline",
-    "create_local_atmosphere_pipeline",
+    "create_book_context_agents",
+    "create_city_agents",
+    "create_landmark_agents",
+    "create_author_agents",
+    "create_expansion_agents",
+    "create_local_atmosphere_agents",
     "create_trip_composer_agent",
     "create_region_analyzer_agent",
-    "create_book_recommendation_pipeline",
-    "create_place_to_book_pipeline",
+    "create_book_recommendation_agents",
+    "create_place_to_book_agents",
     "create_book_recommendation_workflow",
+    "create_expansion_workflow",
     "create_place_to_book_workflow",
-    "create_discovery_workflow",
-    "create_composition_workflow",
+    "create_book_to_place_discovery_workflow",
+    "create_book_to_place_composition_workflow",
     "create_local_atmosphere_workflow",
 ]

--- a/agents/book_context_agent.py
+++ b/agents/book_context_agent.py
@@ -5,12 +5,12 @@ Two-stage pipeline that researches the book's setting, time period, and themes
 using Google Search.
 """
 
-from google.adk.agents import LlmAgent, SequentialAgent
+from google.adk.agents import LlmAgent
 from models.book import BookContext
 from agents.prompts import AgentPrompts, load_prompts
 
 
-def create_book_context_pipeline(
+def create_book_context_agents(
     model,
     google_search_tool,
     book_title: str = "",
@@ -28,7 +28,7 @@ def create_book_context_pipeline(
         prompts: Optional AgentPrompts instance. Loads default version if not provided.
 
     Returns:
-        SequentialAgent that researches and formats book context
+        (researcher, formatter) LlmAgent pair that researches and formats book context
     """
     if prompts is None:
         prompts = load_prompts()
@@ -79,7 +79,4 @@ def create_book_context_pipeline(
         instruction=prompts.book_context_formatter,
     )
 
-    return SequentialAgent(
-        name="book_context_pipeline",
-        sub_agents=[book_context_researcher, book_context_formatter],
-    )
+    return book_context_researcher, book_context_formatter

--- a/agents/book_recommendation_agent.py
+++ b/agents/book_recommendation_agent.py
@@ -11,13 +11,13 @@ The split below lets us keep both: researcher does the searches, formatter
 shapes the results into BookRecommendationsResult.
 """
 
-from google.adk.agents import LlmAgent, SequentialAgent
+from google.adk.agents import LlmAgent
 
 from models.book import BookRecommendationsResult
 from agents.prompts import AgentPrompts, load_prompts
 
 
-def create_book_recommendation_pipeline(
+def create_book_recommendation_agents(
     model,
     google_search_tool,
     book_title: str,
@@ -25,7 +25,7 @@ def create_book_recommendation_pipeline(
     destinations: str,
     themes: str,
     prompts: AgentPrompts | None = None,
-) -> SequentialAgent:
+):
     """Create the book recommendation pipeline.
 
     Researcher uses google_search to find candidate books matching destination,
@@ -42,7 +42,7 @@ def create_book_recommendation_pipeline(
         prompts: Optional AgentPrompts instance. Loads default version if not provided.
 
     Returns:
-        SequentialAgent that researches and formats book recommendations.
+        (researcher, formatter) LlmAgent pair that researches and formats book recommendations.
     """
     if prompts is None:
         prompts = load_prompts()
@@ -75,7 +75,4 @@ def create_book_recommendation_pipeline(
         instruction=formatter_instruction,
     )
 
-    return SequentialAgent(
-        name="book_recommendation_pipeline",
-        sub_agents=[researcher, formatter],
-    )
+    return researcher, formatter

--- a/agents/discovery_agents.py
+++ b/agents/discovery_agents.py
@@ -1,15 +1,15 @@
 """
 Discovery agents for cities, landmarks, and author sites.
 
-Three parallel two-stage pipelines that discover places to visit related to the book.
+Three researcher/formatter agent pairs (run as parallel graph branches) that discover places to visit related to the book.
 """
 
-from google.adk.agents import LlmAgent, SequentialAgent
+from google.adk.agents import LlmAgent
 from models.discovery import CityDiscovery, LandmarkDiscovery, AuthorSites
 from agents.prompts import AgentPrompts, load_prompts
 
 
-def create_city_pipeline(model, google_search_tool, prompts: AgentPrompts | None = None):
+def create_city_agents(model, google_search_tool, prompts: AgentPrompts | None = None):
     """
     Create the city discovery pipeline.
 
@@ -19,7 +19,7 @@ def create_city_pipeline(model, google_search_tool, prompts: AgentPrompts | None
         prompts: Optional AgentPrompts instance. Loads default version if not provided.
 
     Returns:
-        SequentialAgent that discovers and formats cities to visit
+        (researcher, formatter) LlmAgent pair that discovers and formats cities to visit
     """
     if prompts is None:
         prompts = load_prompts()
@@ -39,12 +39,10 @@ def create_city_pipeline(model, google_search_tool, prompts: AgentPrompts | None
         instruction=prompts.city_formatter,
     )
 
-    return SequentialAgent(
-        name="city_pipeline", sub_agents=[city_researcher, city_formatter]
-    )
+    return city_researcher, city_formatter
 
 
-def create_landmark_pipeline(model, google_search_tool, prompts: AgentPrompts | None = None):
+def create_landmark_agents(model, google_search_tool, prompts: AgentPrompts | None = None):
     """
     Create the landmark discovery pipeline.
 
@@ -54,7 +52,7 @@ def create_landmark_pipeline(model, google_search_tool, prompts: AgentPrompts | 
         prompts: Optional AgentPrompts instance. Loads default version if not provided.
 
     Returns:
-        SequentialAgent that discovers and formats landmarks to visit
+        (researcher, formatter) LlmAgent pair that discovers and formats landmarks to visit
     """
     if prompts is None:
         prompts = load_prompts()
@@ -74,13 +72,10 @@ def create_landmark_pipeline(model, google_search_tool, prompts: AgentPrompts | 
         instruction=prompts.landmark_formatter,
     )
 
-    return SequentialAgent(
-        name="landmark_pipeline",
-        sub_agents=[landmark_researcher, landmark_formatter],
-    )
+    return landmark_researcher, landmark_formatter
 
 
-def create_author_pipeline(model, google_search_tool, prompts: AgentPrompts | None = None):
+def create_author_agents(model, google_search_tool, prompts: AgentPrompts | None = None):
     """
     Create the author sites discovery pipeline.
 
@@ -90,7 +85,7 @@ def create_author_pipeline(model, google_search_tool, prompts: AgentPrompts | No
         prompts: Optional AgentPrompts instance. Loads default version if not provided.
 
     Returns:
-        SequentialAgent that discovers and formats author-related sites
+        (researcher, formatter) LlmAgent pair that discovers and formats author-related sites
     """
     if prompts is None:
         prompts = load_prompts()
@@ -110,6 +105,4 @@ def create_author_pipeline(model, google_search_tool, prompts: AgentPrompts | No
         instruction=prompts.author_formatter,
     )
 
-    return SequentialAgent(
-        name="author_pipeline", sub_agents=[author_researcher, author_formatter]
-    )
+    return author_researcher, author_formatter

--- a/agents/discovery_agents.py
+++ b/agents/discovery_agents.py
@@ -6,10 +6,18 @@ Three researcher/formatter agent pairs (run as parallel graph branches) that dis
 
 from google.adk.agents import LlmAgent
 from models.discovery import CityDiscovery, LandmarkDiscovery, AuthorSites
-from agents.prompts import AgentPrompts, load_prompts
+from agents.prompts import AgentPrompts, book_facts_block, load_prompts
 
 
-def create_city_agents(model, google_search_tool, prompts: AgentPrompts | None = None):
+def create_city_agents(
+    model,
+    google_search_tool,
+    book_title: str,
+    author: str,
+    vibe: str | None = None,
+    taste_context: dict | None = None,
+    prompts: AgentPrompts | None = None,
+):
     """
     Create the city discovery pipeline.
 
@@ -28,7 +36,11 @@ def create_city_agents(model, google_search_tool, prompts: AgentPrompts | None =
         name="city_researcher",
         model=model,
         tools=[google_search_tool],
-        instruction=prompts.city_researcher,
+        # Graph-scoped context (ADR #24): this researcher's only implicit
+        # input is the BookContext from its direct predecessor, which has
+        # no title/author/vibe — restore them explicitly.
+        instruction=book_facts_block(book_title, author, vibe, taste_context)
+        + prompts.city_researcher,
     )
 
     city_formatter = LlmAgent(
@@ -42,7 +54,15 @@ def create_city_agents(model, google_search_tool, prompts: AgentPrompts | None =
     return city_researcher, city_formatter
 
 
-def create_landmark_agents(model, google_search_tool, prompts: AgentPrompts | None = None):
+def create_landmark_agents(
+    model,
+    google_search_tool,
+    book_title: str,
+    author: str,
+    vibe: str | None = None,
+    taste_context: dict | None = None,
+    prompts: AgentPrompts | None = None,
+):
     """
     Create the landmark discovery pipeline.
 
@@ -61,7 +81,11 @@ def create_landmark_agents(model, google_search_tool, prompts: AgentPrompts | No
         name="landmark_researcher",
         model=model,
         tools=[google_search_tool],
-        instruction=prompts.landmark_researcher,
+        # Graph-scoped context (ADR #24): this researcher's only implicit
+        # input is the BookContext from its direct predecessor, which has
+        # no title/author/vibe — restore them explicitly.
+        instruction=book_facts_block(book_title, author, vibe, taste_context)
+        + prompts.landmark_researcher,
     )
 
     landmark_formatter = LlmAgent(
@@ -75,7 +99,15 @@ def create_landmark_agents(model, google_search_tool, prompts: AgentPrompts | No
     return landmark_researcher, landmark_formatter
 
 
-def create_author_agents(model, google_search_tool, prompts: AgentPrompts | None = None):
+def create_author_agents(
+    model,
+    google_search_tool,
+    book_title: str,
+    author: str,
+    vibe: str | None = None,
+    taste_context: dict | None = None,
+    prompts: AgentPrompts | None = None,
+):
     """
     Create the author sites discovery pipeline.
 
@@ -94,7 +126,11 @@ def create_author_agents(model, google_search_tool, prompts: AgentPrompts | None
         name="author_researcher",
         model=model,
         tools=[google_search_tool],
-        instruction=prompts.author_researcher,
+        # Graph-scoped context (ADR #24): this researcher's only implicit
+        # input is the BookContext from its direct predecessor, which has
+        # no title/author/vibe — restore them explicitly.
+        instruction=book_facts_block(book_title, author, vibe, taste_context)
+        + prompts.author_researcher,
     )
 
     author_formatter = LlmAgent(

--- a/agents/expansion_agent.py
+++ b/agents/expansion_agent.py
@@ -6,13 +6,13 @@ itinerary based on a user-selected suggestion chip. Mirrors the local_atmosphere
 pattern: researcher uses google_search, formatter emits structured output only.
 """
 
-from google.adk.agents import LlmAgent, SequentialAgent
+from google.adk.agents import LlmAgent
 
 from models.itinerary import ExpansionResult
 from agents.prompts import AgentPrompts, load_prompts
 
 
-def create_expansion_pipeline(
+def create_expansion_agents(
     model,
     google_search_tool,
     book_title: str,
@@ -39,7 +39,7 @@ def create_expansion_pipeline(
         prompts: Optional AgentPrompts instance. Loads default version if not provided.
 
     Returns:
-        SequentialAgent that researches and formats an expansion result.
+        (researcher, formatter) LlmAgent pair that researches and formats an expansion result.
     """
     if prompts is None:
         prompts = load_prompts()
@@ -71,7 +71,4 @@ def create_expansion_pipeline(
         instruction=formatter_instruction,
     )
 
-    return SequentialAgent(
-        name="expansion_pipeline",
-        sub_agents=[researcher, formatter],
-    )
+    return researcher, formatter

--- a/agents/local_atmosphere_agent.py
+++ b/agents/local_atmosphere_agent.py
@@ -6,13 +6,13 @@ whose mood and sensory character evoke a chosen book — used when the reader
 cannot travel to the book's actual setting.
 """
 
-from google.adk.agents import LlmAgent, SequentialAgent
+from google.adk.agents import LlmAgent
 
 from models.itinerary import ComposerEnvelope
 from agents.prompts import AgentPrompts, load_prompts
 
 
-def create_local_atmosphere_pipeline(
+def create_local_atmosphere_agents(
     model,
     google_search_tool,
     location_label: str,
@@ -33,7 +33,7 @@ def create_local_atmosphere_pipeline(
         prompts: Optional AgentPrompts instance. Loads default version if not provided.
 
     Returns:
-        SequentialAgent that researches and formats a local-atmosphere itinerary.
+        (researcher, formatter) LlmAgent pair that researches and formats a local-atmosphere itinerary.
     """
     if prompts is None:
         prompts = load_prompts()
@@ -60,7 +60,4 @@ def create_local_atmosphere_pipeline(
         instruction=formatter_instruction,
     )
 
-    return SequentialAgent(
-        name="local_atmosphere_pipeline",
-        sub_agents=[researcher, formatter],
-    )
+    return researcher, formatter

--- a/agents/local_atmosphere_agent.py
+++ b/agents/local_atmosphere_agent.py
@@ -9,7 +9,7 @@ cannot travel to the book's actual setting.
 from google.adk.agents import LlmAgent
 
 from models.itinerary import ComposerEnvelope
-from agents.prompts import AgentPrompts, load_prompts
+from agents.prompts import AgentPrompts, load_prompts, preferences_block
 
 
 def create_local_atmosphere_agents(
@@ -17,6 +17,7 @@ def create_local_atmosphere_agents(
     google_search_tool,
     location_label: str,
     radius_km: int,
+    preferences: dict | None = None,
     prompts: AgentPrompts | None = None,
 ):
     """
@@ -38,12 +39,15 @@ def create_local_atmosphere_agents(
     if prompts is None:
         prompts = load_prompts()
 
+    # Graph-scoped context (ADR #24): the initial user prompt reaches only
+    # the first node (book_context_researcher) — these two agents sit 3-4
+    # nodes downstream, so preferences must be baked into their instructions.
     researcher_instruction = prompts.local_atmosphere_researcher.format(
         location_label=location_label, radius_km=radius_km
-    )
+    ) + preferences_block(preferences)
     formatter_instruction = prompts.local_atmosphere_formatter.format(
         location_label=location_label, radius_km=radius_km
-    )
+    ) + preferences_block(preferences)
 
     researcher = LlmAgent(
         name="local_atmosphere_researcher",

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -175,6 +175,7 @@ def create_local_atmosphere_workflow(
     author: str,
     location_label: str,
     radius_km: int,
+    preferences: dict | None = None,
     prompts: AgentPrompts | None = None,
 ):
     """
@@ -213,6 +214,7 @@ def create_local_atmosphere_workflow(
         google_search,
         location_label=location_label,
         radius_km=radius_km,
+        preferences=preferences,
         prompts=prompts,
     )
 

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -48,6 +48,8 @@ def create_book_to_place_discovery_workflow(
     model,
     book_title: str,
     author: str,
+    vibe: str | None = None,
+    taste_context: dict | None = None,
     prompts: AgentPrompts | None = None,
 ):
     """
@@ -91,13 +93,31 @@ def create_book_to_place_discovery_workflow(
         model, google_search, book_title=book_title, author=author, prompts=prompts
     )
     city_researcher, city_formatter = create_city_agents(
-        model, google_search, prompts=prompts
+        model,
+        google_search,
+        book_title=book_title,
+        author=author,
+        vibe=vibe,
+        taste_context=taste_context,
+        prompts=prompts,
     )
     landmark_researcher, landmark_formatter = create_landmark_agents(
-        model, google_search, prompts=prompts
+        model,
+        google_search,
+        book_title=book_title,
+        author=author,
+        vibe=vibe,
+        taste_context=taste_context,
+        prompts=prompts,
     )
     author_researcher, author_formatter = create_author_agents(
-        model, google_search, prompts=prompts
+        model,
+        google_search,
+        book_title=book_title,
+        author=author,
+        vibe=vibe,
+        taste_context=taste_context,
+        prompts=prompts,
     )
     region_analyzer = create_region_analyzer_agent(model, prompts=prompts)
     join = JoinNode(name="discovery_join")

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -1,63 +1,79 @@
 """
 Workflow orchestrator.
 
-Creates workflows that coordinate all agents to produce complete literary
-travel itineraries.
+Builds the ADK 2 graph workflows (``google.adk.workflow.Workflow``) that
+coordinate all agents. Agents themselves are plain ``LlmAgent`` pairs built by
+the ``create_*_agents`` factories; this module owns ALL composition (chains,
+fan-out, fan-in) as explicit graph edges — no Sequential/ParallelAgent
+templates (removed in the ADK 2 graph rewrite, ADR #24).
 
-Two-phase architecture (HTTP API with HITL):
-1. Discovery workflow - finds locations and groups into travel regions
-2. Composition workflow - creates itinerary for selected region(s)
+NAMING: the primary capability — a book in, real places out — is
+``book_to_place``, the symmetric counterpart of the ``place_to_book`` reverse
+flow. It runs as two phase workflows because of the human-in-the-loop region
+selection between them (ADR #1):
+
+1. ``book_to_place_discovery``  — finds locations, groups into travel regions
+2. ``book_to_place_composition`` — creates the itinerary for selected region(s)
 
 WHY TWO PHASES WITH HITL?
 - Problem: Books like "Gone with the Wind" span Georgia (USA) and have author
   sites in Atlanta. Auto-generating itineraries for ALL regions would create
   impractical multi-continent trips.
-- Solution: After discovery, show user region options (e.g., "England", "Scotland")
-  and let them choose which region(s) to explore. This prevents wasting tokens
-  on unwanted regions and gives users control over trip scope.
-- Trade-off: Requires human input (not fully autonomous) but produces much more
-  practical and personalized itineraries.
+- Solution: After discovery, show user region options (e.g., "England",
+  "Scotland") and let them choose which region(s) to explore. This prevents
+  wasting tokens on unwanted regions and gives users control over trip scope.
+- Trade-off: Requires human input (not fully autonomous) but produces much
+  more practical and personalized itineraries.
 """
 
-from google.adk.agents import SequentialAgent, ParallelAgent
 from google.adk.tools import google_search
+from google.adk.workflow import JoinNode, START, Workflow
 
-from .book_context_agent import create_book_context_pipeline
+from .book_context_agent import create_book_context_agents
 from .discovery_agents import (
-    create_city_pipeline,
-    create_landmark_pipeline,
-    create_author_pipeline,
+    create_city_agents,
+    create_landmark_agents,
+    create_author_agents,
 )
-from .book_recommendation_agent import create_book_recommendation_pipeline
-from .place_to_book_agent import create_place_to_book_pipeline
-from .expansion_agent import create_expansion_pipeline
-from .local_atmosphere_agent import create_local_atmosphere_pipeline
+from .book_recommendation_agent import create_book_recommendation_agents
+from .place_to_book_agent import create_place_to_book_agents
+from .expansion_agent import create_expansion_agents
+from .local_atmosphere_agent import create_local_atmosphere_agents
 from .trip_composer_agent import create_trip_composer_agent
 from .region_analyzer_agent import create_region_analyzer_agent
 from .prompts import AgentPrompts, load_prompts
 
 
-def create_discovery_workflow(
+def create_book_to_place_discovery_workflow(
     model,
     book_title: str,
     author: str,
     prompts: AgentPrompts | None = None,
 ):
     """
-    Create the discovery workflow that finds locations and analyzes regions.
+    Create the book→place discovery workflow (phase 1 of the primary flow).
 
-    This workflow runs after the book metadata has been confirmed and before
-    user region selection. It discovers cities, landmarks, and author sites,
-    then groups them into practical travel regions for the user to choose from.
+    Runs after the book metadata has been confirmed and before user region
+    selection. It discovers cities, landmarks, and author sites, then groups
+    them into practical travel regions for the user to choose from.
 
-    Architecture:
-        SequentialAgent (discovery_workflow)
-        ├─ book_context_pipeline [research → format] → state["book_context"]
-        ├─ ParallelAgent (parallel_discovery) ⚡ CONCURRENT
-        │  ├─ city_pipeline [research → format] → state["city_discovery"]
-        │  ├─ landmark_pipeline [research → format] → state["landmark_discovery"]
-        │  └─ author_pipeline [research → format] → state["author_sites"]
-        └─ region_analyzer_agent → state["region_analysis"]
+    Graph:
+        START → book_context_researcher → book_context_formatter
+              → ⚡ fan-out: city_researcher   → city_formatter   ─┐
+                          landmark_researcher → landmark_formatter ┼→ join
+                          author_researcher   → author_formatter  ─┘
+              → region_analyzer                                  (fan-in)
+
+    Formatters write state["book_context"] / ["city_discovery"] /
+    ["landmark_discovery"] / ["author_sites"]; region_analyzer writes
+    state["region_analysis"]. The JoinNode is required: a plain node fires on
+    ANY predecessor, and region_analyzer must wait for ALL three branches
+    (pinned by tests/unit/test_graph_workflows.py).
+
+    WHY the fan-out: the three discovery branches make independent
+    google_search queries with no cross-dependencies — running them as
+    parallel graph branches is a 3x latency win at identical token cost
+    (ADR #3).
 
     Args:
         model: The LLM model to use
@@ -66,54 +82,70 @@ def create_discovery_workflow(
         prompts: Optional AgentPrompts instance. Loads default version if not provided.
 
     Returns:
-        SequentialAgent orchestrating the discovery workflow
+        Workflow graph for book→place discovery
     """
     if prompts is None:
         prompts = load_prompts()
 
-    # Create pipelines with exact book info
-    book_context_pipeline = create_book_context_pipeline(
+    book_context_researcher, book_context_formatter = create_book_context_agents(
         model, google_search, book_title=book_title, author=author, prompts=prompts
     )
-
-    city_pipeline = create_city_pipeline(model, google_search, prompts=prompts)
-    landmark_pipeline = create_landmark_pipeline(model, google_search, prompts=prompts)
-    author_pipeline = create_author_pipeline(model, google_search, prompts=prompts)
-
+    city_researcher, city_formatter = create_city_agents(
+        model, google_search, prompts=prompts
+    )
+    landmark_researcher, landmark_formatter = create_landmark_agents(
+        model, google_search, prompts=prompts
+    )
+    author_researcher, author_formatter = create_author_agents(
+        model, google_search, prompts=prompts
+    )
     region_analyzer = create_region_analyzer_agent(model, prompts=prompts)
+    join = JoinNode(name="discovery_join")
 
-    # Create parallel discovery agent for concurrent execution
-    # WHY PARALLEL: Running city/landmark/author agents concurrently provides 3x speedup
-    # (15s vs 45s) with no additional token cost. Each agent makes independent Google
-    # Search queries that don't depend on each other's results.
-    parallel_discovery = ParallelAgent(
-        name="parallel_discovery",
-        sub_agents=[city_pipeline, landmark_pipeline, author_pipeline],
+    return Workflow(
+        name="book_to_place_discovery",
+        edges=[
+            (
+                START,
+                book_context_researcher,
+                book_context_formatter,
+                (city_researcher, landmark_researcher, author_researcher),
+            ),
+            (city_researcher, city_formatter, join),
+            (landmark_researcher, landmark_formatter, join),
+            (author_researcher, author_formatter, join),
+            (join, region_analyzer),
+        ],
     )
 
-    # Build discovery workflow
-    # WHY SEQUENTIAL: Each stage depends on previous stage's output:
-    # - book_context provides setting/theme → discovery agents use this context
-    # - parallel_discovery provides locations → region_analyzer groups them
-    #
-    # reader_profile_agent (an LlmAgent reading get_user_preferences) was
-    # removed here (MYS-436): no UI has ever collected budget/pace/museums/
-    # kids/genres, so it burned a sequential LLM call on every discovery to
-    # always produce the same "no preferences found, using defaults" turn.
-    # trip_composer's own instruction already falls back to those exact
-    # defaults when it finds no reader_profile turn in conversation history
-    # (agents/prompts/{v1,v2,v3}.json, "reader_profile" is prose consumed via
-    # conversation history, not a `{reader_profile}` template variable -- so
-    # there is no interpolation KeyError risk from removing the writer).
-    sub_agents = [
-        book_context_pipeline,
-        parallel_discovery,
-        region_analyzer,
-    ]
 
-    return SequentialAgent(
-        name="discovery_workflow",
-        sub_agents=sub_agents,
+def create_book_to_place_composition_workflow(
+    model, prompts: AgentPrompts | None = None
+):
+    """
+    Create the book→place composition workflow (phase 2 of the primary flow).
+
+    Runs after the user has selected region(s); expects the selection in
+    session state (written by the executor before the run).
+
+    Graph:
+        START → trip_composer → state["composer_envelope"]
+
+    Args:
+        model: The LLM model to use
+        prompts: Optional AgentPrompts instance. Loads default version if not provided.
+
+    Returns:
+        Workflow graph for book→place composition
+    """
+    if prompts is None:
+        prompts = load_prompts()
+
+    trip_composer = create_trip_composer_agent(model, prompts=prompts)
+
+    return Workflow(
+        name="book_to_place_composition",
+        edges=[(START, trip_composer)],
     )
 
 
@@ -132,13 +164,12 @@ def create_local_atmosphere_workflow(
     an itinerary near their current location whose mood and sensory character
     evoke the book.
 
-    Architecture:
-        SequentialAgent (local_atmosphere_workflow)
-        ├─ book_context_pipeline [research → format] → state["book_context"]
-        └─ local_atmosphere_pipeline [research → format] → state["final_itinerary"]
+    Graph:
+        START → book_context_researcher → book_context_formatter
+              → local_atmosphere_researcher → local_atmosphere_formatter
 
-    There is no city/landmark/author/region discovery: those agents look at the
-    book's geography, which is irrelevant here.
+    There is no city/landmark/author/region discovery: those agents look at
+    the book's geography, which is irrelevant here (ADR #13).
 
     Args:
         model: The LLM model to use.
@@ -149,17 +180,15 @@ def create_local_atmosphere_workflow(
         prompts: Optional AgentPrompts instance. Loads default version if not provided.
 
     Returns:
-        SequentialAgent orchestrating the local-atmosphere workflow.
+        Workflow graph for the local-atmosphere flow.
     """
     if prompts is None:
         prompts = load_prompts()
 
-    book_context_pipeline = create_book_context_pipeline(
+    book_context_researcher, book_context_formatter = create_book_context_agents(
         model, google_search, book_title=book_title, author=author, prompts=prompts
     )
-    # reader_profile_agent removed here too (MYS-436) -- same dead hot-path
-    # LLM call as create_discovery_workflow above; see that function's comment.
-    local_pipeline = create_local_atmosphere_pipeline(
+    local_researcher, local_formatter = create_local_atmosphere_agents(
         model,
         google_search,
         location_label=location_label,
@@ -167,9 +196,17 @@ def create_local_atmosphere_workflow(
         prompts=prompts,
     )
 
-    return SequentialAgent(
+    return Workflow(
         name="local_atmosphere_workflow",
-        sub_agents=[book_context_pipeline, local_pipeline],
+        edges=[
+            (
+                START,
+                book_context_researcher,
+                book_context_formatter,
+                local_researcher,
+                local_formatter,
+            )
+        ],
     )
 
 
@@ -186,14 +223,12 @@ def create_expansion_workflow(
     """
     Create the expansion workflow that adds new places to an existing itinerary city.
 
-    Called after composition when the user clicks a suggestion chip. Runs a
-    researcher → formatter pipeline scoped to the chosen city and action.
+    Called after composition when the user clicks a suggestion chip.
 
-    Architecture:
-        SequentialAgent (expansion_workflow)
-        └─ expansion_pipeline
-           ├─ expansion_researcher [google_search] → research notes
-           └─ expansion_formatter [output_schema=ExpansionResult] → state["last_expansion"]
+    Graph:
+        START → expansion_researcher [google_search]
+              → expansion_formatter [output_schema=ExpansionResult]
+              → state["last_expansion"]
 
     Args:
         model: The LLM model to use.
@@ -206,12 +241,12 @@ def create_expansion_workflow(
         prompts: Optional AgentPrompts instance. Loads default version if not provided.
 
     Returns:
-        SequentialAgent orchestrating the expansion pipeline.
+        Workflow graph for the expansion flow.
     """
     if prompts is None:
         prompts = load_prompts()
 
-    expansion_pipeline = create_expansion_pipeline(
+    researcher, formatter = create_expansion_agents(
         model,
         google_search_tool,
         book_title=book_title,
@@ -222,9 +257,9 @@ def create_expansion_workflow(
         prompts=prompts,
     )
 
-    return SequentialAgent(
+    return Workflow(
         name="expansion_workflow",
-        sub_agents=[expansion_pipeline],
+        edges=[(START, researcher, formatter)],
     )
 
 
@@ -241,13 +276,10 @@ def create_book_recommendation_workflow(
     Create the book recommendation workflow.
 
     Called after composition when the user clicks the "Find books like this" chip.
-    Runs a single agent that searches for and returns 5 book recommendations.
 
-    Architecture:
-        SequentialAgent (book_recommendation_workflow)
-        └─ book_recommendation_pipeline
-           ├─ book_recommendation_researcher [google_search] → research notes
-           └─ book_recommendation_formatter [output_schema=BookRecommendationsResult]
+    Graph:
+        START → book_recommendation_researcher [google_search]
+              → book_recommendation_formatter [output_schema=BookRecommendationsResult]
               → state["last_book_recommendations"]
 
     Args:
@@ -260,12 +292,12 @@ def create_book_recommendation_workflow(
         prompts: Optional AgentPrompts instance. Loads default version if not provided.
 
     Returns:
-        SequentialAgent orchestrating the book recommendation pipeline.
+        Workflow graph for the book-recommendation flow.
     """
     if prompts is None:
         prompts = load_prompts()
 
-    pipeline = create_book_recommendation_pipeline(
+    researcher, formatter = create_book_recommendation_agents(
         model,
         google_search_tool,
         book_title=book_title,
@@ -275,38 +307,9 @@ def create_book_recommendation_workflow(
         prompts=prompts,
     )
 
-    return SequentialAgent(
+    return Workflow(
         name="book_recommendation_workflow",
-        sub_agents=[pipeline],
-    )
-
-
-def create_composition_workflow(model, prompts: AgentPrompts | None = None):
-    """
-    Create the composition workflow that generates the final itinerary.
-
-    This workflow runs after the user has selected a region.
-    It expects the selected region to be stored in session state as "selected_region".
-
-    Architecture:
-        SequentialAgent (composition_workflow)
-        └─ trip_composer_agent → state["final_itinerary"]
-
-    Args:
-        model: The LLM model to use
-        prompts: Optional AgentPrompts instance. Loads default version if not provided.
-
-    Returns:
-        SequentialAgent orchestrating the composition workflow
-    """
-    if prompts is None:
-        prompts = load_prompts()
-
-    trip_composer = create_trip_composer_agent(model, prompts=prompts)
-
-    return SequentialAgent(
-        name="composition_workflow",
-        sub_agents=[trip_composer],
+        edges=[(START, researcher, formatter)],
     )
 
 
@@ -319,19 +322,15 @@ def create_place_to_book_workflow(
     """
     Create the place→book reverse-routing workflow (AI candidate layer).
 
-    The reverse of discovery: a destination is the input and grounded,
-    literal/vibe-labelled book candidates are the output. Wraps the
-    place_to_book pipeline (researcher [google_search] → formatter
-    [output_schema=PlaceToBookCandidates]).
+    The reverse of the primary book→place flow: a destination is the input
+    and grounded, literal/vibe-labelled book candidates are the output.
+    Exposed as ``POST /place-to-book`` (gateway secret enforced); the
+    storyland-services gateway runs the authoritative Google Books existence
+    check downstream.
 
-    Isolated capability — not yet wired into the HTTP API; the BE place→book
-    endpoint will call it (PR 3 of the reverse-flow feature).
-
-    Architecture:
-        SequentialAgent (place_to_book_workflow)
-        └─ place_to_book_pipeline
-           ├─ place_to_book_researcher [google_search] → research notes
-           └─ place_to_book_formatter [output_schema=PlaceToBookCandidates]
+    Graph:
+        START → place_to_book_researcher [google_search]
+              → place_to_book_formatter [output_schema=PlaceToBookCandidates]
               → state["last_place_to_book"]
 
     Args:
@@ -341,16 +340,16 @@ def create_place_to_book_workflow(
         prompts: Optional AgentPrompts instance. Loads default version if not provided.
 
     Returns:
-        SequentialAgent orchestrating the place→book pipeline.
+        Workflow graph for the place→book flow.
     """
     if prompts is None:
         prompts = load_prompts()
 
-    pipeline = create_place_to_book_pipeline(
+    researcher, formatter = create_place_to_book_agents(
         model, google_search_tool, place=place, prompts=prompts
     )
 
-    return SequentialAgent(
+    return Workflow(
         name="place_to_book_workflow",
-        sub_agents=[pipeline],
+        edges=[(START, researcher, formatter)],
     )

--- a/agents/place_to_book_agent.py
+++ b/agents/place_to_book_agent.py
@@ -11,7 +11,7 @@ input and books are the output. No new model and no new paid API — it reuses t
 same google_search researcher pass already used across discovery.
 """
 
-from google.adk.agents import LlmAgent, SequentialAgent
+from google.adk.agents import LlmAgent
 
 from models.place_to_book import PlaceToBookCandidates
 from agents.prompts import AgentPrompts, load_prompts
@@ -21,12 +21,12 @@ from agents.prompts import AgentPrompts, load_prompts
 PLACE_TO_BOOK_OUTPUT_KEY = "last_place_to_book"
 
 
-def create_place_to_book_pipeline(
+def create_place_to_book_agents(
     model,
     google_search_tool,
     place: str,
     prompts: AgentPrompts | None = None,
-) -> SequentialAgent:
+):
     """Create the place→book reverse-routing pipeline.
 
     Researcher uses google_search to find books genuinely set in (or strongly
@@ -41,7 +41,7 @@ def create_place_to_book_pipeline(
         prompts: Optional AgentPrompts instance. Loads default version if not provided.
 
     Returns:
-        SequentialAgent that researches and formats place→book candidates.
+        (researcher, formatter) LlmAgent pair that researches and formats place→book candidates.
     """
     if prompts is None:
         prompts = load_prompts()
@@ -64,7 +64,4 @@ def create_place_to_book_pipeline(
         instruction=formatter_instruction,
     )
 
-    return SequentialAgent(
-        name="place_to_book_pipeline",
-        sub_agents=[researcher, formatter],
-    )
+    return researcher, formatter

--- a/agents/prompts.py
+++ b/agents/prompts.py
@@ -90,6 +90,26 @@ def book_facts_block(
     return "\n".join(lines) + "\n\n"
 
 
+def preferences_block(preferences: dict | None) -> str:
+    """Explicit reader-preferences block for graph-scoped agent instructions.
+
+    Appending preferences to a flow's initial user prompt only reaches the
+    FIRST node of the graph (trigger-chain scoping, ADR #24); any agent
+    deeper in the chain needs them baked into its instruction. Empty when no
+    preferences were supplied — the instruction is byte-identical to the
+    no-preferences build. Lives in this cache-fingerprinted module for the
+    same reason as book_facts_block.
+    """
+    if not preferences:
+        return ""
+    import json
+
+    return (
+        "\n\nREADER PREFERENCES — honor these when choosing places and "
+        "pacing:\n" + json.dumps(preferences)
+    )
+
+
 def load_prompts(version: str = CURRENT_PROMPT_VERSION) -> AgentPrompts:
     """
     Load agent prompts for a given version from agents/prompts/{version}.json.

--- a/agents/prompts.py
+++ b/agents/prompts.py
@@ -52,6 +52,44 @@ class AgentPrompts:
     place_to_book_formatter: str  # template with {place}
 
 
+def book_facts_block(
+    book_title: str,
+    author: str,
+    vibe: str | None = None,
+    taste_context: dict | None = None,
+) -> str:
+    """Explicit book-facts header prepended to graph-scoped researcher instructions.
+
+    Under the ADK 2 graph runtime (ADR #24) a node's conversation is scoped to
+    its trigger chain: the city/landmark/author researchers receive only the
+    BookContext emitted by their direct predecessor — which carries locations,
+    period, and themes but NOT the exact title, author, or the reader's
+    vibe/taste biasing that ride the discovery user prompt. On 1.x templates
+    they saw all of it implicitly. This block restores those facts explicitly.
+
+    Lives in THIS module deliberately: core/cache_version.py fingerprints
+    ``agents.prompts`` source, so any edit here flips the discovery cache
+    namespace. Baking the block in the factory modules instead would change
+    effective instructions WITHOUT invalidating cached discovery results —
+    the MYS-222/MYS-462 class of error.
+    """
+    lines = [
+        "BOOK FACTS (explicit — the conversation may not contain them):",
+        f'Title: "{book_title}"',
+        f"Author: {author}",
+    ]
+    if vibe:
+        lines.append(f"Reader's requested vibe: {vibe}")
+    if taste_context:
+        titles = ", ".join(taste_context.get("titles") or [])
+        moods = ", ".join(taste_context.get("moods") or [])
+        if titles:
+            lines.append(f"Reader also loved: {titles}")
+        if moods:
+            lines.append(f"Reader's preferred moods: {moods}")
+    return "\n".join(lines) + "\n\n"
+
+
 def load_prompts(version: str = CURRENT_PROMPT_VERSION) -> AgentPrompts:
     """
     Load agent prompts for a given version from agents/prompts/{version}.json.

--- a/core/executor.py
+++ b/core/executor.py
@@ -651,8 +651,17 @@ class WorkflowExecutor:
             composition_workflow = create_book_to_place_composition_workflow(self._model)
             runner = self._build_runner(composition_workflow, langfuse_plugin)
 
+            # Graph-runtime history is scoped per invocation (ADR #24): the
+            # composer sees none of the discovery conversation, so its
+            # grounded inputs are passed explicitly from session state.
             prompt = build_composition_prompt(
-                exact_title, exact_author, selected_regions
+                exact_title,
+                exact_author,
+                selected_regions,
+                book_context=state.book_context,
+                city_discovery=state.city_discovery,
+                landmark_discovery=state.landmark_discovery,
+                author_sites=state.author_sites,
             )
             message = types.Content(
                 role="user", parts=[types.Part(text=prompt)]

--- a/core/executor.py
+++ b/core/executor.py
@@ -696,6 +696,7 @@ class WorkflowExecutor:
                 city_discovery=state.city_discovery,
                 landmark_discovery=state.landmark_discovery,
                 author_sites=state.author_sites,
+                preferences=state.user_preferences,
             )
             message = types.Content(
                 role="user", parts=[types.Part(text=prompt)]
@@ -859,7 +860,8 @@ class WorkflowExecutor:
             runner = self._build_runner(workflow, langfuse_plugin)
 
             prompt = build_local_atmosphere_prompt(
-                book_title, author, location_label, radius_km
+                book_title, author, location_label, radius_km,
+                preferences=preferences,
             )
             message = types.Content(
                 role="user", parts=[types.Part(text=prompt)]

--- a/core/executor.py
+++ b/core/executor.py
@@ -42,8 +42,8 @@ from google.adk.plugins.logging_plugin import LoggingPlugin
 
 from agents.orchestrator import (
     create_book_recommendation_workflow,
-    create_discovery_workflow,
-    create_composition_workflow,
+    create_book_to_place_discovery_workflow,
+    create_book_to_place_composition_workflow,
     create_expansion_workflow,
     create_local_atmosphere_workflow,
 )
@@ -102,17 +102,12 @@ logger = get_logger("storyland.core.executor")
 DISCOVERY_AGENT_STEPS: dict[str, str] = {
     "book_context_researcher": "Researching book setting and themes",
     "book_context_formatter": "Formatting book context",
-    "book_context_pipeline": "Analyzing book context",
-    "parallel_discovery": "Running parallel location discovery",
     "city_researcher": "Finding cities related to the book",
     "city_formatter": "Formatting city results",
-    "city_pipeline": "Discovering cities",
     "landmark_researcher": "Discovering landmarks and key locations",
     "landmark_formatter": "Formatting landmark results",
-    "landmark_pipeline": "Discovering landmarks",
     "author_researcher": "Locating author-related sites",
     "author_formatter": "Formatting author sites",
-    "author_pipeline": "Discovering author sites",
     "region_analyzer": "Analyzing geographic regions",
 }
 
@@ -123,13 +118,11 @@ LOCAL_ATMOSPHERE_AGENT_STEPS: dict[str, str] = {
     "book_context_pipeline": "Analyzing book atmosphere",
     "local_atmosphere_researcher": "Finding atmospheric places near you",
     "local_atmosphere_formatter": "Composing your local outing",
-    "local_atmosphere_pipeline": "Building local-atmosphere itinerary",
 }
 
 EXPANSION_AGENT_STEPS: dict[str, str] = {
     "expansion_researcher": "Searching for new places",
     "expansion_formatter": "Curating your additions",
-    "expansion_pipeline": "Finding new places to add",
 }
 
 SOFT_CHIP_CAP = 6
@@ -139,8 +132,6 @@ BOOK_RECOMMENDATION_HARD_CAP = 5
 BOOK_RECOMMENDATION_AGENT_STEPS: dict[str, str] = {
     "book_recommendation_researcher": "Searching for book recommendations",
     "book_recommendation_formatter": "Curating your book picks",
-    "book_recommendation_pipeline": "Finding books for you",
-    "book_recommendation_workflow": "Finding books for you",
 }
 
 APP_NAME = "storyland"
@@ -232,7 +223,7 @@ class WorkflowExecutor:
         if langfuse_plugin is not None:
             plugins.append(langfuse_plugin)
         return Runner(
-            agent=workflow,
+            node=workflow,
             app_name=APP_NAME,
             session_service=self._session_service,
             plugins=plugins,
@@ -443,7 +434,7 @@ class WorkflowExecutor:
             )
 
             langfuse_plugin = self._create_langfuse_plugin()
-            discovery_workflow = create_discovery_workflow(
+            discovery_workflow = create_book_to_place_discovery_workflow(
                 self._model, book_title=exact_title, author=exact_author
             )
             runner = self._build_runner(discovery_workflow, langfuse_plugin)
@@ -657,7 +648,7 @@ class WorkflowExecutor:
             )
 
             langfuse_plugin = self._create_langfuse_plugin()
-            composition_workflow = create_composition_workflow(self._model)
+            composition_workflow = create_book_to_place_composition_workflow(self._model)
             runner = self._build_runner(composition_workflow, langfuse_plugin)
 
             prompt = build_composition_prompt(

--- a/core/executor.py
+++ b/core/executor.py
@@ -856,6 +856,7 @@ class WorkflowExecutor:
                 author=author,
                 location_label=location_label,
                 radius_km=radius_km,
+                preferences=preferences,
             )
             runner = self._build_runner(workflow, langfuse_plugin)
 

--- a/core/executor.py
+++ b/core/executor.py
@@ -235,16 +235,20 @@ class WorkflowExecutor:
         user_id: str,
         book_title: str,
         author: str,
-        region_analysis: dict,
+        cached: dict,
     ) -> AsyncGenerator[DomainEvent, None]:
         """Replay a cached discovery result without invoking Gemini.
 
         The session already exists (created by ``discover`` before the cache
-        lookup). This writes the confirmed book metadata and the cached
-        region analysis into session state via ``append_event`` so the
-        downstream discover->compose handoff (which reads ``state.regions``)
-        behaves identically to a fresh run.
+        lookup). ``cached`` is the v2 grounding bundle: region_analysis PLUS
+        book_context and the three discovery payloads. ALL of it is written
+        into session state via ``append_event`` so the downstream
+        discover->compose handoff behaves identically to a fresh run —
+        compose() reads the grounding from state (ADR #24 graph scoping), so
+        a hit that replayed only regions would compose from city names alone
+        on precisely the popular, repeated titles the cache serves most.
         """
+        region_analysis = cached.get("region_analysis") or {}
         # A cache HIT must never replay a region with no place_key: hits land
         # hardest on popular, repeated titles — exactly the book-club case the
         # combined readaway exists for — so a keyless replay would kill the
@@ -263,15 +267,23 @@ class WorkflowExecutor:
         session = await self._session_service.get_session(
             app_name=APP_NAME, user_id=user_id, session_id=job_id
         )
+        state_delta = {
+            SessionStateKeys.BOOK_METADATA: book_metadata.model_dump(),
+            SessionStateKeys.REGION_ANALYSIS: region_analysis,
+        }
+        # Replay the grounding payloads compose() will read from state.
+        for key, value in (
+            (SessionStateKeys.BOOK_CONTEXT, cached.get("book_context")),
+            (SessionStateKeys.CITY_DISCOVERY, cached.get("city_discovery")),
+            (SessionStateKeys.LANDMARK_DISCOVERY, cached.get("landmark_discovery")),
+            (SessionStateKeys.AUTHOR_SITES, cached.get("author_sites")),
+        ):
+            if value:
+                state_delta[key] = value
         cache_event = Event(
             invocation_id="system",
             author="system",
-            actions=EventActions(
-                state_delta={
-                    SessionStateKeys.BOOK_METADATA: book_metadata.model_dump(),
-                    SessionStateKeys.REGION_ANALYSIS: region_analysis,
-                }
-            ),
+            actions=EventActions(state_delta=state_delta),
         )
         await self._session_service.append_event(session, cache_event)
 
@@ -313,7 +325,10 @@ class WorkflowExecutor:
         pref_sig = hashlib.sha1(
             repr(pref_items).encode("utf-8")
         ).hexdigest()
-        key = f"discover:v1:{norm_title}|{norm_author}|{pref_sig}"
+        # v2: the cached value is the full grounding bundle (region_analysis +
+        # book_context + the three discovery payloads), not just region_analysis —
+        # a cache HIT must compose with the same grounding as a fresh run.
+        key = f"discover:v2:{norm_title}|{norm_author}|{pref_sig}"
         norm_vibe = (vibe or "").strip().lower()
         if norm_vibe:
             key += f"|vibe={norm_vibe}"
@@ -403,7 +418,7 @@ class WorkflowExecutor:
                 user_id=user_id,
                 book_title=book_title,
                 author=author,
-                region_analysis=cached_region_analysis,
+                cached=cached_region_analysis,
             ):
                 yield ev
             return
@@ -434,8 +449,15 @@ class WorkflowExecutor:
             )
 
             langfuse_plugin = self._create_langfuse_plugin()
+            # vibe/taste ride the researcher instructions now (ADR #24:
+            # graph-scoped context — branch researchers never see the user
+            # prompt that used to carry them).
             discovery_workflow = create_book_to_place_discovery_workflow(
-                self._model, book_title=exact_title, author=exact_author
+                self._model,
+                book_title=exact_title,
+                author=exact_author,
+                vibe=vibe,
+                taste_context=taste_context,
             )
             runner = self._build_runner(discovery_workflow, langfuse_plugin)
 
@@ -499,9 +521,21 @@ class WorkflowExecutor:
             regions = region_analysis.get("regions", [])
 
             # Store on miss: cache only non-empty, schema-validated region
-            # sets so a future hit can safely short-circuit the chain.
+            # sets so a future hit can safely short-circuit the chain. The
+            # bundle carries the grounding payloads too: on a HIT, compose()
+            # reads them from replayed session state (a hit that composed
+            # from region names alone was the first PR-3 gate failure).
             if self._cache_enabled and regions:
-                await self._discovery_cache.set(cache_key, region_analysis)
+                await self._discovery_cache.set(
+                    cache_key,
+                    {
+                        "region_analysis": region_analysis,
+                        "book_context": run_state.book_context,
+                        "city_discovery": run_state.city_discovery,
+                        "landmark_discovery": run_state.landmark_discovery,
+                        "author_sites": run_state.author_sites,
+                    },
+                )
 
             yield RegionsReady(
                 job_id=job_id,

--- a/core/executor.py
+++ b/core/executor.py
@@ -221,6 +221,10 @@ class WorkflowExecutor:
         """
         plugins = [LoggingPlugin()]
         if langfuse_plugin is not None:
+            # Inject the trace-name identity: under Runner(node=...) ADK builds
+            # InvocationContext with agent=None, so the plugin cannot recover
+            # the root name from the context (see LangfusePlugin.root_name).
+            langfuse_plugin.root_name = getattr(workflow, "name", None)
             plugins.append(langfuse_plugin)
         return Runner(
             node=workflow,

--- a/core/place_to_book.py
+++ b/core/place_to_book.py
@@ -221,7 +221,7 @@ class PlaceToBookResolver:
         ``core.place_to_book.Runner`` as the single fake seam.
         """
         return Runner(
-            agent=workflow,
+            node=workflow,
             app_name=APP_NAME,
             session_service=self._session_service,
             plugins=[LoggingPlugin()],

--- a/core/prompts.py
+++ b/core/prompts.py
@@ -74,16 +74,56 @@ def build_composition_prompt(
     book_title: str,
     author: str,
     selected_regions: List[dict],
+    book_context: dict | None = None,
+    city_discovery: object | None = None,
+    landmark_discovery: object | None = None,
+    author_sites: object | None = None,
 ) -> str:
-    """Build the user prompt for the composition phase (phase 3)."""
-    return (
-        f'Create a travel itinerary for "{book_title}" by {author}.\n\n'
-        f"Use ONLY the cities from the selected region(s): "
-        f"{json.dumps(selected_regions)}\n\n"
-        f"Create a personalized itinerary based on user preferences "
-        f"and the selected region(s).\n"
-        f"Include ALL cities from the selected regions in your itinerary."
+    """Build the user prompt for the composition phase (phase 3).
+
+    Under the ADK 2 graph runtime an invocation's conversation is scoped to
+    its trigger chain — the composer (a separate invocation from discovery)
+    sees NOTHING of the discovery conversation. On the 1.x template runtime
+    it implicitly saw all of it. The grounded research the composer needs is
+    therefore passed EXPLICITLY here, read from session state (where the
+    discovery formatters put it via output_key): book context for
+    theme/setting fit, and the three discovery payloads so stops come from
+    researched places instead of the model's unaided world knowledge.
+    Explicit-and-bounded beats the old implicit-and-unbounded history: the
+    composer gets exactly the validated payloads, not every intermediate
+    researcher turn.
+    """
+    sections = [
+        f'Create a travel itinerary for "{book_title}" by {author}.\n',
+        (
+            "Use ONLY the cities from the selected region(s): "
+            f"{json.dumps(selected_regions)}\n"
+        ),
+    ]
+    if book_context:
+        sections.append(
+            "Book context (setting, time period, themes) from research:\n"
+            f"{json.dumps(book_context)}\n"
+        )
+    grounded = {
+        "cities": city_discovery,
+        "landmarks": landmark_discovery,
+        "author_sites": author_sites,
+    }
+    grounded = {k: v for k, v in grounded.items() if v}
+    if grounded:
+        sections.append(
+            "Grounded discovery research — prefer these real, researched "
+            "places (within the selected regions) when composing stops, and "
+            "label match_type/grounding_source from this evidence:\n"
+            f"{json.dumps(grounded)}\n"
+        )
+    sections.append(
+        "Create a personalized itinerary based on user preferences "
+        "and the selected region(s).\n"
+        "Include ALL cities from the selected regions in your itinerary."
     )
+    return "\n".join(sections)
 
 
 def build_local_atmosphere_prompt(

--- a/core/prompts.py
+++ b/core/prompts.py
@@ -78,6 +78,7 @@ def build_composition_prompt(
     city_discovery: object | None = None,
     landmark_discovery: object | None = None,
     author_sites: object | None = None,
+    preferences: dict | None = None,
 ) -> str:
     """Build the user prompt for the composition phase (phase 3).
 
@@ -111,6 +112,15 @@ def build_composition_prompt(
         "author_sites": author_sites,
     }
     grounded = {k: v for k, v in grounded.items() if v}
+    if preferences:
+        # user:preferences reach the composer explicitly (MYS-436 removed the
+        # reader_profile agent that used to surface them as a conversation
+        # turn; the API — and the eval harness — still supply them).
+        sections.append(
+            "READER PREFERENCES — honor these when choosing stops, pacing, "
+            "and trip length:\n"
+            f"{json.dumps(preferences)}\n"
+        )
     if grounded:
         sections.append(
             "Grounded discovery research — prefer these real, researched "
@@ -131,6 +141,7 @@ def build_local_atmosphere_prompt(
     author: str,
     location_label: str,
     radius_km: int,
+    preferences: dict | None = None,
 ) -> str:
     """Build the user prompt for the local-atmosphere flow.
 
@@ -147,4 +158,10 @@ def build_local_atmosphere_prompt(
         f"Find real places near the user whose mood, era, and sensory feel "
         f"evoke the book. Group them into 1-3 nearby towns and return a "
         f"TripItinerary that respects the user's preferences."
+        + (
+            "\n\nREADER PREFERENCES — honor these when choosing stops and "
+            "pacing:\n" + json.dumps(preferences)
+            if preferences
+            else ""
+        )
     )

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -101,6 +101,8 @@ formatter = LlmAgent(
 )
 
 pipeline = SequentialAgent(sub_agents=[researcher, formatter])
+# ^ historical (ADK 1.x). Since the graph rewrite (ADR #24) the pair is wired
+#   as Workflow edges: (START, researcher, formatter) — same two-stage contract.
 ```
 
 ### Rationale
@@ -170,6 +172,8 @@ This pattern appears in:
 
 ### Decision
 Run city, landmark, and author discovery agents concurrently using `ParallelAgent`.
+
+> **Implementation superseded (2026-07, ADR #24):** the fan-out is now explicit graph edges — `book_context_formatter → (city, landmark, author) → JoinNode → region_analyzer`. The decision (parallelize the three independent branches) is unchanged; only the mechanism moved from the template agent to the graph runtime.
 
 ### Implementation
 ```python
@@ -1023,6 +1027,40 @@ Migrate in stages, eval-gated against a two-run pre-migration baseline (storylan
 
 ---
 
+## 24. Graph-Runtime Orchestration + the Primary Flow Named `book_to_place` (2026-07-19)
+
+### Context
+
+PR 2 of the ADK migration (ADR #23) ran on the deprecated-but-functional `SequentialAgent`/`ParallelAgent` templates. Separately, the codebase had a naming asymmetry: the reverse direction was a named capability (`place_to_book`) while the primary direction — a book in, real places out — was the unnamed default ("the workflow"), which is why the harness had grown two dialects for driving the same runner.
+
+### Decision
+
+**All six workflows are explicit `google.adk.workflow.Workflow` graphs** built in `agents/orchestrator.py`; the `agents/create_*_agents` factories return plain `(researcher, formatter)` `LlmAgent` pairs and own NO composition. Zero template agents remain (asserted: constructing every workflow emits no Sequential/ParallelAgent deprecation warning). `Runner` is driven via `node=` (one seam: `_build_runner` in the executor and the resolver).
+
+**The primary flow is named `book_to_place`**, the symmetric counterpart of `place_to_book`: phase workflows `book_to_place_discovery` and `book_to_place_composition` (factories `create_book_to_place_discovery_workflow` / `create_book_to_place_composition_workflow`). Executor methods keep their phase verbs (`discover`/`compose`) and the HTTP contract is byte-identical (golden-stream snapshot unchanged).
+
+Discovery graph (the only non-linear one):
+
+```
+START → book_context_researcher → book_context_formatter
+      → fan-out: city_r→city_f, landmark_r→landmark_f, author_r→author_f
+      → JoinNode(discovery_join) → region_analyzer
+```
+
+The JoinNode is load-bearing: a plain node fires on ANY predecessor; region_analyzer must wait for ALL three branches.
+
+**Graph semantics are pinned by tests, not assumed** (`tests/unit/test_graph_workflows.py` drives real Workflows through a real Runner with a scripted model): (1) downstream nodes see upstream responses in their request contents — the ADR #2 researcher→formatter contract; (2) `output_key` still writes session state — ADR #5; (3) events keep per-agent authorship — the progress-mapping contract; (4) JoinNode gates the fan-in to exactly one run after all branches. `tests/unit/test_agents.py` pins the graph shapes (edges, join, terminals).
+
+Kept deliberately: the researcher/formatter split (ADK 2.x would allow tools + output_schema on one agent; collapsing is a separate eval-gated experiment), the ADR #11 `append_event` persistence pattern (verified compatible), the two-endpoint HITL facade (native pause/resume still deferred).
+
+### Trade-offs
+
+**Benefits:** off the deprecated path before removal; composition is explicit data (edges) instead of nested agent trees; dead progress-map entries for container agents removed; the primary capability is greppable by name; symmetric naming ends the "named reverse, unnamed default" asymmetry.
+
+**Costs:** factory renames touch the executor's imports and monkeypatch targets (mechanical); Langfuse span hierarchy shows graph node names (dashboards keyed on `discovery_workflow_invocation` see `book_to_place_discovery_invocation` after this change).
+
+---
+
 ## Summary: Key Architectural Patterns
 
 | Pattern | Benefit | Trade-off |
@@ -1048,5 +1086,6 @@ Migrate in stages, eval-gated against a two-run pre-migration baseline (storylan
 | **Abuse/ops hardening (ADR #21)** | Token spend protected; bounded stores; honest tone; per-branch traces | More knobs to configure |
 | **Shared run harness (ADR #22)** | One ADK-facing scaffold for all flows; explicit per-flow error policy | Flow bodies are nested generators; policy lives in `GuardSpec`, not inline |
 | **ADK 2.x, template-first (ADR #23)** | Supported line; CVE ignores retired; public-API plugin; bisectable stages | Deprecation warnings until the graph rewrite; fresh session DB at cutover |
+| **Graph workflows + `book_to_place` naming (ADR #24)** | Explicit edges, no deprecated templates; primary flow named; semantics test-pinned | Factory renames; Langfuse trace names change |
 
 These patterns work together to create a **reliable, performant, and user-friendly** multi-agent system for generating literary travel itineraries.

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -199,18 +199,17 @@ A complete evaluation run produces this span hierarchy:
 
 ```
 eval_run_YYYYMMDD_v2  (dataset run root — from start_as_current_observation)
-├── discovery_workflow_invocation  (plugin root span)
-│   └── discovery_workflow
-│       ├── book_context_pipeline
-│       │   ├── book_context_researcher
-│       │   │   └── gemini-2.5-flash_call  (generation, with token counts)
-│       │   └── book_context_formatter
-│       │       └── gemini-2.5-flash_call
-│       ├── parallel_discovery  (city/landmark/author agents in parallel)
+├── book_to_place_discovery_invocation  (plugin root span)
+│   └── book_to_place_discovery
+│       ├── book_context_researcher
+│       │   └── gemini-2.5-flash_call  (generation, with token counts)
+│       ├── book_context_formatter
+│       │   └── gemini-2.5-flash_call
+│       ├── city/landmark/author researcher→formatter  (parallel graph branches)
 │       │   └── ...
 │       └── region_analyzer
 │           └── gemini-2.5-flash_call
-├── composition_workflow_invocation  (plugin root span)
+├── book_to_place_composition_invocation  (plugin root span)
 │   └── ...
 └── llm_score_itinerary  (generation — from @observe in llm_scorer.py)
     model: gemini-2.5-flash-lite, input/output tokens, scores as output

--- a/evaluation/tools/run_scheduled_eval.py
+++ b/evaluation/tools/run_scheduled_eval.py
@@ -22,8 +22,8 @@ from common.config import load_config
 from core.retry import build_retry_options
 from services.session_service import create_session_service
 from agents.orchestrator import (
-    create_discovery_workflow,
-    create_composition_workflow,
+    create_book_to_place_discovery_workflow,
+    create_book_to_place_composition_workflow,
 )
 from agents.prompts import load_prompts, CURRENT_PROMPT_VERSION, AgentPrompts
 from google.adk.models.google_llm import Gemini
@@ -494,11 +494,11 @@ async def _run_evaluation_case(
         root_span.update(metadata={"current_phase": "discovery"})
 
         try:
-            discovery_workflow = create_discovery_workflow(
+            discovery_workflow = create_book_to_place_discovery_workflow(
                 model, book_title=exact_title, author=exact_author, prompts=prompts
             )
             discovery_runner = Runner(
-                agent=discovery_workflow,
+                node=discovery_workflow,
                 app_name="storyland",
                 session_service=session_service,
                 plugins=[LoggingPlugin(), langfuse_plugin],
@@ -587,9 +587,9 @@ Find cities, landmarks, and author-related sites, then group them into practical
         )
 
         try:
-            composition_workflow = create_composition_workflow(model, prompts=prompts)
+            composition_workflow = create_book_to_place_composition_workflow(model, prompts=prompts)
             composition_runner = Runner(
-                agent=composition_workflow,
+                node=composition_workflow,
                 app_name="storyland",
                 session_service=session_service,
                 plugins=[LoggingPlugin(), langfuse_plugin],

--- a/evaluation/tools/run_scheduled_eval.py
+++ b/evaluation/tools/run_scheduled_eval.py
@@ -19,7 +19,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from common.logging import get_logger, configure_logging
 from common.config import load_config
+from core.prompts import build_composition_prompt
 from core.retry import build_retry_options
+from core.session_state import SessionStateAccessor
 from services.session_service import create_session_service
 from agents.orchestrator import (
     create_book_to_place_discovery_workflow,
@@ -595,12 +597,26 @@ Find cities, landmarks, and author-related sites, then group them into practical
                 plugins=[LoggingPlugin(), langfuse_plugin],
             )
 
-            composition_prompt = f"""Create a travel itinerary for "{exact_title}" by {exact_author}.
-
-Use ONLY the cities from the selected region(s): {json.dumps(selected_regions)}
-
-Create a personalized itinerary based on user preferences and the selected region(s).
-Include ALL cities from the selected regions in your itinerary."""
+            # Same prompt path as production (core.prompts.build_composition_prompt)
+            # INCLUDING the explicit grounding from session state — under the
+            # graph runtime (ADR #24) the composer sees none of the discovery
+            # conversation, so an eval that composed from region names alone
+            # would score a different, under-grounded workflow than prod.
+            grounding_session = await session_service.get_session(
+                app_name="storyland", user_id=user_id, session_id=session_id
+            )
+            grounding_state = SessionStateAccessor(
+                grounding_session.state if grounding_session else {}
+            )
+            composition_prompt = build_composition_prompt(
+                exact_title,
+                exact_author,
+                selected_regions,
+                book_context=grounding_state.book_context,
+                city_discovery=grounding_state.city_discovery,
+                landmark_discovery=grounding_state.landmark_discovery,
+                author_sites=grounding_state.author_sites,
+            )
             composition_message = types.Content(
                 role="user", parts=[types.Part(text=composition_prompt)]
             )

--- a/evaluation/tools/run_scheduled_eval.py
+++ b/evaluation/tools/run_scheduled_eval.py
@@ -499,6 +499,7 @@ async def _run_evaluation_case(
             discovery_workflow = create_book_to_place_discovery_workflow(
                 model, book_title=exact_title, author=exact_author, prompts=prompts
             )
+            langfuse_plugin.root_name = discovery_workflow.name
             discovery_runner = Runner(
                 node=discovery_workflow,
                 app_name="storyland",
@@ -590,6 +591,7 @@ Find cities, landmarks, and author-related sites, then group them into practical
 
         try:
             composition_workflow = create_book_to_place_composition_workflow(model, prompts=prompts)
+            langfuse_plugin.root_name = composition_workflow.name
             composition_runner = Runner(
                 node=composition_workflow,
                 app_name="storyland",

--- a/evaluation/tools/run_scheduled_eval.py
+++ b/evaluation/tools/run_scheduled_eval.py
@@ -616,6 +616,7 @@ Find cities, landmarks, and author-related sites, then group them into practical
                 city_discovery=grounding_state.city_discovery,
                 landmark_discovery=grounding_state.landmark_discovery,
                 author_sites=grounding_state.author_sites,
+                preferences=grounding_state.user_preferences,
             )
             composition_message = types.Content(
                 role="user", parts=[types.Part(text=composition_prompt)]

--- a/plugins/langfuse_plugin.py
+++ b/plugins/langfuse_plugin.py
@@ -103,6 +103,7 @@ class LangfusePlugin(BasePlugin):
         public_key: Optional[str] = None,
         host: Optional[str] = None,
         enabled: bool = True,
+        root_name: Optional[str] = None,
     ):
         """
         Initialize Langfuse plugin.
@@ -112,8 +113,15 @@ class LangfusePlugin(BasePlugin):
             public_key: Langfuse public key (from env LANGFUSE_PUBLIC_KEY)
             host: Langfuse host URL (from env LANGFUSE_HOST)
             enabled: Enable/disable plugin (auto-disabled if credentials missing)
+            root_name: Trace-name identity for the run's root workflow. Under
+                Runner(node=...) ADK 2.5 builds InvocationContext with
+                agent=None (and node_path=None at user-message time), so the
+                plugin cannot recover the root identity from the context —
+                the caller that builds the Runner KNOWS the workflow and
+                injects its name here (see WorkflowExecutor._build_runner).
         """
         super().__init__(name="langfuse_plugin")
+        self.root_name = root_name
         self.enabled = enabled and LANGFUSE_AVAILABLE
         self.client: Optional[Langfuse] = None
         self._token_usage = TokenUsage()
@@ -153,6 +161,30 @@ class LangfusePlugin(BasePlugin):
         else:
             logger.info("langfuse_disabled", reason="missing_credentials")
             self.enabled = False
+
+    def _resolve_root_name(self, invocation_context: InvocationContext) -> str:
+        """Trace-name identity for this invocation, explicit-first.
+
+        NOT the getattr(x, 'attr', default) idiom: when
+        ``invocation_context.agent`` is None (every Runner(node=...) root on
+        ADK 2.5), that idiom silently returns the default — the third
+        silent-wrong-answer of its kind in this migration (after the
+        usage_metadata declared-field trap). Explicit chain instead: real
+        agent name → injected root_name → loud WARNING + 'unknown_agent'.
+        """
+        agent = invocation_context.agent
+        if agent is not None:
+            name = getattr(agent, "name", None)
+            if name:
+                return name
+        if self.root_name:
+            return self.root_name
+        logger.warning(
+            "langfuse_root_identity_missing",
+            invocation_id=getattr(invocation_context, "invocation_id", None),
+            hint="pass root_name= or set plugin.root_name before Runner construction",
+        )
+        return "unknown_agent"
 
     @staticmethod
     def _branch_key(callback_context: CallbackContext) -> str:
@@ -197,7 +229,7 @@ class LangfusePlugin(BasePlugin):
             return None
 
         try:
-            agent_name = getattr(invocation_context.agent, 'name', 'unknown_agent')
+            agent_name = self._resolve_root_name(invocation_context)
             user_id = invocation_context.user_id
             session_id = invocation_context.session.id if invocation_context.session else None
 

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -166,6 +166,32 @@ class TestLocalAtmosphereAgents:
         assert "Salem, MA" in formatter.instruction
         assert "60" in formatter.instruction
 
+    def test_preferences_baked_into_both_instructions(self, model_name, mock_google_search_tool):
+        """Codex P2 (2026-07-19 21:10): preferences appended to the initial
+        user prompt reach only the FIRST graph node; the formatter is 3-4
+        nodes downstream. Both local agents must carry them in-instruction."""
+        researcher, formatter = create_local_atmosphere_agents(
+            model_name,
+            mock_google_search_tool,
+            location_label="Salem, MA",
+            radius_km=60,
+            preferences={"pace": "la-prefs-marker", "budget": "low"},
+        )
+        assert "la-prefs-marker" in researcher.instruction
+        assert "la-prefs-marker" in formatter.instruction
+
+    def test_no_preferences_leaves_instructions_unchanged(self, model_name, mock_google_search_tool):
+        with_none = create_local_atmosphere_agents(
+            model_name, mock_google_search_tool,
+            location_label="Salem, MA", radius_km=60, preferences=None,
+        )
+        without = create_local_atmosphere_agents(
+            model_name, mock_google_search_tool,
+            location_label="Salem, MA", radius_km=60,
+        )
+        assert with_none[0].instruction == without[0].instruction
+        assert with_none[1].instruction == without[1].instruction
+
 
 class TestLocalAtmosphereWorkflow:
     """Tests for create_local_atmosphere_workflow."""

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -96,35 +96,50 @@ class TestBookContextAgents:
 
 
 class TestCityAgents:
+    def test_researcher_carries_book_facts(self, model_name, mock_google_search_tool):
+        """Graph-scoped context (ADR #24): the branch researchers never see the
+        discovery user prompt, so title/author/vibe/taste must be baked into
+        their instructions (Codex P1 on the first PR-3 head)."""
+        researcher, _ = create_city_agents(
+            model_name,
+            mock_google_search_tool,
+            book_title="Persuasion",
+            author="Jane Austen",
+            vibe="melancholic coastal",
+            taste_context={"titles": ["Rebecca"], "moods": ["windswept"]},
+        )
+        for needle in ("Persuasion", "Jane Austen", "melancholic coastal", "Rebecca", "windswept"):
+            assert needle in researcher.instruction, needle
+
     def test_pair_names(self, model_name, mock_google_search_tool):
-        researcher, formatter = create_city_agents(model_name, mock_google_search_tool)
+        researcher, formatter = create_city_agents(model_name, mock_google_search_tool, book_title="1984", author="George Orwell")
         assert researcher.name == "city_researcher"
         assert formatter.name == "city_formatter"
 
     def test_formatter_output_key(self, model_name, mock_google_search_tool):
-        _, formatter = create_city_agents(model_name, mock_google_search_tool)
+        _, formatter = create_city_agents(model_name, mock_google_search_tool, book_title="1984", author="George Orwell")
         assert formatter.output_key == "city_discovery"
 
 
 class TestLandmarkAgents:
     def test_pair_names(self, model_name, mock_google_search_tool):
-        researcher, formatter = create_landmark_agents(model_name, mock_google_search_tool)
+        researcher, formatter = create_landmark_agents(model_name, mock_google_search_tool, book_title="1984", author="George Orwell")
         assert researcher.name == "landmark_researcher"
         assert formatter.name == "landmark_formatter"
 
     def test_formatter_output_key(self, model_name, mock_google_search_tool):
-        _, formatter = create_landmark_agents(model_name, mock_google_search_tool)
+        _, formatter = create_landmark_agents(model_name, mock_google_search_tool, book_title="1984", author="George Orwell")
         assert formatter.output_key == "landmark_discovery"
 
 
 class TestAuthorAgents:
     def test_pair_names(self, model_name, mock_google_search_tool):
-        researcher, formatter = create_author_agents(model_name, mock_google_search_tool)
+        researcher, formatter = create_author_agents(model_name, mock_google_search_tool, book_title="1984", author="George Orwell")
         assert researcher.name == "author_researcher"
         assert formatter.name == "author_formatter"
 
     def test_formatter_output_key(self, model_name, mock_google_search_tool):
-        _, formatter = create_author_agents(model_name, mock_google_search_tool)
+        _, formatter = create_author_agents(model_name, mock_google_search_tool, book_title="1984", author="George Orwell")
         assert formatter.output_key == "author_sites"
 
 

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -1,33 +1,39 @@
 """
-Unit tests for agent factory functions.
+Unit tests for agent factory functions and workflow graphs.
 
-Tests that agent factories create properly configured agents with correct types.
+Agent factories return (researcher, formatter) LlmAgent pairs; workflow
+factories return google.adk.workflow.Workflow graphs (ADK 2 graph rewrite,
+ADR #24 — no Sequential/ParallelAgent templates). Structural assertions here
+are graph-native: node names, edge pairs, join gating.
 """
 
 import pytest
 
-from google.adk.agents import SequentialAgent, ParallelAgent, LlmAgent
+from google.adk.agents import LlmAgent
 from google.adk.tools import FunctionTool
+from google.adk.workflow import JoinNode, Workflow
 
 from agents import (
-    create_book_context_pipeline,
-    create_city_pipeline,
-    create_landmark_pipeline,
-    create_author_pipeline,
-    create_local_atmosphere_pipeline,
+    create_book_context_agents,
+    create_city_agents,
+    create_landmark_agents,
+    create_author_agents,
+    create_local_atmosphere_agents,
     create_trip_composer_agent,
     create_region_analyzer_agent,
-    create_book_recommendation_pipeline,
+    create_book_recommendation_agents,
     create_book_recommendation_workflow,
-    create_discovery_workflow,
-    create_composition_workflow,
+    create_book_to_place_discovery_workflow,
+    create_book_to_place_composition_workflow,
     create_local_atmosphere_workflow,
 )
 from agents.prompts import load_prompts, AgentPrompts
 
+START_NAME = "__START__"
+
 
 # =============================================================================
-# Fixtures
+# Fixtures / helpers
 # =============================================================================
 
 @pytest.fixture
@@ -46,141 +52,100 @@ def mock_google_search_tool():
     return FunctionTool(mock_search)
 
 
-# =============================================================================
-# Book Metadata Pipeline Tests
-# =============================================================================
+def edge_pairs(workflow: Workflow) -> set[tuple[str, str]]:
+    """The workflow's edges as (from_name, to_name) pairs."""
+    return {(e.from_node.name, e.to_node.name) for e in workflow.graph.edges}
+
+
+def node_names(workflow: Workflow) -> set[str]:
+    return {n.name for n in workflow.graph.nodes}
+
+
+def successors(workflow: Workflow, name: str) -> set[str]:
+    return {t for f, t in edge_pairs(workflow) if f == name}
+
+
+def predecessors(workflow: Workflow, name: str) -> set[str]:
+    return {f for f, t in edge_pairs(workflow) if t == name}
+
 
 # =============================================================================
-# Book Context Pipeline Tests
+# Agent-pair factory tests
 # =============================================================================
 
-class TestBookContextPipeline:
-    """Tests for create_book_context_pipeline."""
+class TestBookContextAgents:
+    """Tests for create_book_context_agents."""
 
-    def test_creates_sequential_agent(self, model_name, mock_google_search_tool):
-        """Test that pipeline returns a SequentialAgent."""
-        pipeline = create_book_context_pipeline(
+    def test_returns_researcher_formatter_pair(self, model_name, mock_google_search_tool):
+        researcher, formatter = create_book_context_agents(
             model_name, mock_google_search_tool,
             book_title="The Nightingale", author="Kristin Hannah"
         )
+        assert researcher.name == "book_context_researcher"
+        assert formatter.name == "book_context_formatter"
 
-        assert isinstance(pipeline, SequentialAgent)
-
-    def test_pipeline_has_correct_name(self, model_name, mock_google_search_tool):
-        """Test pipeline has expected name."""
-        pipeline = create_book_context_pipeline(
+    def test_researcher_has_tool_formatter_has_schema(self, model_name, mock_google_search_tool):
+        researcher, formatter = create_book_context_agents(
             model_name, mock_google_search_tool,
             book_title="The Nightingale", author="Kristin Hannah"
         )
-
-        assert pipeline.name == "book_context_pipeline"
-
-    def test_pipeline_has_sub_agents(self, model_name, mock_google_search_tool):
-        """Test pipeline contains sub-agents."""
-        pipeline = create_book_context_pipeline(
-            model_name, mock_google_search_tool,
-            book_title="The Nightingale", author="Kristin Hannah"
-        )
-
-        assert len(pipeline.sub_agents) == 2
+        assert researcher.tools
+        assert researcher.output_schema is None
+        assert not formatter.tools
+        assert formatter.output_schema is not None
 
 
-# =============================================================================
-# City Pipeline Tests
-# =============================================================================
+class TestCityAgents:
+    def test_pair_names(self, model_name, mock_google_search_tool):
+        researcher, formatter = create_city_agents(model_name, mock_google_search_tool)
+        assert researcher.name == "city_researcher"
+        assert formatter.name == "city_formatter"
 
-class TestCityPipeline:
-    """Tests for create_city_pipeline."""
-
-    def test_creates_sequential_agent(self, model_name, mock_google_search_tool):
-        """Test that pipeline returns a SequentialAgent."""
-        pipeline = create_city_pipeline(model_name, mock_google_search_tool)
-
-        assert isinstance(pipeline, SequentialAgent)
-
-    def test_pipeline_has_correct_name(self, model_name, mock_google_search_tool):
-        """Test pipeline has expected name."""
-        pipeline = create_city_pipeline(model_name, mock_google_search_tool)
-
-        assert pipeline.name == "city_pipeline"
+    def test_formatter_output_key(self, model_name, mock_google_search_tool):
+        _, formatter = create_city_agents(model_name, mock_google_search_tool)
+        assert formatter.output_key == "city_discovery"
 
 
-# =============================================================================
-# Landmark Pipeline Tests
-# =============================================================================
+class TestLandmarkAgents:
+    def test_pair_names(self, model_name, mock_google_search_tool):
+        researcher, formatter = create_landmark_agents(model_name, mock_google_search_tool)
+        assert researcher.name == "landmark_researcher"
+        assert formatter.name == "landmark_formatter"
 
-class TestLandmarkPipeline:
-    """Tests for create_landmark_pipeline."""
-
-    def test_creates_sequential_agent(self, model_name, mock_google_search_tool):
-        """Test that pipeline returns a SequentialAgent."""
-        pipeline = create_landmark_pipeline(model_name, mock_google_search_tool)
-
-        assert isinstance(pipeline, SequentialAgent)
-
-    def test_pipeline_has_correct_name(self, model_name, mock_google_search_tool):
-        """Test pipeline has expected name."""
-        pipeline = create_landmark_pipeline(model_name, mock_google_search_tool)
-
-        assert pipeline.name == "landmark_pipeline"
+    def test_formatter_output_key(self, model_name, mock_google_search_tool):
+        _, formatter = create_landmark_agents(model_name, mock_google_search_tool)
+        assert formatter.output_key == "landmark_discovery"
 
 
-# =============================================================================
-# Author Pipeline Tests
-# =============================================================================
+class TestAuthorAgents:
+    def test_pair_names(self, model_name, mock_google_search_tool):
+        researcher, formatter = create_author_agents(model_name, mock_google_search_tool)
+        assert researcher.name == "author_researcher"
+        assert formatter.name == "author_formatter"
 
-class TestAuthorPipeline:
-    """Tests for create_author_pipeline."""
-
-    def test_creates_sequential_agent(self, model_name, mock_google_search_tool):
-        """Test that pipeline returns a SequentialAgent."""
-        pipeline = create_author_pipeline(model_name, mock_google_search_tool)
-
-        assert isinstance(pipeline, SequentialAgent)
-
-    def test_pipeline_has_correct_name(self, model_name, mock_google_search_tool):
-        """Test pipeline has expected name."""
-        pipeline = create_author_pipeline(model_name, mock_google_search_tool)
-
-        assert pipeline.name == "author_pipeline"
+    def test_formatter_output_key(self, model_name, mock_google_search_tool):
+        _, formatter = create_author_agents(model_name, mock_google_search_tool)
+        assert formatter.output_key == "author_sites"
 
 
-# =============================================================================
-# Local Atmosphere Pipeline Tests
-# =============================================================================
-
-class TestLocalAtmospherePipeline:
-    """Tests for create_local_atmosphere_pipeline."""
-
-    def test_creates_sequential_agent(self, model_name, mock_google_search_tool):
-        pipeline = create_local_atmosphere_pipeline(
+class TestLocalAtmosphereAgents:
+    def test_pair_names(self, model_name, mock_google_search_tool):
+        researcher, formatter = create_local_atmosphere_agents(
             model_name,
             mock_google_search_tool,
             location_label="New York, NY",
             radius_km=80,
         )
-        assert isinstance(pipeline, SequentialAgent)
-        assert pipeline.name == "local_atmosphere_pipeline"
-
-    def test_has_two_sub_agents(self, model_name, mock_google_search_tool):
-        pipeline = create_local_atmosphere_pipeline(
-            model_name,
-            mock_google_search_tool,
-            location_label="New York, NY",
-            radius_km=80,
-        )
-        assert len(pipeline.sub_agents) == 2
-        assert pipeline.sub_agents[0].name == "local_atmosphere_researcher"
-        assert pipeline.sub_agents[1].name == "local_atmosphere_formatter"
+        assert researcher.name == "local_atmosphere_researcher"
+        assert formatter.name == "local_atmosphere_formatter"
 
     def test_location_baked_into_instructions(self, model_name, mock_google_search_tool):
-        pipeline = create_local_atmosphere_pipeline(
+        researcher, formatter = create_local_atmosphere_agents(
             model_name,
             mock_google_search_tool,
             location_label="Salem, MA",
             radius_km=60,
         )
-        researcher, formatter = pipeline.sub_agents
         assert "Salem, MA" in researcher.instruction
         assert "60" in researcher.instruction
         assert "Salem, MA" in formatter.instruction
@@ -190,7 +155,7 @@ class TestLocalAtmospherePipeline:
 class TestLocalAtmosphereWorkflow:
     """Tests for create_local_atmosphere_workflow."""
 
-    def test_creates_sequential_agent(self, model_name):
+    def test_creates_workflow_graph(self, model_name):
         workflow = create_local_atmosphere_workflow(
             model_name,
             book_title="Wuthering Heights",
@@ -198,12 +163,13 @@ class TestLocalAtmosphereWorkflow:
             location_label="New York, NY",
             radius_km=80,
         )
-        assert isinstance(workflow, SequentialAgent)
+        assert isinstance(workflow, Workflow)
         assert workflow.name == "local_atmosphere_workflow"
 
-    def test_two_stage_pipeline(self, model_name):
-        """book_context_pipeline -> local_atmosphere_pipeline (MYS-436: no
-        reader_profile_agent hop -- see TestNoReaderProfileAgent)."""
+    def test_linear_chain(self, model_name):
+        """START → book_context researcher→formatter → local researcher→formatter.
+
+        MYS-436: no reader_profile hop — see TestNoReaderProfileAgent."""
         workflow = create_local_atmosphere_workflow(
             model_name,
             book_title="X",
@@ -211,11 +177,12 @@ class TestLocalAtmosphereWorkflow:
             location_label="Boston, MA",
             radius_km=80,
         )
-        names = [a.name for a in workflow.sub_agents]
-        assert names == [
-            "book_context_pipeline",
-            "local_atmosphere_pipeline",
-        ]
+        assert edge_pairs(workflow) == {
+            (START_NAME, "book_context_researcher"),
+            ("book_context_researcher", "book_context_formatter"),
+            ("book_context_formatter", "local_atmosphere_researcher"),
+            ("local_atmosphere_researcher", "local_atmosphere_formatter"),
+        }
 
 
 # =============================================================================
@@ -226,22 +193,15 @@ class TestTripComposerAgent:
     """Tests for create_trip_composer_agent."""
 
     def test_creates_llm_agent(self, model_name):
-        """Test that trip composer returns an LlmAgent."""
         agent = create_trip_composer_agent(model_name)
-
         assert isinstance(agent, LlmAgent)
 
     def test_agent_has_correct_name(self, model_name):
-        """Test agent has expected name."""
         agent = create_trip_composer_agent(model_name)
-
         assert agent.name == "trip_composer"
 
     def test_agent_has_output_schema(self, model_name):
-        """Test agent has Pydantic output schema configured."""
         agent = create_trip_composer_agent(model_name)
-
-        # Should have output_schema or output_key set for Pydantic validation
         assert hasattr(agent, 'output_schema') or hasattr(agent, 'output_key')
 
 
@@ -251,9 +211,9 @@ class TestTripComposerAgent:
 
 class TestNoReaderProfileAgent:
     """Pins the deletion: reader_profile_agent must not exist anywhere in the
-    tree, and no SequentialAgent this module builds may contain an agent
-    named "reader_profile_agent" -- a regression here would silently
-    reintroduce a per-search LLM call that produces a constant (MYS-436)."""
+    tree, and no workflow graph this module builds may contain a node named
+    "reader_profile_agent" -- a regression here would silently reintroduce a
+    per-search LLM call that produces a constant (MYS-436)."""
 
     def test_factory_function_is_gone(self):
         import agents
@@ -266,11 +226,10 @@ class TestNoReaderProfileAgent:
         assert importlib.util.find_spec("agents.reader_profile_agent") is None
 
     def test_discovery_workflow_has_no_reader_profile_agent(self, model_name):
-        workflow = create_discovery_workflow(
+        workflow = create_book_to_place_discovery_workflow(
             model_name, book_title="1984", author="George Orwell"
         )
-        names = [a.name for a in workflow.sub_agents]
-        assert "reader_profile_agent" not in names
+        assert "reader_profile_agent" not in node_names(workflow)
 
     def test_local_atmosphere_workflow_has_no_reader_profile_agent(self, model_name):
         workflow = create_local_atmosphere_workflow(
@@ -280,17 +239,9 @@ class TestNoReaderProfileAgent:
             location_label="Boston, MA",
             radius_km=80,
         )
-        names = [a.name for a in workflow.sub_agents]
-        assert "reader_profile_agent" not in names
+        assert "reader_profile_agent" not in node_names(workflow)
 
 
-# =============================================================================
-# Workflow Orchestrator Tests
-# =============================================================================
-
-
-# =============================================================================
-# Main Workflow Tests (Two-Phase Workflow)
 # =============================================================================
 # Region Analyzer Agent Tests
 # =============================================================================
@@ -299,167 +250,126 @@ class TestRegionAnalyzerAgent:
     """Tests for create_region_analyzer_agent."""
 
     def test_creates_llm_agent(self, model_name):
-        """Test that region analyzer returns an LlmAgent."""
         agent = create_region_analyzer_agent(model_name)
-
         assert isinstance(agent, LlmAgent)
 
     def test_agent_has_correct_name(self, model_name):
-        """Test agent has expected name."""
         agent = create_region_analyzer_agent(model_name)
-
         assert agent.name == "region_analyzer"
 
     def test_agent_has_output_schema(self, model_name):
-        """Test agent has Pydantic output schema configured."""
         agent = create_region_analyzer_agent(model_name)
-
         assert hasattr(agent, 'output_schema') or hasattr(agent, 'output_key')
 
     def test_agent_has_output_key(self, model_name):
-        """Test agent stores output in region_analysis key."""
         agent = create_region_analyzer_agent(model_name)
-
         assert agent.output_key == "region_analysis"
 
 
 # =============================================================================
-# Discovery Workflow Tests (Three-Phase Workflow)
+# Book→Place Discovery Workflow (phase 1 of the primary flow)
 # =============================================================================
 
-class TestDiscoveryWorkflow:
-    """Tests for create_discovery_workflow."""
+class TestBookToPlaceDiscoveryWorkflow:
+    """Tests for create_book_to_place_discovery_workflow's graph shape."""
 
-    def test_creates_sequential_agent(self, model_name):
-        """Test that discovery workflow returns a SequentialAgent."""
-        workflow = create_discovery_workflow(
+    def _workflow(self, model_name):
+        return create_book_to_place_discovery_workflow(
             model_name, book_title="1984", author="George Orwell"
         )
 
-        assert isinstance(workflow, SequentialAgent)
+    def test_creates_workflow_graph(self, model_name):
+        workflow = self._workflow(model_name)
+        assert isinstance(workflow, Workflow)
+        assert workflow.name == "book_to_place_discovery"
 
-    def test_workflow_has_correct_name(self, model_name):
-        """Test discovery workflow has expected name."""
-        workflow = create_discovery_workflow(
-            model_name, book_title="1984", author="George Orwell"
-        )
+    def test_context_chain_precedes_fanout(self, model_name):
+        """START → context researcher → formatter → 3-way fan-out."""
+        workflow = self._workflow(model_name)
+        assert successors(workflow, START_NAME) == {"book_context_researcher"}
+        assert successors(workflow, "book_context_researcher") == {
+            "book_context_formatter"
+        }
+        assert successors(workflow, "book_context_formatter") == {
+            "city_researcher",
+            "landmark_researcher",
+            "author_researcher",
+        }
 
-        assert workflow.name == "discovery_workflow"
+    def test_each_branch_is_researcher_then_formatter(self, model_name):
+        workflow = self._workflow(model_name)
+        for key in ("city", "landmark", "author"):
+            assert successors(workflow, f"{key}_researcher") == {f"{key}_formatter"}
 
-    def test_workflow_has_three_stages(self, model_name):
-        """Test discovery workflow has 3 stages (MYS-436: reader_profile_agent
-        removed -- was a dead hot-path LLM call producing a constant)."""
-        workflow = create_discovery_workflow(
-            model_name, book_title="1984", author="George Orwell"
-        )
-
-        # book_context, parallel_discovery, region_analyzer
-        assert len(workflow.sub_agents) == 3
-
-    def test_workflow_ends_with_region_analyzer(self, model_name):
-        """Test discovery workflow ends with region_analyzer."""
-        workflow = create_discovery_workflow(
-            model_name, book_title="1984", author="George Orwell"
-        )
-
-        stage_names = [agent.name for agent in workflow.sub_agents]
-        assert stage_names[-1] == "region_analyzer"
-
-    def test_workflow_stages_order(self, model_name):
-        """Test discovery workflow stages are in correct order."""
-        workflow = create_discovery_workflow(
-            model_name, book_title="1984", author="George Orwell"
-        )
-
-        stage_names = [agent.name for agent in workflow.sub_agents]
-
-        assert stage_names[0] == "book_context_pipeline"
-        assert stage_names[1] == "parallel_discovery"
-        assert stage_names[2] == "region_analyzer"
-
-    def test_workflow_contains_parallel_agent(self, model_name):
-        """Test discovery workflow contains a ParallelAgent for discovery."""
-        workflow = create_discovery_workflow(
-            model_name, book_title="1984", author="George Orwell"
-        )
-
-        parallel_agents = [
-            agent for agent in workflow.sub_agents
-            if isinstance(agent, ParallelAgent)
+    def test_join_gates_region_analyzer_on_all_branches(self, model_name):
+        """The fan-in MUST be a JoinNode: a plain node fires on ANY
+        predecessor, and region_analyzer needs ALL three formatter outputs
+        (behavioral pin: tests/unit/test_graph_workflows.py)."""
+        workflow = self._workflow(model_name)
+        assert predecessors(workflow, "discovery_join") == {
+            "city_formatter",
+            "landmark_formatter",
+            "author_formatter",
+        }
+        join_nodes = [
+            n for n in workflow.graph.nodes if isinstance(n, JoinNode)
         ]
-        assert len(parallel_agents) == 1
-        assert parallel_agents[0].name == "parallel_discovery"
+        assert [n.name for n in join_nodes] == ["discovery_join"]
+        assert successors(workflow, "discovery_join") == {"region_analyzer"}
+
+    def test_region_analyzer_is_terminal(self, model_name):
+        workflow = self._workflow(model_name)
+        assert successors(workflow, "region_analyzer") == set()
 
 
 # =============================================================================
-# Composition Workflow Tests (Three-Phase Workflow)
+# Book→Place Composition Workflow (phase 2 of the primary flow)
 # =============================================================================
 
-class TestCompositionWorkflow:
-    """Tests for create_composition_workflow."""
+class TestBookToPlaceCompositionWorkflow:
+    """Tests for create_book_to_place_composition_workflow."""
 
-    def test_creates_sequential_agent(self, model_name):
-        """Test that composition workflow returns a SequentialAgent."""
-        workflow = create_composition_workflow(model_name)
+    def test_creates_workflow_graph(self, model_name):
+        workflow = create_book_to_place_composition_workflow(model_name)
+        assert isinstance(workflow, Workflow)
+        assert workflow.name == "book_to_place_composition"
 
-        assert isinstance(workflow, SequentialAgent)
-
-    def test_workflow_has_correct_name(self, model_name):
-        """Test composition workflow has expected name."""
-        workflow = create_composition_workflow(model_name)
-
-        assert workflow.name == "composition_workflow"
-
-    def test_workflow_has_one_stage(self, model_name):
-        """Test composition workflow has 1 stage (trip_composer only)."""
-        workflow = create_composition_workflow(model_name)
-
-        assert len(workflow.sub_agents) == 1
-
-    def test_workflow_contains_trip_composer(self, model_name):
-        """Test composition workflow contains trip_composer agent."""
-        workflow = create_composition_workflow(model_name)
-
-        assert workflow.sub_agents[0].name == "trip_composer"
+    def test_single_composer_node(self, model_name):
+        workflow = create_book_to_place_composition_workflow(model_name)
+        assert edge_pairs(workflow) == {(START_NAME, "trip_composer")}
 
 
 # =============================================================================
-# BookContext Pipeline Dynamic Instruction Tests
+# BookContext Dynamic Instruction Tests
 # =============================================================================
 
 class TestBookContextDynamicInstruction:
-    """Verify book_context_pipeline handles both known and unknown title/author."""
+    """Verify book_context agents handle both known and unknown title/author."""
 
     def test_known_title_baked_into_instruction(self, model_name, mock_google_search_tool):
-        """When title/author are provided, they should appear in the instruction."""
-        pipeline = create_book_context_pipeline(
+        researcher, _ = create_book_context_agents(
             model_name, mock_google_search_tool,
             book_title="1984", author="George Orwell"
         )
-        researcher = pipeline.sub_agents[0]
         assert '"1984"' in researcher.instruction
         assert "George Orwell" in researcher.instruction
 
     def test_no_title_uses_dynamic_reference(self, model_name, mock_google_search_tool):
-        """When no title/author provided, instruction should reference conversation history."""
-        pipeline = create_book_context_pipeline(
+        researcher, _ = create_book_context_agents(
             model_name, mock_google_search_tool
         )
-        researcher = pipeline.sub_agents[0]
         assert "book_metadata" in researcher.instruction
         assert "[from conversation]" not in researcher.instruction
 
     def test_title_starting_with_bracket_is_treated_as_real_title(
         self, model_name, mock_google_search_tool
     ):
-        """A real title like '[Pygmalion]' should still be baked into the instruction."""
-        pipeline = create_book_context_pipeline(
+        researcher, _ = create_book_context_agents(
             model_name,
             mock_google_search_tool,
             book_title="[Pygmalion]",
             author="George Bernard Shaw",
         )
-        researcher = pipeline.sub_agents[0]
         assert '"[Pygmalion]" by George Bernard Shaw' in researcher.instruction
 
 
@@ -471,22 +381,18 @@ class TestLoadPrompts:
     """Tests for the versioned prompt loader."""
 
     def test_load_prompts_default_returns_agent_prompts(self):
-        """load_prompts() with no args returns an AgentPrompts instance."""
         prompts = load_prompts()
         assert isinstance(prompts, AgentPrompts)
         assert prompts.trip_composer  # non-empty string
 
     def test_load_prompts_caches_same_object(self):
-        """Repeated calls for the same version return the identical cached object."""
         assert load_prompts("v2") is load_prompts("v2")
 
     def test_load_prompts_missing_version_raises(self):
-        """Requesting a non-existent version raises FileNotFoundError."""
         with pytest.raises(FileNotFoundError, match="v99"):
             load_prompts("v99")
 
     def test_book_recommendation_prompts_exist(self):
-        """AgentPrompts includes both book_recommendation prompt fields."""
         prompts = load_prompts()
         for field in ("book_recommendation_researcher", "book_recommendation_formatter"):
             assert hasattr(prompts, field)
@@ -497,72 +403,47 @@ class TestLoadPrompts:
 
 
 # =============================================================================
-# BookRecommendationPipeline Tests
+# Book Recommendation agents + workflow
 # =============================================================================
 
 
-class TestBookRecommendationPipeline:
-    """Tests for create_book_recommendation_pipeline."""
+class TestBookRecommendationAgents:
+    """Tests for create_book_recommendation_agents."""
 
-    def test_creates_sequential_agent(self, model_name, mock_google_search_tool):
-        pipeline = create_book_recommendation_pipeline(
-            model_name,
-            mock_google_search_tool,
-            book_title="The Da Vinci Code",
-            author="Dan Brown",
-            destinations="Paris, London",
-            themes="mystery, art, religion",
-        )
-        assert isinstance(pipeline, SequentialAgent)
-        assert pipeline.name == "book_recommendation_pipeline"
-
-    def test_pipeline_has_researcher_and_formatter(self, model_name, mock_google_search_tool):
-        pipeline = create_book_recommendation_pipeline(
-            model_name,
-            mock_google_search_tool,
+    def _pair(self, model_name, tool, **overrides):
+        kwargs = dict(
             book_title="1984",
             author="George Orwell",
             destinations="London",
             themes="dystopia, surveillance",
         )
-        assert len(pipeline.sub_agents) == 2
-        researcher, formatter = pipeline.sub_agents
+        kwargs.update(overrides)
+        return create_book_recommendation_agents(model_name, tool, **kwargs)
+
+    def test_pair_names(self, model_name, mock_google_search_tool):
+        researcher, formatter = self._pair(model_name, mock_google_search_tool)
         assert isinstance(researcher, LlmAgent)
         assert isinstance(formatter, LlmAgent)
         assert researcher.name == "book_recommendation_researcher"
         assert formatter.name == "book_recommendation_formatter"
 
     def test_researcher_uses_search_tool_only(self, model_name, mock_google_search_tool):
-        """ADK forbids tools + output_schema. Researcher gets the tool, formatter gets the schema."""
-        pipeline = create_book_recommendation_pipeline(
-            model_name,
-            mock_google_search_tool,
-            book_title="1984",
-            author="George Orwell",
-            destinations="London",
-            themes="dystopia",
-        )
-        researcher, formatter = pipeline.sub_agents
+        """The researcher gets the tool, the formatter gets the schema. ADK 2.x
+        would allow combining them; the separation is the ADR #2
+        anti-hallucination contract, kept deliberately."""
+        researcher, formatter = self._pair(model_name, mock_google_search_tool)
         assert researcher.tools and len(researcher.tools) == 1
         assert researcher.output_schema is None
         assert not formatter.tools
 
     def test_formatter_has_output_schema(self, model_name, mock_google_search_tool):
         from models.book import BookRecommendationsResult
-        pipeline = create_book_recommendation_pipeline(
-            model_name,
-            mock_google_search_tool,
-            book_title="1984",
-            author="George Orwell",
-            destinations="London",
-            themes="dystopia, surveillance",
-        )
-        formatter = pipeline.sub_agents[1]
+        _, formatter = self._pair(model_name, mock_google_search_tool)
         assert formatter.output_schema is BookRecommendationsResult
         assert formatter.output_key == "last_book_recommendations"
 
     def test_prompt_interpolation(self, model_name, mock_google_search_tool):
-        pipeline = create_book_recommendation_pipeline(
+        researcher, formatter = self._pair(
             model_name,
             mock_google_search_tool,
             book_title="Middlemarch",
@@ -570,7 +451,6 @@ class TestBookRecommendationPipeline:
             destinations="Coventry, London",
             themes="social reform, marriage",
         )
-        researcher, formatter = pipeline.sub_agents
         for agent in (researcher, formatter):
             assert "Middlemarch" in agent.instruction
             assert "George Eliot" in agent.instruction
@@ -581,38 +461,24 @@ class TestBookRecommendationPipeline:
 class TestBookRecommendationWorkflow:
     """Tests for create_book_recommendation_workflow."""
 
-    def test_creates_sequential_agent(self, model_name, mock_google_search_tool):
-        wf = create_book_recommendation_workflow(
+    def _workflow(self, model_name, tool):
+        return create_book_recommendation_workflow(
             model_name,
-            mock_google_search_tool,
+            tool,
             book_title="1984",
             author="George Orwell",
             destinations="London",
             themes="dystopia",
         )
-        assert isinstance(wf, SequentialAgent)
 
-    def test_workflow_name(self, model_name, mock_google_search_tool):
-        wf = create_book_recommendation_workflow(
-            model_name,
-            mock_google_search_tool,
-            book_title="1984",
-            author="George Orwell",
-            destinations="London",
-            themes="dystopia",
-        )
+    def test_creates_workflow_graph(self, model_name, mock_google_search_tool):
+        wf = self._workflow(model_name, mock_google_search_tool)
+        assert isinstance(wf, Workflow)
         assert wf.name == "book_recommendation_workflow"
 
-    def test_workflow_wraps_pipeline(self, model_name, mock_google_search_tool):
-        wf = create_book_recommendation_workflow(
-            model_name,
-            mock_google_search_tool,
-            book_title="1984",
-            author="George Orwell",
-            destinations="London",
-            themes="dystopia",
-        )
-        assert len(wf.sub_agents) == 1
-        pipeline = wf.sub_agents[0]
-        assert isinstance(pipeline, SequentialAgent)
-        assert pipeline.name == "book_recommendation_pipeline"
+    def test_researcher_to_formatter_chain(self, model_name, mock_google_search_tool):
+        wf = self._workflow(model_name, mock_google_search_tool)
+        assert edge_pairs(wf) == {
+            (START_NAME, "book_recommendation_researcher"),
+            ("book_recommendation_researcher", "book_recommendation_formatter"),
+        }

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -101,7 +101,7 @@ class TestDiscoveryCacheKey:
         assert k1 != k2
 
     def test_versioned_prefix(self):
-        assert self._key("Dune", "Herbert", None).startswith("discover:v1:")
+        assert self._key("Dune", "Herbert", None).startswith("discover:v2:")
 
     def test_absent_vibe_key_is_unchanged(self):
         # An absent vibe must produce the exact pre-vibe key (cache continuity).
@@ -111,7 +111,7 @@ class TestDiscoveryCacheKey:
         explicit_none = WorkflowExecutor._discovery_cache_key(
             "Dune", "Herbert", None, None
         )
-        assert with_default == explicit_none == "discover:v1:dune|herbert|" + (
+        assert with_default == explicit_none == "discover:v2:dune|herbert|" + (
             with_default.split("|")[-1]
         )
 
@@ -210,7 +210,9 @@ class TestExecutorCacheHit:
         # MYS-460: a cached entry carries the grounded geo fields, and the replay
         # must mint the place_key from them. This is the AC stated as behaviour —
         # a HIT can never hand the wire a region with no cross-job identity.
-        cached = {
+        # v2 bundle shape: region_analysis + the grounding payloads compose()
+        # reads from replayed state (ADR #24).
+        region_analysis = {
             "regions": [
                 {
                     "region_id": 1,
@@ -223,6 +225,10 @@ class TestExecutorCacheHit:
                 }
             ],
             "analysis_note": "cached note",
+        }
+        cached = {
+            "region_analysis": region_analysis,
+            "book_context": {"themes": ["southern gothic"]},
         }
         # The executor namespaces keys with the model/prompt version, so prime
         # the store through the same helper discover() uses.
@@ -242,7 +248,7 @@ class TestExecutorCacheHit:
         assert len(regions_events) == 1
         replayed = regions_events[0].regions
         # The cached payload is relayed intact...
-        assert replayed == [{**cached["regions"][0], "place_key": "us:atlanta"}]
+        assert replayed == [{**region_analysis["regions"][0], "place_key": "us:atlanta"}]
         # ...and the identity is on it. Cache hits land hardest on popular,
         # repeated titles — exactly the book-club case the combined readaway is
         # for — so a keyless replay would kill the feature on precisely the books

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -194,7 +194,7 @@ class TestExecutorCacheHit:
         def _boom(*args, **kwargs):
             raise AssertionError("discovery chain invoked on a cache hit")
 
-        monkeypatch.setattr(ex, "create_discovery_workflow", _boom)
+        monkeypatch.setattr(ex, "create_book_to_place_discovery_workflow", _boom)
         monkeypatch.setattr(ex, "Runner", _boom)
 
         config = ExecutorConfig(

--- a/tests/unit/test_discovery_errors.py
+++ b/tests/unit/test_discovery_errors.py
@@ -150,7 +150,7 @@ def _make_executor(monkeypatch, raise_exc):
     from core.executor import WorkflowExecutor
     from services.session_service import create_session_service
 
-    monkeypatch.setattr(ex, "create_discovery_workflow", lambda *a, **k: object())
+    monkeypatch.setattr(ex, "create_book_to_place_discovery_workflow", lambda *a, **k: object())
 
     class _RaisingRunner:
         def __init__(self, *args, **kwargs):

--- a/tests/unit/test_empty_discovery_guard.py
+++ b/tests/unit/test_empty_discovery_guard.py
@@ -29,7 +29,7 @@ def _make_executor(monkeypatch, regions):
     from services.session_service import create_session_service
 
     # Stub the workflow builder: never construct/run a real Gemini chain.
-    monkeypatch.setattr(ex, "create_discovery_workflow", lambda *a, **k: object())
+    monkeypatch.setattr(ex, "create_book_to_place_discovery_workflow", lambda *a, **k: object())
 
     class _FakeRunner:
         def __init__(self, *args, **kwargs):

--- a/tests/unit/test_golden_stream.py
+++ b/tests/unit/test_golden_stream.py
@@ -197,3 +197,86 @@ class TestGoldenStream:
         )
         assert types_ == ["WorkflowError", "WorkflowComplete"]
         assert sse == ["error", "done"]
+
+
+class TestComposerExplicitGrounding:
+    """The composer's prompt must carry the discovery research explicitly.
+
+    Under the graph runtime (ADR #24) the composition invocation sees none of
+    the discovery conversation, so build_composition_prompt interpolates
+    book_context and the three discovery payloads from session state. This
+    test drives the real executor with fake runners and asserts the message
+    handed to the composition Runner contains that grounding — the regression
+    that caused the first PR-3 eval-gate FAIL (composer composing from city
+    names alone).
+    """
+
+    async def test_compose_prompt_contains_state_grounding(self, monkeypatch):
+        executor, ex = _make_executor(monkeypatch)
+
+        monkeypatch.setattr(
+            ex,
+            "Runner",
+            _state_writing_runner(
+                lambda: {
+                    SessionStateKeys.REGION_ANALYSIS: {
+                        "regions": _REGIONS,
+                        "analysis_note": "note",
+                    },
+                    SessionStateKeys.BOOK_CONTEXT: {
+                        "setting": "Bath and Lyme Regis",
+                        "themes": ["persuasion-marker-theme"],
+                    },
+                    SessionStateKeys.CITY_DISCOVERY: {
+                        "cities": [{"name": "Bath", "reason": "city-marker-reason"}]
+                    },
+                    SessionStateKeys.LANDMARK_DISCOVERY: {
+                        "landmarks": [{"name": "The Cobb", "reason": "landmark-marker"}]
+                    },
+                    SessionStateKeys.AUTHOR_SITES: {
+                        "sites": [{"name": "Chawton Cottage", "reason": "author-marker"}]
+                    },
+                }
+            ),
+        )
+
+        job_id = None
+        async for ev in executor.discover(book_title="Persuasion", author="Jane Austen"):
+            if isinstance(ev, JobStarted):
+                job_id = ev.job_id
+
+        captured_prompts = []
+
+        class _CapturingRunner:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            async def run_async(self, user_id, session_id, new_message):
+                captured_prompts.append(
+                    "".join(p.text or "" for p in new_message.parts)
+                )
+                if False:
+                    yield None
+
+        monkeypatch.setattr(ex, "Runner", _CapturingRunner)
+
+        # ExtractionError is expected (the capturing runner writes no
+        # envelope) — only the outbound prompt matters here.
+        async for _ in executor.compose(job_id=job_id, region_ids=[1]):
+            pass
+
+        assert len(captured_prompts) == 1
+        prompt = captured_prompts[0]
+        for marker in (
+            "persuasion-marker-theme",
+            "city-marker-reason",
+            "landmark-marker",
+            "author-marker",
+        ):
+            assert marker in prompt, f"composer prompt lost grounding: {marker}"

--- a/tests/unit/test_golden_stream.py
+++ b/tests/unit/test_golden_stream.py
@@ -280,3 +280,94 @@ class TestComposerExplicitGrounding:
             "author-marker",
         ):
             assert marker in prompt, f"composer prompt lost grounding: {marker}"
+
+    async def test_cache_hit_compose_prompt_carries_grounding(self, monkeypatch):
+        """A discovery CACHE HIT must compose with the same grounding as a
+        fresh run (Codex P1 on the first PR-3 head: _emit_cached_discovery
+        replayed only region_analysis, so cache hits — precisely the popular,
+        repeated titles — composed from city names alone)."""
+        import core.executor as ex
+        from core.executor import WorkflowExecutor
+        from core.types import ExecutorConfig
+        from services.session_service import create_session_service
+
+        monkeypatch.setattr(
+            ex, "create_book_to_place_discovery_workflow", lambda *a, **k: object()
+        )
+        monkeypatch.setattr(
+            ex, "create_book_to_place_composition_workflow", lambda *a, **k: object()
+        )
+        config = ExecutorConfig(
+            model_name="gemini-2.0-flash",
+            google_api_key="test-key",
+            cache_enabled=True,  # the point of this test
+        )
+        executor = WorkflowExecutor(
+            config=config,
+            session_service=create_session_service(use_database=False),
+            model=object(),
+        )
+
+        monkeypatch.setattr(
+            ex,
+            "Runner",
+            _state_writing_runner(
+                lambda: {
+                    SessionStateKeys.REGION_ANALYSIS: {
+                        "regions": _REGIONS,
+                        "analysis_note": "note",
+                    },
+                    SessionStateKeys.BOOK_CONTEXT: {"themes": ["cached-theme-marker"]},
+                    SessionStateKeys.CITY_DISCOVERY: {"cities": ["cached-city-marker"]},
+                    SessionStateKeys.LANDMARK_DISCOVERY: {"landmarks": ["cached-landmark-marker"]},
+                    SessionStateKeys.AUTHOR_SITES: {"sites": ["cached-author-marker"]},
+                }
+            ),
+        )
+
+        # Run 1: fresh discovery — populates the cache with the v2 bundle.
+        async for _ in executor.discover(book_title="Persuasion", author="Jane Austen"):
+            pass
+
+        # Run 2: identical request — MUST be a cache hit (no runner needed).
+        monkeypatch.setattr(ex, "Runner", None)  # a fresh run would crash
+        hit_job_id = None
+        async for ev in executor.discover(book_title="Persuasion", author="Jane Austen"):
+            if isinstance(ev, JobStarted):
+                hit_job_id = ev.job_id
+
+        captured_prompts = []
+
+        class _CapturingRunner:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            async def run_async(self, user_id, session_id, new_message):
+                captured_prompts.append(
+                    "".join(p.text or "" for p in new_message.parts)
+                )
+                if False:
+                    yield None
+
+        monkeypatch.setattr(ex, "Runner", _CapturingRunner)
+        async for _ in executor.compose(job_id=hit_job_id, region_ids=[1]):
+            pass
+
+        assert len(captured_prompts) == 1
+        prompt = captured_prompts[0]
+        for marker in (
+            "cached-theme-marker",
+            "cached-city-marker",
+            "cached-landmark-marker",
+            "cached-author-marker",
+        ):
+            assert marker in prompt, (
+                f"cache-hit compose lost grounding: {marker} — "
+                "_emit_cached_discovery is not replaying the full bundle"
+            )

--- a/tests/unit/test_golden_stream.py
+++ b/tests/unit/test_golden_stream.py
@@ -84,8 +84,8 @@ def _make_executor(monkeypatch):
     from core.executor import WorkflowExecutor
     from services.session_service import create_session_service
 
-    monkeypatch.setattr(ex, "create_discovery_workflow", lambda *a, **k: object())
-    monkeypatch.setattr(ex, "create_composition_workflow", lambda *a, **k: object())
+    monkeypatch.setattr(ex, "create_book_to_place_discovery_workflow", lambda *a, **k: object())
+    monkeypatch.setattr(ex, "create_book_to_place_composition_workflow", lambda *a, **k: object())
 
     config = ExecutorConfig(
         model_name="gemini-2.0-flash",

--- a/tests/unit/test_golden_stream.py
+++ b/tests/unit/test_golden_stream.py
@@ -223,6 +223,10 @@ class TestComposerExplicitGrounding:
                         "regions": _REGIONS,
                         "analysis_note": "note",
                     },
+                    SessionStateKeys.USER_PREFERENCES: {
+                        "pace": "prefs-marker-pace",
+                        "duration_days": 12,
+                    },
                     SessionStateKeys.BOOK_CONTEXT: {
                         "setting": "Bath and Lyme Regis",
                         "themes": ["persuasion-marker-theme"],
@@ -278,6 +282,10 @@ class TestComposerExplicitGrounding:
             "city-marker-reason",
             "landmark-marker",
             "author-marker",
+            # MYS-436 follow-up: user:preferences must reach the composer
+            # explicitly (the reader_profile turn that used to carry them is
+            # gone; the API and the eval harness still supply them).
+            "prefs-marker-pace",
         ):
             assert marker in prompt, f"composer prompt lost grounding: {marker}"
 

--- a/tests/unit/test_graph_workflows.py
+++ b/tests/unit/test_graph_workflows.py
@@ -353,3 +353,49 @@ class TestGraphHistoryScoping:
         text = _request_text(second_requests[0])
         assert "FIRST-INVOCATION-OUTPUT" not in text
         assert "prompt-one" not in text
+
+
+class TestNodeRootInvocationIdentity:
+    """Pin the ADK fact behind the root_name injection (Codex #7): under
+    Runner(node=...), InvocationContext reaches plugins with agent=None and
+    node_path=None at user-message time — there is nothing to scavenge, which
+    is WHY LangfusePlugin.root_name is injected at the _build_runner seam.
+    If an ADK upgrade starts populating agent for node roots, this reds and
+    the injection (plus its two call sites) can be retired.
+    """
+
+    async def test_agent_is_none_for_workflow_roots(self, monkeypatch):
+        from google.adk.plugins import BasePlugin
+
+        _install_scripted_model(monkeypatch, lambda r: "x")
+        seen = {}
+
+        class _Recorder(BasePlugin):
+            def __init__(self):
+                super().__init__(name="recorder")
+
+            async def on_user_message_callback(self, *, invocation_context, user_message):
+                seen["agent"] = invocation_context.agent
+                seen["node_path"] = getattr(invocation_context, "node_path", None)
+                return None
+
+        agent = LlmAgent(name="solo", model=_model(), instruction="i")
+        workflow = Workflow(name="identity_wf", edges=[(START, agent)])
+        service = InMemorySessionService()
+        await service.create_session(
+            app_name=APP, user_id=USER, session_id="ident", state={}
+        )
+        runner = Runner(
+            node=workflow, app_name=APP, session_service=service, plugins=[_Recorder()]
+        )
+        async with runner:
+            async for _ in runner.run_async(
+                user_id=USER,
+                session_id="ident",
+                new_message=types.Content(role="user", parts=[types.Part(text="go")]),
+            ):
+                pass
+
+        assert "agent" in seen, "on_user_message_callback never fired"
+        assert seen["agent"] is None
+        assert seen["node_path"] is None

--- a/tests/unit/test_graph_workflows.py
+++ b/tests/unit/test_graph_workflows.py
@@ -30,6 +30,8 @@ from google.adk.sessions import InMemorySessionService
 from google.adk.workflow import JoinNode, START, Workflow
 from google.genai import types
 
+from core.events import Phase
+
 APP = "storyland"
 USER = "graph-test"
 
@@ -221,6 +223,74 @@ class TestGraphSemantics:
         # Branch events keep their agent authorship (progress mapping).
         authors = {e.author for e in events if getattr(e, "author", None)}
         assert {"branch_city", "branch_landmark", "branch_author"} <= authors
+
+
+class TestHarnessPumpAgainstRealGraph:
+    """Drive the REAL harness pump against a REAL graph run (Codex P2 check).
+
+    The concern: Workflow sets ctx.event_author = workflow name, so child
+    events might be workflow-authored, silently breaking pump_events'
+    per-agent progress mapping and capture_authors researcher-text capture.
+    This runs the actual pump_events (not a fake) over an actual
+    Runner(node=Workflow) stream and asserts both mechanisms work — the
+    LLM-content events are agent-authored even though workflow-level events
+    exist alongside them.
+    """
+
+    async def test_pump_progress_and_capture_work_under_graphs(self, monkeypatch):
+        from core.run_harness import RunCapture, pump_events
+
+        researcher = LlmAgent(
+            name="p_researcher",
+            model=_model(),
+            instruction="P-RESEARCH-MARKER: find things.",
+        )
+        formatter = LlmAgent(
+            name="p_formatter",
+            model=_model(),
+            instruction="P-FORMAT-MARKER: structure things.",
+        )
+
+        def script(llm_request):
+            if "P-RESEARCH-MARKER" in _request_text(llm_request):
+                return "captured-researcher-evidence"
+            return "formatted"
+
+        _install_scripted_model(monkeypatch, script)
+
+        service = InMemorySessionService()
+        await service.create_session(
+            app_name=APP, user_id=USER, session_id="pump", state={}
+        )
+        workflow = Workflow(name="p_wf", edges=[(START, researcher, formatter)])
+        runner = Runner(node=workflow, app_name=APP, session_service=service)
+
+        capture = RunCapture()
+        progress = [
+            ev
+            async for ev in pump_events(
+                runner,
+                user_id=USER,
+                session_id="pump",
+                message=types.Content(role="user", parts=[types.Part(text="go")]),
+                phase=Phase.DISCOVERY,
+                agent_steps={
+                    "p_researcher": "Researching",
+                    "p_formatter": "Formatting",
+                },
+                capture=capture,
+                capture_authors=("p_researcher",),
+            )
+        ]
+
+        assert [p.step for p in progress] == ["Researching", "Formatting"], (
+            "per-agent progress mapping broke under the graph runtime — "
+            "child events are no longer agent-authored"
+        )
+        assert capture.text_for("p_researcher") == "captured-researcher-evidence", (
+            "capture_authors recorded nothing — the grounding filter's "
+            "evidence path is dead under graphs"
+        )
 
 
 class TestGraphHistoryScoping:

--- a/tests/unit/test_graph_workflows.py
+++ b/tests/unit/test_graph_workflows.py
@@ -1,0 +1,223 @@
+"""Semantics pins for ADK 2 graph workflows (PR 3 of the ADK 2 migration).
+
+These tests run REAL `google.adk.workflow.Workflow` graphs through a REAL
+Runner with a scripted model (Gemini.generate_content_async patched at class
+level, the same seam test_cache_real_api meters). They pin the four
+behaviors the orchestrator rewrite depends on — if an ADK upgrade changes
+any of them, these fail before the eval gate has to catch it:
+
+1. History: a downstream LlmAgent node sees the upstream node's response in
+   its llm_request contents (the researcher→formatter anti-hallucination
+   contract, ADR #2).
+2. output_key: a formatter's structured output lands in session.state under
+   its output_key (the state-handoff contract, ADR #5).
+3. Authorship: events carry the AGENT's name as author (the progress-mapping
+   contract the harness pump and golden-stream rely on).
+4. Fan-out/fan-in: a tuple chain element fans out, a JoinNode waits for ALL
+   branches (the parallel-discovery contract, ADR #3).
+"""
+
+import json
+
+import pytest
+from pydantic import BaseModel
+
+import google.adk.models.google_llm as google_llm
+from google.adk.agents import LlmAgent
+from google.adk.models.llm_response import LlmResponse
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.adk.workflow import JoinNode, START, Workflow
+from google.genai import types
+
+APP = "storyland"
+USER = "graph-test"
+
+
+class _FactOut(BaseModel):
+    fact: str
+
+
+def _model():
+    return google_llm.Gemini(
+        model="gemini-2.5-flash-lite", client_kwargs={"api_key": "dummy"}
+    )
+
+
+def _canned(text: str) -> LlmResponse:
+    return LlmResponse(
+        content=types.Content(role="model", parts=[types.Part(text=text)]),
+        usage_metadata=types.GenerateContentResponseUsageMetadata(
+            prompt_token_count=10, candidates_token_count=5, total_token_count=15
+        ),
+    )
+
+
+def _install_scripted_model(monkeypatch, script_for_request):
+    """Patch Gemini.generate_content_async with a scripted responder.
+
+    ``script_for_request(llm_request) -> str`` chooses the canned text; every
+    captured llm_request is recorded for assertions.
+    """
+    captured = []
+
+    async def scripted(self, *args, **kwargs):
+        llm_request = args[0] if args else kwargs.get("llm_request")
+        captured.append(llm_request)
+        yield _canned(script_for_request(llm_request))
+
+    monkeypatch.setattr(google_llm.Gemini, "generate_content_async", scripted)
+    return captured
+
+
+def _request_text(llm_request) -> str:
+    """All text visible to the model in one request (system + contents)."""
+    chunks = []
+    config = getattr(llm_request, "config", None)
+    system = getattr(config, "system_instruction", None) if config else None
+    if system:
+        chunks.append(str(system))
+    for content in getattr(llm_request, "contents", None) or []:
+        for part in getattr(content, "parts", None) or []:
+            text = getattr(part, "text", None)
+            if text:
+                chunks.append(text)
+    return "\n".join(chunks)
+
+
+async def _run(workflow, prompt="run it"):
+    service = InMemorySessionService()
+    session_id = "graph-session"
+    await service.create_session(
+        app_name=APP, user_id=USER, session_id=session_id, state={}
+    )
+    runner = Runner(node=workflow, app_name=APP, session_service=service)
+    events = []
+    async with runner:
+        async for event in runner.run_async(
+            user_id=USER,
+            session_id=session_id,
+            new_message=types.Content(role="user", parts=[types.Part(text=prompt)]),
+        ):
+            events.append(event)
+    session = await service.get_session(
+        app_name=APP, user_id=USER, session_id=session_id
+    )
+    return events, session
+
+
+class TestGraphSemantics:
+    async def test_downstream_node_sees_upstream_history_and_output_key(
+        self, monkeypatch
+    ):
+        researcher = LlmAgent(
+            name="g_researcher",
+            model=_model(),
+            instruction="RESEARCH-MARKER: find facts.",
+        )
+        formatter = LlmAgent(
+            name="g_formatter",
+            model=_model(),
+            instruction="FORMAT-MARKER: structure the researcher's findings.",
+            output_schema=_FactOut,
+            output_key="g_out",
+        )
+
+        def script(llm_request):
+            text = _request_text(llm_request)
+            if "RESEARCH-MARKER" in text:
+                return "GROUNDED FACT ALPHA discovered in the archives."
+            return json.dumps({"fact": "GROUNDED FACT ALPHA"})
+
+        captured = _install_scripted_model(monkeypatch, script)
+
+        workflow = Workflow(
+            name="g_wf", edges=[(START, researcher, formatter)]
+        )
+        events, session = await _run(workflow)
+
+        # Pin 1 — history: the formatter's request must contain the
+        # researcher's response text (ADR #2 depends on it).
+        formatter_requests = [
+            r for r in captured if "FORMAT-MARKER" in _request_text(r)
+        ]
+        assert len(formatter_requests) == 1
+        assert "GROUNDED FACT ALPHA discovered in the archives." in _request_text(
+            formatter_requests[0]
+        ), (
+            "formatter did not see the researcher's output in its request — "
+            "the researcher→formatter contract is broken under graph workflows"
+        )
+
+        # Pin 2 — output_key: structured output landed in session state.
+        raw = session.state.get("g_out")
+        assert raw is not None, "output_key wrote nothing to session state"
+        parsed = raw if isinstance(raw, dict) else json.loads(raw)
+        assert parsed["fact"] == "GROUNDED FACT ALPHA"
+
+        # Pin 3 — authorship: agent-authored events keep the agent name.
+        authors = {e.author for e in events if getattr(e, "author", None)}
+        assert "g_researcher" in authors
+        assert "g_formatter" in authors
+
+    async def test_fanout_join_runs_all_branches_before_join_successor(
+        self, monkeypatch
+    ):
+        branch_agents = [
+            LlmAgent(
+                name=f"branch_{key}",
+                model=_model(),
+                instruction=f"BRANCH-{key.upper()}-MARKER: research {key}.",
+                output_key=f"out_{key}",
+            )
+            for key in ("city", "landmark", "author")
+        ]
+        analyzer = LlmAgent(
+            name="g_analyzer",
+            model=_model(),
+            instruction="ANALYZE-MARKER: combine all branch findings.",
+            output_key="analysis",
+        )
+
+        def script(llm_request):
+            text = _request_text(llm_request)
+            for key in ("city", "landmark", "author"):
+                if f"BRANCH-{key.upper()}-MARKER" in text:
+                    return f"finding-for-{key}"
+            return "combined-analysis"
+
+        captured = _install_scripted_model(monkeypatch, script)
+
+        join = JoinNode(name="g_join")
+        workflow = Workflow(
+            name="g_parallel_wf",
+            edges=[
+                (START, tuple(branch_agents)),
+                (branch_agents[0], join),
+                (branch_agents[1], join),
+                (branch_agents[2], join),
+                (join, analyzer),
+            ],
+        )
+        events, session = await _run(workflow)
+
+        # All three branches ran, and each wrote its output_key.
+        for key in ("city", "landmark", "author"):
+            assert session.state.get(f"out_{key}") == f"finding-for-{key}"
+
+        # Pin 4 — the analyzer ran exactly once, and only after every branch:
+        # its request is the LAST model call, and by then all three branch
+        # responses exist.
+        analyzer_requests = [
+            r for r in captured if "ANALYZE-MARKER" in _request_text(r)
+        ]
+        assert len(analyzer_requests) == 1, (
+            "JoinNode must gate the analyzer to exactly one run after ALL "
+            "predecessors — got %d runs" % len(analyzer_requests)
+        )
+        assert captured.index(analyzer_requests[0]) == len(captured) - 1
+        assert session.state.get("analysis") == "combined-analysis"
+
+        # Branch events keep their agent authorship (progress mapping).
+        authors = {e.author for e in events if getattr(e, "author", None)}
+        assert {"branch_city", "branch_landmark", "branch_author"} <= authors

--- a/tests/unit/test_graph_workflows.py
+++ b/tests/unit/test_graph_workflows.py
@@ -221,3 +221,65 @@ class TestGraphSemantics:
         # Branch events keep their agent authorship (progress mapping).
         authors = {e.author for e in events if getattr(e, "author", None)}
         assert {"branch_city", "branch_landmark", "branch_author"} <= authors
+
+
+class TestGraphHistoryScoping:
+    """Pin the graph runtime's history model so nobody re-assumes 1.x behavior.
+
+    Under graphs, an agent's conversation is scoped to its TRIGGER CHAIN:
+    a direct successor sees its predecessor's output (pinned above), but a
+    second invocation on the same session sees NOTHING of the first — not
+    even its user message. This is why the composer's grounded inputs are
+    passed explicitly via build_composition_prompt (state → prompt), not via
+    implicit conversation history. If an ADK upgrade ever changes this to
+    full-history again, this test fails and the explicit wiring (plus its
+    token cost) should be re-evaluated.
+    """
+
+    async def test_second_invocation_sees_nothing_of_the_first(self, monkeypatch):
+        first = LlmAgent(
+            name="first_agent",
+            model=_model(),
+            instruction="FIRST-MARKER: produce facts.",
+        )
+        second = LlmAgent(
+            name="second_agent",
+            model=_model(),
+            instruction="SECOND-MARKER: compose from whatever you can see.",
+        )
+
+        def script(llm_request):
+            text = _request_text(llm_request)
+            if "FIRST-MARKER" in text:
+                return "FIRST-INVOCATION-OUTPUT"
+            return "second-output"
+
+        captured = _install_scripted_model(monkeypatch, script)
+
+        service = InMemorySessionService()
+        await service.create_session(
+            app_name=APP, user_id=USER, session_id="cross", state={}
+        )
+
+        async def drive(workflow, prompt):
+            runner = Runner(node=workflow, app_name=APP, session_service=service)
+            async with runner:
+                async for _ in runner.run_async(
+                    user_id=USER,
+                    session_id="cross",
+                    new_message=types.Content(
+                        role="user", parts=[types.Part(text=prompt)]
+                    ),
+                ):
+                    pass
+
+        await drive(Workflow(name="wf_a", edges=[(START, first)]), "prompt-one")
+        await drive(Workflow(name="wf_b", edges=[(START, second)]), "prompt-two")
+
+        second_requests = [
+            r for r in captured if "SECOND-MARKER" in _request_text(r)
+        ]
+        assert len(second_requests) == 1
+        text = _request_text(second_requests[0])
+        assert "FIRST-INVOCATION-OUTPUT" not in text
+        assert "prompt-one" not in text

--- a/tests/unit/test_langfuse_token_extraction.py
+++ b/tests/unit/test_langfuse_token_extraction.py
@@ -77,3 +77,55 @@ class TestExtractTokenUsage:
 
     def test_object_without_field_returns_none(self):
         assert _plugin()._extract_token_usage(object()) is None
+
+
+class TestResolveRootName:
+    """Trace-name identity under Runner(node=...) roots (Codex #7, 21:58).
+
+    ADK 2.5 builds InvocationContext with agent=None for node roots (pinned
+    in test_graph_workflows.TestNodeRootInvocationIdentity), so the old
+    getattr(invocation_context.agent, 'name', 'unknown_agent') silently named
+    EVERY trace unknown_agent_invocation — falsifying the dashboard note and
+    blinding the Langfuse instrument PR 4's cost/quality case depends on.
+    Identity is now injected at the _build_runner seam.
+    """
+
+    def test_real_agent_name_wins(self):
+        from types import SimpleNamespace
+
+        plugin = LangfusePlugin(root_name="injected_wf")
+        ctx = SimpleNamespace(agent=SimpleNamespace(name="real_agent"), invocation_id="i")
+        assert plugin._resolve_root_name(ctx) == "real_agent"
+
+    def test_none_agent_falls_back_to_injected_root_name(self):
+        from types import SimpleNamespace
+
+        plugin = LangfusePlugin(root_name="book_to_place_discovery")
+        ctx = SimpleNamespace(agent=None, invocation_id="i")
+        assert plugin._resolve_root_name(ctx) == "book_to_place_discovery"
+
+    def test_nothing_available_warns_and_returns_unknown(self):
+        from types import SimpleNamespace
+
+        plugin = LangfusePlugin()
+        ctx = SimpleNamespace(agent=None, invocation_id="i")
+        assert plugin._resolve_root_name(ctx) == "unknown_agent"
+
+    def test_build_runner_injects_workflow_name(self):
+        """The executor seam is the injection point — every flow gets it."""
+        from types import SimpleNamespace
+
+        import core.executor as ex
+        from core.executor import WorkflowExecutor
+        from core.types import ExecutorConfig
+        from services.session_service import create_session_service
+
+        executor = WorkflowExecutor(
+            config=ExecutorConfig(model_name="m", google_api_key="k"),
+            session_service=create_session_service(use_database=False),
+            model=object(),
+        )
+        plugin = LangfusePlugin()
+        workflow = SimpleNamespace(name="book_to_place_composition")
+        executor._build_runner(workflow, plugin)
+        assert plugin.root_name == "book_to_place_composition"

--- a/tests/unit/test_place_key.py
+++ b/tests/unit/test_place_key.py
@@ -728,8 +728,9 @@ class TestExecutorWiring:
         # Fresh run: the value we CACHE and the value we EMIT come from the same
         # enriched payload — a cached hit and a fresh run must be identical on the wire.
         assert "region_analysis = enrich_region_analysis(run_state.region_analysis)" in src
-        assert "await self._discovery_cache.set(cache_key, region_analysis)" in src
-        assert "await self._discovery_cache.set(cache_key, run_state.region_analysis)" not in src, (
+        # v2 bundle: the ENRICHED analysis is what goes into the cached bundle.
+        assert '"region_analysis": region_analysis,' in src
+        assert '"region_analysis": run_state.region_analysis' not in src, (
             "caching the RAW analysis would store regions with no place_key"
         )
         # Cache replay path.

--- a/tests/unit/test_place_to_book.py
+++ b/tests/unit/test_place_to_book.py
@@ -355,3 +355,92 @@ class TestResolver:
         result = await resolver.resolve("   ")
         assert result.found is False
         assert runs == []  # never ran the pipeline
+
+
+# ---------------------------------------------------------------------------
+# Resolver capture under the REAL graph runtime (Codex P2, 2026-07-19 20:48)
+# ---------------------------------------------------------------------------
+
+class TestResolverCaptureUnderRealGraph:
+    """Drive the REAL PlaceToBookResolver._run_pipeline — real workflow, real
+    Runner(node=...), scripted model — and prove the researcher-text capture
+    path is alive under graph authorship.
+
+    The concern: if Workflow stamped child events with the workflow author,
+    capture_authors=("place_to_book_researcher",) would record nothing,
+    researcher_text would be empty, and filter_grounded_candidates would FAIL
+    OPEN — invented titles returned instead of dropped, on /books-set-in/*
+    under a "Verified" badge. The executor pump was refuted separately
+    (TestHarnessPumpAgainstRealGraph); this covers the resolver's own capture
+    path, the second instance of the class. If it reds, the evidence path is
+    dead and the fail-open below returns BOTH titles.
+    """
+
+    async def test_researcher_capture_feeds_grounding_filter(self, monkeypatch):
+        import json as _json
+
+        import google.adk.models.google_llm as google_llm
+        from google.adk.models.llm_response import LlmResponse
+        from google.adk.sessions import InMemorySessionService
+        from google.genai import types as genai_types
+
+        calls = []
+
+        def _canned(text):
+            return LlmResponse(
+                content=genai_types.Content(
+                    role="model", parts=[genai_types.Part(text=text)]
+                ),
+                usage_metadata=genai_types.GenerateContentResponseUsageMetadata(
+                    prompt_token_count=5, candidates_token_count=5, total_token_count=10
+                ),
+            )
+
+        async def scripted(self, *args, **kwargs):
+            calls.append(1)
+            if len(calls) == 1:
+                # Researcher: grounded evidence names ONE real title only.
+                yield _canned(
+                    "Grounded research: The Book of Disquiet by Pessoa is set in Lisbon."
+                )
+            else:
+                # Formatter: returns the grounded title AND an invented one.
+                yield _canned(_json.dumps({
+                    "candidates": [
+                        {
+                            "title": "The Book of Disquiet",
+                            "author": "Fernando Pessoa",
+                            "description": "d",
+                            "why_it_fits": "w",
+                            "match_type": "literal",
+                            "maps_to": "Baixa, Lisbon",
+                        },
+                        {
+                            "title": "Totally Invented Title",
+                            "author": "Nobody",
+                            "description": "d",
+                            "why_it_fits": "w",
+                            "match_type": "literal",
+                            "maps_to": "Lisbon",
+                        },
+                    ]
+                }))
+
+        monkeypatch.setattr(google_llm.Gemini, "generate_content_async", scripted)
+
+        model = google_llm.Gemini(
+            model="gemini-2.5-flash-lite", client_kwargs={"api_key": "dummy"}
+        )
+        resolver = PlaceToBookResolver(
+            model, session_service=InMemorySessionService()
+        )
+        result = await resolver.resolve("Lisbon")
+
+        titles = [c.title for c in result.candidates]
+        assert "Totally Invented Title" not in titles, (
+            "invented title survived — researcher_text was empty and the "
+            "grounding filter failed open: the resolver capture path is dead "
+            "under graph authorship"
+        )
+        assert titles == ["The Book of Disquiet"]
+        assert result.found is True

--- a/tests/unit/test_place_to_book.py
+++ b/tests/unit/test_place_to_book.py
@@ -9,13 +9,13 @@ not-found state, and result caching.
 
 import pytest
 
-from google.adk.agents import SequentialAgent, LlmAgent
+from google.adk.agents import LlmAgent
 from google.adk.events import Event
 from google.adk.tools import FunctionTool
 from google.genai import types
 
 from agents import (
-    create_place_to_book_pipeline,
+    create_place_to_book_agents,
     create_place_to_book_workflow,
 )
 from models.place_to_book import (
@@ -200,26 +200,34 @@ class TestLabelInvariants:
 # ---------------------------------------------------------------------------
 
 class TestFactories:
-    def test_pipeline_is_sequential(self, mock_google_search_tool):
-        pipe = create_place_to_book_pipeline("gemini-2.0-flash", mock_google_search_tool, place="Lisbon")
-        assert isinstance(pipe, SequentialAgent)
-        assert pipe.name == "place_to_book_pipeline"
-        assert len(pipe.sub_agents) == 2
-        names = [a.name for a in pipe.sub_agents]
-        assert names == ["place_to_book_researcher", "place_to_book_formatter"]
+    def test_agent_pair(self, mock_google_search_tool):
+        researcher, formatter = create_place_to_book_agents(
+            "gemini-2.0-flash", mock_google_search_tool, place="Lisbon"
+        )
+        assert researcher.name == "place_to_book_researcher"
+        assert formatter.name == "place_to_book_formatter"
 
     def test_researcher_has_search_tool_formatter_does_not(self, mock_google_search_tool):
-        pipe = create_place_to_book_pipeline("gemini-2.0-flash", mock_google_search_tool, place="Tokyo")
-        researcher, formatter = pipe.sub_agents
+        researcher, formatter = create_place_to_book_agents(
+            "gemini-2.0-flash", mock_google_search_tool, place="Tokyo"
+        )
         assert isinstance(researcher, LlmAgent) and researcher.tools
-        # Formatter is tool-less (output_schema forbids tools in ADK).
+        # Formatter stays tool-less: ADK 2.x allows tools + output_schema, but
+        # the researcher/formatter separation is the ADR #2 anti-hallucination
+        # contract, kept deliberately.
         assert not formatter.tools
 
-    def test_workflow_wraps_pipeline(self, mock_google_search_tool):
+    def test_workflow_is_researcher_to_formatter_graph(self, mock_google_search_tool):
+        from google.adk.workflow import Workflow
+
         wf = create_place_to_book_workflow("gemini-2.0-flash", mock_google_search_tool, place="Dublin")
-        assert isinstance(wf, SequentialAgent)
+        assert isinstance(wf, Workflow)
         assert wf.name == "place_to_book_workflow"
-        assert len(wf.sub_agents) == 1
+        chain = [(e.from_node.name, e.to_node.name) for e in wf.graph.edges]
+        assert chain == [
+            ("__START__", "place_to_book_researcher"),
+            ("place_to_book_researcher", "place_to_book_formatter"),
+        ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

All six workflows are now explicit `google.adk.workflow.Workflow` graphs — **zero Sequential/ParallelAgent templates remain** (asserted by constructing every workflow with warnings captured: no template deprecation fires). The `create_*_agents` factories return plain `(researcher, formatter)` LlmAgent pairs and own no composition; chains, the 3-way discovery fan-out, and the `JoinNode` fan-in are edges in [orchestrator.py](agents/orchestrator.py). `Runner` is driven via `node=` at the single `_build_runner` seam.

**The primary flow gets its name: `book_to_place`** — the symmetric counterpart of `place_to_book`, per review: the reverse direction was a named capability while the primary direction was the unnamed default. Phase workflows: `book_to_place_discovery` / `book_to_place_composition`. Executor methods keep their phase verbs (`discover`/`compose`); **the HTTP contract is byte-identical** — the golden-stream SSE snapshot passes unchanged.

## Discovery graph

```
START → book_context_researcher → book_context_formatter
      → fan-out: city_r→city_f | landmark_r→landmark_f | author_r→author_f
      → JoinNode(discovery_join) → region_analyzer
```

The JoinNode is load-bearing: a plain node fires on ANY predecessor; region_analyzer needs ALL three branches.

## Semantics pinned, not assumed

New [test_graph_workflows.py](tests/unit/test_graph_workflows.py) drives **real Workflows through a real Runner with a scripted model** (class-level `generate_content_async` patch) and pins the four contracts the rewrite depends on:
1. downstream nodes see upstream responses in their request (ADR #2 researcher→formatter anti-hallucination);
2. `output_key` writes session state (ADR #5);
3. events keep per-agent authorship (progress mapping / golden stream);
4. JoinNode gates the fan-in to exactly one run after all branches (ADR #3).

`test_agents.py` rewritten graph-native (edges, join, terminals — same semantic pins as before, including the MYS-436 reader-profile guard).

## Kept deliberately

Researcher/formatter split (2.x would allow tools+schema on one agent — separate eval-gated experiment), ADR #11 `append_event` persistence, the two-endpoint HITL facade. Docs: ADR #24, supersession notes on ADR #2/#3 snippets, README + evaluation/README diagrams.

⚠️ **Dashboard note:** Langfuse root spans rename to `book_to_place_{discovery,composition}_invocation`.

## Verification

748 unit / integration gate green / coverage 82.47% (floor 74) / golden-stream unchanged. Eval gate run on this branch to follow as a comment (thresholds per the calibrated baseline on #209).

🤖 Generated with [Claude Code](https://claude.com/claude-code)