### PR TITLE
fix(core): token-overlap grounding match replaces naive substring matching (MYS-582)

### DIFF
--- a/core/extraction.py
+++ b/core/extraction.py
@@ -120,8 +120,9 @@ def downgrade_ungrounded_match_types(
     The trust core of the hallucination guardrail: the formatter self-labels each
     stop's ``match_type``, but a self-label is not evidence. Here we *derive* the
     label server-side from a real check — any stop the formatter marked
-    ``literal``/``historical`` whose name does not appear in the grounded
-    discovery research (city/landmark/author/context) is downgraded to the
+    ``literal``/``historical`` whose name is not grounded in the discovery
+    research (city/landmark/author/context; see ``is_title_grounded`` for the
+    token-overlap matching rule) is downgraded to the
     weakest claim (``vibe``) and has its ``grounding_source`` cleared, since the
     cited evidence didn't hold up. Stops are never dropped and never upgraded.
 
@@ -133,7 +134,7 @@ def downgrade_ungrounded_match_types(
     if not itinerary_dict:
         return itinerary_dict
 
-    haystack = _normalize_text(grounding_text)
+    haystack = grounding_token_set(grounding_text)
     if not haystack:
         return itinerary_dict
 
@@ -142,8 +143,7 @@ def downgrade_ungrounded_match_types(
         for stop in city.get("stops") or []:
             if stop.get("match_type") not in _GROUNDED_MATCH_TYPES:
                 continue
-            name = _normalize_text(stop.get("name"))
-            if name and name in haystack:
+            if is_title_grounded(stop.get("name"), haystack):
                 continue
             stop["match_type"] = _DOWNGRADE_TARGET
             stop["grounding_source"] = None
@@ -250,11 +250,50 @@ def extract_book_recommendations_from_state(state_accessor) -> Optional[dict]:
     )
 
 
-def _normalize_text(text: object) -> str:
-    """Lowercase + collapse whitespace for tolerant substring matching."""
+# Leading/interior articles carry no grounding signal and are the usual source
+# of surface-form mismatches ("Pump Room" vs "The Grand Pump Room").
+_ARTICLES = frozenset({"the", "a", "an"})
+
+# 1-2 token titles require every token in the grounding text; 3+ token titles
+# tolerate exactly this many missing tokens, which absorbs surface variants
+# like "The Grand Pump Room" vs "Pump Room". A flat overlap ratio is
+# deliberately avoided: it would let long titles pass with several unsupported
+# tokens, and long place names are where scattered-word false matches bite.
+_GROUNDING_MAX_MISSING = 1
+
+
+def grounding_token_set(text: object) -> frozenset:
+    """Tokenize grounding text once for repeated is_title_grounded() checks.
+
+    Word tokens (unicode-aware, lowercased, punctuation stripped). An empty
+    result means "no usable evidence" — every caller treats that as its
+    fail-open branch, same as the old empty-string check.
+    """
     if not isinstance(text, str):
-        return ""
-    return re.sub(r"\s+", " ", text).strip().lower()
+        return frozenset()
+    return frozenset(re.findall(r"\w+", text.lower()))
+
+
+def is_title_grounded(title: object, haystack_tokens: frozenset) -> bool:
+    """Shared grounding-match primitive for the output-side guards.
+
+    Token containment replacing naive substring matching, which failed in
+    both directions: "The Mill" false-matched any text containing the
+    substring (e.g. "the millionaire"), while a grounded "The Grand Pump
+    Room" was missed when the research said "Pump Room". Matching on whole
+    word tokens fixes the former; tolerating at most one missing token on
+    3+ token titles fixes the latter. The allowance is a fixed count, not a
+    ratio, so a long title cannot pass on scattered partial support.
+
+    A title with no significant tokens (empty/None/articles-only) is never
+    grounded — identical to the old empty-normalized-title behavior.
+    """
+    title_tokens = grounding_token_set(title) - _ARTICLES
+    if not title_tokens:
+        return False
+    missing = len(title_tokens - haystack_tokens)
+    allowed_missing = _GROUNDING_MAX_MISSING if len(title_tokens) >= 3 else 0
+    return missing <= allowed_missing
 
 
 def filter_grounded_recommendations(
@@ -264,7 +303,8 @@ def filter_grounded_recommendations(
 
     The book-recommendation formatter is tool-less and instructed never to
     invent books, but as a defensive post-validation we drop any recommendation
-    whose title does not appear in the grounded researcher candidate text. This
+    whose title is not grounded in the researcher candidate text (per the
+    ``is_title_grounded`` token-overlap rule). This
     is the output-side complement to relaxing the schema floor: relaxing the
     floor removes the *pressure* to fabricate; this removes any title that was
     fabricated anyway.
@@ -281,15 +321,11 @@ def filter_grounded_recommendations(
         return None
 
     recs = rec_data.get("recommendations") or []
-    haystack = _normalize_text(researcher_text)
+    haystack = grounding_token_set(researcher_text)
     if not haystack:
         return rec_data
 
-    grounded = [
-        rec
-        for rec in recs
-        if _normalize_text(rec.get("title")) and _normalize_text(rec.get("title")) in haystack
-    ]
+    grounded = [rec for rec in recs if is_title_grounded(rec.get("title"), haystack)]
 
     if not grounded or len(grounded) == len(recs):
         return rec_data

--- a/core/place_to_book.py
+++ b/core/place_to_book.py
@@ -39,7 +39,7 @@ from models.place_to_book import PlaceBookCandidate, PlaceToBookCandidates, Plac
 from services.session_service import create_session_service
 
 from .cache import TTLCache
-from .extraction import _normalize_text
+from .extraction import grounding_token_set, is_title_grounded
 from .run_harness import RunCapture, pump_events
 from .session_state import SessionStateAccessor
 
@@ -100,9 +100,10 @@ def cache_key(place: str) -> str:
     return f"{_CACHE_KEY_PREFIX}{normalize_place(place)}"
 
 
-# _normalize_text is shared with core.extraction (imported above). The
-# grounding FILTERS themselves stay separate on purpose: this module's filter
-# treats an all-dropped result as a valid honest not-found, while the
+# The grounding-match primitive (grounding_token_set / is_title_grounded) is
+# shared with core.extraction (imported above). The grounding FILTERS
+# themselves stay separate on purpose: this module's filter treats an
+# all-dropped result as a valid honest not-found, while the
 # book-recommendation filter fails open on that outcome — different contracts,
 # documented on each function.
 
@@ -137,7 +138,8 @@ def extract_place_to_book_from_state(state_accessor) -> Optional[List[dict]]:
 def filter_grounded_candidates(
     candidates: Optional[List[dict]], researcher_text: str
 ) -> List[dict]:
-    """Drop candidates whose title is not present in the grounded researcher text.
+    """Drop candidates whose title is not grounded in the researcher text
+    (per the shared ``is_title_grounded`` token-overlap rule).
 
     Output-side complement to the formatter's "never invent" instruction. Unlike
     the book-recommendation filter, dropping every candidate is a VALID outcome
@@ -148,14 +150,10 @@ def filter_grounded_candidates(
     """
     if not candidates:
         return []
-    haystack = _normalize_text(researcher_text)
+    haystack = grounding_token_set(researcher_text)
     if not haystack:
         return list(candidates)
-    grounded = [
-        c
-        for c in candidates
-        if _normalize_text(c.get("title")) and _normalize_text(c.get("title")) in haystack
-    ]
+    grounded = [c for c in candidates if is_title_grounded(c.get("title"), haystack)]
     if len(grounded) != len(candidates):
         logger.info(
             "place_to_book_grounding_filtered",

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -36,6 +36,8 @@ from core.extraction import (
     extract_expansion_from_state,
     extract_book_recommendations_from_state,
     downgrade_ungrounded_match_types,
+    grounding_token_set,
+    is_title_grounded,
 )
 from core.events import ExpansionReady
 from core.executor import WorkflowExecutor
@@ -1006,6 +1008,62 @@ class TestDowngradeUngroundedMatchTypes:
 
     def test_none_itinerary_returns_none(self):
         assert downgrade_ungrounded_match_types(None, _RESEARCH) is None
+
+    def test_short_generic_name_no_substring_false_positive(self):
+        # "The Mill" used to substring-match "the millionaire" in unrelated text.
+        itin = _itinerary_with_stops([_stop("The Mill", "literal", grounding_source="x")])
+        research = "A tour of the millionaire's mansion district in Atlanta."
+        out = downgrade_ungrounded_match_types(itin, research)
+        stop = out["cities"][0]["stops"][0]
+        assert stop["match_type"] == "vibe"
+        assert stop["grounding_source"] is None
+
+    def test_surface_variant_name_still_grounded(self):
+        # One missing token ("Grand") must not downgrade a grounded stop.
+        itin = _itinerary_with_stops(
+            [_stop("The Grand Pump Room", "literal", grounding_source="ch. 2")]
+        )
+        research = "Austen's characters take the waters at the Pump Room in Bath."
+        out = downgrade_ungrounded_match_types(itin, research)
+        stop = out["cities"][0]["stops"][0]
+        assert stop["match_type"] == "literal"
+        assert stop["grounding_source"] == "ch. 2"
+
+
+class TestGroundingTokenMatch:
+    """The shared matching primitive behind all three grounding guards."""
+
+    def test_exact_match(self):
+        haystack = grounding_token_set("Visit the Margaret Mitchell House today")
+        assert is_title_grounded("Margaret Mitchell House", haystack)
+
+    def test_two_token_title_requires_both_tokens(self):
+        haystack = grounding_token_set("only the pump is mentioned here")
+        assert not is_title_grounded("Pump Room", haystack)
+
+    def test_three_token_title_tolerates_one_missing(self):
+        haystack = grounding_token_set("scenes at the pump room in bath")
+        assert is_title_grounded("Grand Pump Room", haystack)
+
+    def test_long_title_never_tolerates_two_missing(self):
+        # The allowance is a fixed count, not a ratio: a flat 0.6 threshold
+        # would pass this 5-token title on 3/5 scattered support.
+        haystack = grounding_token_set("the pump room and roman spa")
+        assert not is_title_grounded("Grand Pump Room Roman Baths", haystack)
+
+    def test_word_boundaries_respected(self):
+        haystack = grounding_token_set("the millionaire's mansion")
+        assert not is_title_grounded("The Mill", haystack)
+
+    def test_empty_or_articles_only_title_never_grounded(self):
+        haystack = grounding_token_set("the a an anything")
+        assert not is_title_grounded("The", haystack)
+        assert not is_title_grounded("", haystack)
+        assert not is_title_grounded(None, haystack)
+
+    def test_non_string_grounding_text_yields_empty_set(self):
+        assert grounding_token_set(None) == frozenset()
+        assert grounding_token_set(42) == frozenset()
 
 
 class TestGroundingResearchText:

--- a/tests/unit/test_place_to_book.py
+++ b/tests/unit/test_place_to_book.py
@@ -170,6 +170,23 @@ class TestGroundingFilter:
         assert filter_grounded_candidates([], "text") == []
         assert filter_grounded_candidates(None, "text") == []
 
+    def test_no_substring_false_positive_for_short_title(self):
+        # "The Mill" formerly substring-matched "the millionaire" — and here
+        # dropping to empty is the valid honest not-found outcome.
+        cands = [_candidate("The Mill")]
+        out = filter_grounded_candidates(cands, "a profile of the millionaire founder")
+        assert out == []
+
+    def test_surface_variant_title_kept(self):
+        cands = [_candidate("The Grand Pump Room")]
+        out = filter_grounded_candidates(cands, "scenes set in the Pump Room at Bath")
+        assert [c["title"] for c in out] == ["The Grand Pump Room"]
+
+    def test_exact_title_kept(self):
+        cands = [_candidate("Real Title")]
+        out = filter_grounded_candidates(cands, "the researcher covered Real Title fully")
+        assert [c["title"] for c in out] == ["Real Title"]
+
 
 # ---------------------------------------------------------------------------
 # Label invariants

--- a/tests/unit/test_recommendation_floor.py
+++ b/tests/unit/test_recommendation_floor.py
@@ -108,3 +108,20 @@ class TestFilterGroundedRecommendations:
 
     def test_none_input_returns_none(self):
         assert filter_grounded_recommendations(None, "anything") is None
+
+    def test_no_substring_false_positive_for_short_title(self):
+        # "The Mill" formerly substring-matched "the millionaire"; paired with a
+        # grounded title so the all-dropped fail-open cannot mask the drop.
+        data = self._data("Beloved", "The Mill")
+        researcher = "Candidate: Beloved by Toni Morrison, set near the millionaire's estate."
+        out = filter_grounded_recommendations(data, researcher)
+        titles = [r["title"] for r in out["recommendations"]]
+        assert titles == ["Beloved"]
+        assert out["limited_matches"] is True
+
+    def test_surface_variant_title_kept(self):
+        data = self._data("The Grand Budapest Hotel", "Phantom")
+        researcher = "The researcher found Budapest Hotel among the candidates."
+        out = filter_grounded_recommendations(data, researcher)
+        titles = [r["title"] for r in out["recommendations"]]
+        assert titles == ["The Grand Budapest Hotel"]


### PR DESCRIPTION
Opened by the Engineering Lead for review. Commit `77bd66c`; ticket [MYS-582](https://linear.app/mystoryland/issue/MYS-582).

## What

The three output-side grounding guards matched via lowercase substring (`_normalize_text`), failing in both directions the July 2026 review flagged:

- **False positive:** short generic names matched superstrings — "The Mill" in "the millionaire" — so an unsupported stop passed the guard.
- **False negative:** grounded surface variants were wrongly downgraded — "The Grand Pump Room" against research saying "Pump Room".

Replaced with a shared primitive: `grounding_token_set()` / `is_title_grounded()` — unicode word tokens, articles stripped, **all tokens required for 1–2 token titles, at most one missing token for 3+ token titles**. The allowance is a **fixed count, not a ratio**, so long titles cannot pass on scattered partial support.

Each filter's fail-open contract is unchanged and re-pinned by tests: `downgrade_ungrounded_match_types` never drops stops and fails open on no evidence; `filter_grounded_recommendations` fails open on no-text *and* all-dropped; `filter_grounded_candidates` fails open on no-text while keeping all-dropped as a valid honest not-found. The three filters stay separate. The evidence-capture path is untouched.

## Review note carried in from the ticket, resolved

MYS-582's review contract flagged that a flat 0.6 containment does **not** implement "3+ tokens tolerate one missing token" — at 5 tokens, 3/5 = 0.60 passes, tolerating two. That was resolved in the implementation's favour: the rule is now a literal fixed count, and the counterexample is pinned as `test_long_title_never_tolerates_two_missing` ("Grand Pump Room Roman Baths" against research supporting 3 of 5 tokens now fails, where 0.6 would have passed it).

## Tests

775 unit passed. 10 integration passed, 4 `real_api` live tests deselected as `make test-integration` defines — those 4 fail on an invalid Gemini key against the unmodified baseline too (pre-existing, filed separately). No new dependency, so no relock.

## Eval (founder-approved, per-run G4)

Run 29779118506, dispatched against this branch. Both real datasets completed; gate **passed**:

| dataset | this run | gate | pooled baseline | Δ | max noise |
| -- | -- | -- | -- | -- | -- |
| storyland_eval (n=8) | 4.50 | ≥ 4.10 | 4.44 | +0.06 | 0.17 |
| books_v1 (n=10) | 2.75 | ≥ 2.08 | 2.88 | −0.13 | 0.40 |

Both deltas sit inside measured judge noise — **no directional claim in either direction.**

`mechanism:` LLM-as-judge (`score_itinerary`, 6 dims) over two datasets, plus guard telemetry counted from the run's compositions. Gate = interim constants, a catastrophe detector rather than a quality threshold. Dimensions flat against the known profile; cost/case $0.0048–0.0057, in line with trend; low `books_v1` cases are the familiar bimodal names (Shogun 1.17, Leviathan Wakes 1.33), not new failures.

**Guard telemetry:** across 18 composed itineraries the new matcher downgraded **zero** stops and the rec filter dropped **zero** titles; the pre-change run downgraded 3. Recorded as an observation, not a claim — the runs are not case-aligned. See the review comment for what this does and doesn't establish.

**Caveat, stated plainly:** the deterministic place→book eval (`run_place_to_book_eval.py`) — the one that measures the `filter_grounded_candidates` path this change touches — did not run. On this branch it is wired into no workflow; that is no longer true of `main` (ai#230 added a `place_to_book` runner dispatch input). So the p2b side of this change is covered by unit tests only.