### PR TITLE
fix(eval): judge omitting a demanded dimension fails scoring instead of thinning the average

### DIFF
--- a/evaluation/tools/llm_scorer.py
+++ b/evaluation/tools/llm_scorer.py
@@ -319,6 +319,17 @@ Respond with ONLY a valid JSON object (no markdown, no explanation) with these e
         if not score_preferences and scores.preference_adherence is not None:
             # Judge scored a dimension it was told to skip — force honesty.
             scores = scores.model_copy(update={"preference_adherence": None})
+        if score_preferences and scores.preference_adherence is None:
+            # The inverse gap (Codex P2 on PR #228): the field is Optional for
+            # the no-preference shape, so a judge that OMITS it on a
+            # preference-carrying case would silently produce a 5-dimension
+            # average — the API-contract shape passing without adherence ever
+            # being measured. A missing demanded dimension is a scoring
+            # FAILURE, not a thinner success: raise into the existing
+            # scoring-failed path so the case shows up unscored and visible.
+            raise ValueError(
+                "judge omitted preference_adherence on a preference-carrying case"
+            )
 
         usage = response.usage_metadata
         get_client().update_current_generation(

--- a/evaluation/tools/run_scheduled_eval.py
+++ b/evaluation/tools/run_scheduled_eval.py
@@ -56,12 +56,18 @@ def _summarize_by_shape(case_results: List[Dict[str, Any]]) -> Dict[str, Any]:
     """
     shapes: Dict[str, Dict[str, Any]] = {}
     for shape_name, wants in (("with_preferences", True), ("without_preferences", False)):
-        scored = [
+        in_shape = [
             c for c in case_results
-            if c.get("scores") and bool(c.get("has_preferences")) == wants
+            if "has_preferences" in c and bool(c.get("has_preferences")) == wants
         ]
+        scored = [c for c in in_shape if c.get("scores")]
+        # Evaluated-but-unscored cases (e.g. the judge omitted a demanded
+        # dimension and scoring failed) must stay VISIBLE in the cell — a
+        # shrinking n with no marker would be a silent case-count
+        # inconsistency replacing the silent dimension-count one (#229 review).
+        n_unscored = len(in_shape) - len(scored)
         if not scored:
-            shapes[shape_name] = {"n": 0}
+            shapes[shape_name] = {"n": 0, "n_unscored": n_unscored}
             continue
         averages = [c["scores"]["average"] for c in scored]
         tokens = [
@@ -71,6 +77,7 @@ def _summarize_by_shape(case_results: List[Dict[str, Any]]) -> Dict[str, Any]:
         ]
         shapes[shape_name] = {
             "n": len(scored),
+            "n_unscored": n_unscored,
             "mean_average": round(sum(averages) / len(averages), 3),
             "mean_total_tokens": round(sum(tokens) / len(tokens)) if tokens else None,
         }

--- a/tests/unit/test_eval_shapes.py
+++ b/tests/unit/test_eval_shapes.py
@@ -52,18 +52,27 @@ class TestSummarizeByShape:
             self._case(True, 4.0, 2000),
             self._case(True, 3.0, 1000),
             self._case(False, 2.0, 500),
-            {"has_preferences": False},  # unscored (failed) case: excluded
+            {"has_preferences": False},  # unscored (failed) case
         ]
         shapes = _summarize_by_shape(results)
         assert shapes["with_preferences"] == {
-            "n": 2, "mean_average": 3.5, "mean_total_tokens": 1500,
+            "n": 2, "n_unscored": 0, "mean_average": 3.5, "mean_total_tokens": 1500,
         }
         assert shapes["without_preferences"]["n"] == 1
         assert shapes["without_preferences"]["mean_average"] == 2.0
+        # The unscored case stays VISIBLE in its cell, never silently dropped.
+        assert shapes["without_preferences"]["n_unscored"] == 1
 
     def test_empty_shape_reports_zero(self):
         shapes = _summarize_by_shape([self._case(True, 4.0)])
-        assert shapes["without_preferences"] == {"n": 0}
+        assert shapes["without_preferences"] == {"n": 0, "n_unscored": 0}
+
+    def test_all_unscored_shape_still_visible(self):
+        """A shape where every case failed scoring reports n=0 but a nonzero
+        n_unscored — the difference between 'no cases ran' and 'cases ran and
+        none could be scored' must be readable from the artifact."""
+        shapes = _summarize_by_shape([{"has_preferences": True}])
+        assert shapes["with_preferences"] == {"n": 0, "n_unscored": 1}
 
 
 class TestEvalsetShapeSplit:
@@ -160,7 +169,12 @@ class TestJudgeDimensionContract:
             llm_scorer.genai, "Client",
             lambda **kw: SimpleNamespace(models=_FakeModels()),
         )
-        with pytest.raises(Exception):
+        # Narrow by review: pytest.raises(Exception) would pass on ANY failure
+        # — a mis-wired fake raising AttributeError before the parse would go
+        # green with the guard never exercised (the same
+        # success-over-the-thing-it-checks class this PR closes). The match
+        # pins that THE GUARD is what fired.
+        with pytest.raises(ValueError, match="omitted preference_adherence"):
             await llm_scorer.score_itinerary(
                 api_key="k", book_title="B", author="A", input_text="i",
                 itinerary={"cities": []},

--- a/tests/unit/test_eval_shapes.py
+++ b/tests/unit/test_eval_shapes.py
@@ -119,3 +119,50 @@ class TestModelDefault:
         self._base_env(monkeypatch)
         monkeypatch.setenv("MODEL_NAME", "gemini-3.5-flash")
         assert load_config().model_name == "gemini-3.5-flash"
+
+
+class TestJudgeDimensionContract:
+    """Codex P2 on PR #228: preference_adherence is Optional for the
+    no-preference shape, so a judge omitting it on a preference-CARRYING case
+    would silently average 5 dims — the API-contract shape passing without
+    adherence measured. The scorer now raises into its scoring-failed path
+    instead. (Audit of all four PR-4 eval runs on disk: zero occurrences —
+    latent, not fired; this pins it shut.)"""
+
+    def test_scores_model_allows_none(self):
+        # The model itself stays permissive (no-pref shape needs None)...
+        s = ItineraryScores(
+            book_relevance=3, completeness=3, actionability=3,
+            geographical_accuracy=3, engagement=3,
+        )
+        assert s.preference_adherence is None
+
+    async def test_missing_demanded_dimension_fails_scoring(self, monkeypatch):
+        """score_itinerary with preferences must FAIL (not 5-dim-average) when
+        the judge response omits preference_adherence."""
+        import json as _json
+        from types import SimpleNamespace
+
+        from evaluation.tools import llm_scorer
+
+        class _FakeModels:
+            def generate_content(self, **kwargs):
+                return SimpleNamespace(
+                    text=_json.dumps({
+                        "book_relevance": 4, "completeness": 4,
+                        "actionability": 4, "geographical_accuracy": 4,
+                        "engagement": 4,
+                    }),
+                    usage_metadata=None,
+                )
+
+        monkeypatch.setattr(
+            llm_scorer.genai, "Client",
+            lambda **kw: SimpleNamespace(models=_FakeModels()),
+        )
+        with pytest.raises(Exception):
+            await llm_scorer.score_itinerary(
+                api_key="k", book_title="B", author="A", input_text="i",
+                itinerary={"cities": []},
+                preferences={"pace": "fast"},
+            )


### PR DESCRIPTION
Closes the Codex P2 that #228 merged over (post-hoc review by @o-ostrovskiy).

**The gap:** `preference_adherence` is Optional unconditionally; only the no-preference branch forced None post-parse. A judge omitting the dimension on a preference-carrying case would silently produce a 5-dim average — the API-contract shape passing without adherence measured.

**Audit before fix** (all four PR-4 eval runs, on-disk, no re-run): **zero occurrences** — every preference-carrying case scored 6 dims, every prod-shape case exactly 5, in all four runs. Latent, never fired: the 0.753 baseline spread and paired −0.269 are pure score variance; **the PR-4 verdict stands untouched**.

**Fix:** on the preference branch, a parsed response missing the dimension raises into the existing scoring-failed path — the case surfaces as unscored and visible, never as a silently different quantity. Pinned both ways (`TestJudgeDimensionContract`).

Gates: 771 unit / integration green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)