### PR TITLE
feat(eval): judge calibration — labeling queue, agreement analysis, weekly spot-check (MYS-586)

### DIFF
--- a/.github/workflows/scheduled-eval.yml
+++ b/.github/workflows/scheduled-eval.yml
@@ -65,6 +65,7 @@ jobs:
           echo "LANGFUSE_SECRET_KEY=${{ secrets.LANGFUSE_SECRET_KEY }}" >> .env
           echo "LANGFUSE_PUBLIC_KEY=${{ secrets.LANGFUSE_PUBLIC_KEY }}" >> .env
           echo "LANGFUSE_HOST=${{ secrets.LANGFUSE_HOST }}" >> .env
+          echo "LANGFUSE_REVIEW_QUEUE_ID=${{ vars.LANGFUSE_REVIEW_QUEUE_ID }}" >> .env
 
       - name: Sync Langfuse datasets
         timeout-minutes: 5

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ The unit suite (`tests/unit/`) by area — per-module counts rot with every PR, 
 | API layer | `test_api.py`, `test_gateway_auth.py`, `test_ratelimit.py`, `test_request_input_limits.py`, `test_dependencies.py` |
 | Caching | `test_cache.py`, `test_disk_cache.py`, `test_cache_version.py` |
 | Place features | `test_place_key.py`, `test_place_to_book.py`, `test_place_to_book_eval.py` |
-| Quality & guardrails | `test_llm_scorer.py`, `test_tone_guardrail.py`, `test_recommendation_floor.py` |
+| Quality & guardrails | `test_llm_scorer.py`, `test_tone_guardrail.py`, `test_recommendation_floor.py`, `test_judge_calibration.py`, `test_spot_check.py` |
 | Eval harnesses | `test_local_atmosphere_eval.py`, `test_expansion_eval.py`, `test_eval_dataset_routing.py` |
 | Observability | `test_sentry.py`, `test_langfuse_plugin_concurrency.py`, `test_langfuse_pricing.py` |
 | Sessions & ops | `test_services.py`, `test_session_retention.py` |

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -226,7 +226,7 @@ is recorded in the results JSON under `human_spot_check` with
 `status: pending_review`, and the trend report renders a "Human spot-checks"
 section where unreviewed cases stay listed with their age — skipped reviews
 are visible, not silent. A case counts as reviewed once its trace carries any
-ANNOTATION-source score in Langfuse.
+`human_*` label score in Langfuse (entered via the annotation UI or the API).
 
 Set `LANGFUSE_REVIEW_QUEUE_ID` (e.g. as a GitHub Actions variable) to have
 flagged traces auto-enqueued into an annotation queue; enqueue failures are

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -190,6 +190,52 @@ Each evaluation is scored on 6 dimensions (1-5 scale):
 
 LLM-as-judge scoring is implemented in `evaluation/tools/llm_scorer.py` using Gemini to evaluate itineraries against these criteria.
 
+### Judge Calibration (human labels)
+
+The judge has never been anchored to human labels, and its run-to-run noise is
+large (books_v1 ±0.40, storyland_eval ±0.17 on identical code) — so judge
+scores gate only catastrophes until calibrated. `evaluation/tools/judge_calibration.py`
+manages the calibration loop against Langfuse annotation queues:
+
+```bash
+# 1. Build the labeling queue: pulls ~30 judge-scored itineraries from recent
+#    dataset runs, creates human_<dimension> score configs (1-5, exact rubric
+#    text from SCORING_CRITERIA), enqueues the traces, writes a manifest to
+#    evaluation/calibration/. Needs LANGFUSE_* creds in .env.
+python evaluation/tools/judge_calibration.py build-queue          # --dry-run to preview
+
+# 2. Hand-label in Langfuse: Annotation Queues → judge-calibration-2026-07.
+#    Score from the trace OUTPUT (itinerary) + INPUT (book, preferences);
+#    don't look at the judge's existing scores first.
+
+# 3. Compute judge-vs-human agreement (per-dimension mean absolute difference
+#    and direction bias, |Δ|≥2 disagreement list):
+python evaluation/tools/judge_calibration.py agreement
+```
+
+The manifest (`evaluation/calibration/queue_manifest_*.json`) is the join key
+between judge scores and human labels — commit it. Rubric re-anchoring edits
+to `SCORING_CRITERIA` and gate-threshold recomputation are driven by the
+agreement report.
+
+### Weekly Human Spot-Check
+
+Each scheduled eval run randomly flags up to 2 scored cases for human review
+(seeded by run date, so a same-day re-run flags the same cases). The selection
+is recorded in the results JSON under `human_spot_check` with
+`status: pending_review`, and the trend report renders a "Human spot-checks"
+section where unreviewed cases stay listed with their age — skipped reviews
+are visible, not silent. A case counts as reviewed once its trace carries any
+ANNOTATION-source score in Langfuse.
+
+Set `LANGFUSE_REVIEW_QUEUE_ID` (e.g. as a GitHub Actions variable) to have
+flagged traces auto-enqueued into an annotation queue; enqueue failures are
+non-fatal and the JSON record remains the source of truth.
+
+Results JSONs also now carry the full `itinerary` payload, the `preferences`
+the judge saw, and the Langfuse `trace_id` per case, so review and calibration
+work from artifacts alone.
+
 ### Automated Evaluations
 
 Evaluations run automatically via GitHub Actions:
@@ -340,6 +386,7 @@ evaluation/
 │   ├── eval_dashboard.py          # Dashboard and reporting
 │   ├── langfuse_eval.py           # Dataset creation pipeline
 │   ├── llm_scorer.py              # LLM-as-judge quality scoring
+│   ├── judge_calibration.py       # Human-label queue + judge-vs-human agreement
 │   └── setup_langfuse_eval.sh     # Setup script
 ├── storyland_eval.evalset.json    # Dataset (8 diverse books)
 ├── books_v1.evalset.json          # Dataset (10 books with expected output + criteria)
@@ -347,6 +394,7 @@ evaluation/
 ├── local_atmosphere_v1.evalset.json  # Dataset (8 local-atmosphere cases, mixed preference shapes)
 ├── expansion_v1.evalset.json      # Dataset (5 expansion two-step deterministic cases)
 ├── langfuse_datasets.json         # Dataset registry incl. per-dataset flow (gitignored)
+├── calibration/                   # Judge-calibration manifests + agreement reports (tracked)
 ├── results/                       # Evaluation run results (gitignored)
 ├── trend_report.md                # Generated trend report (tracked)
 └── metrics.json                   # Exported metrics (gitignored)

--- a/evaluation/calibration/agreement_report.json
+++ b/evaluation/calibration/agreement_report.json
@@ -1,0 +1,485 @@
+{
+  "n_manifest_items": 30,
+  "n_labeled_items": 30,
+  "per_dimension": {
+    "book_relevance": {
+      "n": 29,
+      "mean_abs_diff": 1.172,
+      "bias": -0.897,
+      "large_disagreements": 12
+    },
+    "preference_adherence": {
+      "n": 16,
+      "mean_abs_diff": 0.875,
+      "bias": -0.75,
+      "large_disagreements": 3
+    },
+    "completeness": {
+      "n": 29,
+      "mean_abs_diff": 1.0,
+      "bias": -0.862,
+      "large_disagreements": 11
+    },
+    "actionability": {
+      "n": 29,
+      "mean_abs_diff": 0.759,
+      "bias": -0.69,
+      "large_disagreements": 7
+    },
+    "geographical_accuracy": {
+      "n": 29,
+      "mean_abs_diff": 1.241,
+      "bias": -0.759,
+      "large_disagreements": 10
+    },
+    "engagement": {
+      "n": 30,
+      "mean_abs_diff": 0.7,
+      "bias": -0.5,
+      "large_disagreements": 6
+    }
+  },
+  "large_disagreements": [
+    {
+      "dimension": "book_relevance",
+      "dataset": "storyland_eval",
+      "item_id": "d48fbd3c",
+      "run_name": "eval_run_20260720_202412_v3",
+      "book_title": "Under the Tuscan Sun",
+      "judge": 5,
+      "human": 3
+    },
+    {
+      "dimension": "book_relevance",
+      "dataset": "books_v1",
+      "item_id": "query_011",
+      "run_name": "eval_run_20260720_033838_v3",
+      "book_title": "The Lord of the Rings",
+      "judge": 3,
+      "human": 5
+    },
+    {
+      "dimension": "book_relevance",
+      "dataset": "books_v1",
+      "item_id": "query_012",
+      "run_name": "eval_run_20260720_033838_v3",
+      "book_title": "The Long Walk",
+      "judge": 1,
+      "human": 3
+    },
+    {
+      "dimension": "book_relevance",
+      "dataset": "books_v1",
+      "item_id": "query_014",
+      "run_name": "eval_run_20260720_033838_v3",
+      "book_title": "Red, White & Royal Blue",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "book_relevance",
+      "dataset": "books_v1",
+      "item_id": "query_016",
+      "run_name": "eval_run_20260720_033838_v3",
+      "book_title": "The Kite Runner",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "book_relevance",
+      "dataset": "books_v1",
+      "item_id": "query_017",
+      "run_name": "eval_run_20260720_033838_v3",
+      "book_title": "Crime and Punishment",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "book_relevance",
+      "dataset": "books_v1",
+      "item_id": "query_020",
+      "run_name": "eval_run_20260720_033838_v3",
+      "book_title": "Shogun",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "book_relevance",
+      "dataset": "books_v1",
+      "item_id": "query_014",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "Red, White & Royal Blue",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "book_relevance",
+      "dataset": "books_v1",
+      "item_id": "query_017",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "Crime and Punishment",
+      "judge": 2,
+      "human": 5
+    },
+    {
+      "dimension": "book_relevance",
+      "dataset": "books_v1",
+      "item_id": "query_018",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "Wild",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "book_relevance",
+      "dataset": "books_v1",
+      "item_id": "query_020",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "Shogun",
+      "judge": 1,
+      "human": 3
+    },
+    {
+      "dimension": "book_relevance",
+      "dataset": "books_v1",
+      "item_id": "query_012",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "The Long Walk",
+      "judge": 2,
+      "human": 5
+    },
+    {
+      "dimension": "preference_adherence",
+      "dataset": "books_v1",
+      "item_id": "query_017",
+      "run_name": "eval_run_20260720_033838_v3",
+      "book_title": "Crime and Punishment",
+      "judge": 1,
+      "human": 4
+    },
+    {
+      "dimension": "preference_adherence",
+      "dataset": "books_v1",
+      "item_id": "query_017",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "Crime and Punishment",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "preference_adherence",
+      "dataset": "books_v1",
+      "item_id": "query_019",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "Dracula",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "completeness",
+      "dataset": "books_v1",
+      "item_id": "query_012",
+      "run_name": "eval_run_20260720_033838_v3",
+      "book_title": "The Long Walk",
+      "judge": 1,
+      "human": 3
+    },
+    {
+      "dimension": "completeness",
+      "dataset": "books_v1",
+      "item_id": "query_014",
+      "run_name": "eval_run_20260720_033838_v3",
+      "book_title": "Red, White & Royal Blue",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "completeness",
+      "dataset": "books_v1",
+      "item_id": "query_016",
+      "run_name": "eval_run_20260720_033838_v3",
+      "book_title": "The Kite Runner",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "completeness",
+      "dataset": "books_v1",
+      "item_id": "query_018",
+      "run_name": "eval_run_20260720_033838_v3",
+      "book_title": "Wild",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "completeness",
+      "dataset": "books_v1",
+      "item_id": "query_020",
+      "run_name": "eval_run_20260720_033838_v3",
+      "book_title": "Shogun",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "completeness",
+      "dataset": "books_v1",
+      "item_id": "query_014",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "Red, White & Royal Blue",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "completeness",
+      "dataset": "books_v1",
+      "item_id": "query_017",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "Crime and Punishment",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "completeness",
+      "dataset": "books_v1",
+      "item_id": "query_018",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "Wild",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "completeness",
+      "dataset": "books_v1",
+      "item_id": "query_019",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "Dracula",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "completeness",
+      "dataset": "books_v1",
+      "item_id": "query_020",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "Shogun",
+      "judge": 1,
+      "human": 3
+    },
+    {
+      "dimension": "completeness",
+      "dataset": "books_v1",
+      "item_id": "query_012",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "The Long Walk",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "actionability",
+      "dataset": "books_v1",
+      "item_id": "query_014",
+      "run_name": "eval_run_20260720_033838_v3",
+      "book_title": "Red, White & Royal Blue",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "actionability",
+      "dataset": "books_v1",
+      "item_id": "query_018",
+      "run_name": "eval_run_20260720_033838_v3",
+      "book_title": "Wild",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "actionability",
+      "dataset": "books_v1",
+      "item_id": "query_014",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "Red, White & Royal Blue",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "actionability",
+      "dataset": "books_v1",
+      "item_id": "query_017",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "Crime and Punishment",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "actionability",
+      "dataset": "books_v1",
+      "item_id": "query_018",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "Wild",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "actionability",
+      "dataset": "books_v1",
+      "item_id": "query_019",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "Dracula",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "actionability",
+      "dataset": "books_v1",
+      "item_id": "query_020",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "Shogun",
+      "judge": 1,
+      "human": 3
+    },
+    {
+      "dimension": "geographical_accuracy",
+      "dataset": "books_v1",
+      "item_id": "query_011",
+      "run_name": "eval_run_20260720_033838_v3",
+      "book_title": "The Lord of the Rings",
+      "judge": 3,
+      "human": 5
+    },
+    {
+      "dimension": "geographical_accuracy",
+      "dataset": "books_v1",
+      "item_id": "query_012",
+      "run_name": "eval_run_20260720_033838_v3",
+      "book_title": "The Long Walk",
+      "judge": 1,
+      "human": 3
+    },
+    {
+      "dimension": "geographical_accuracy",
+      "dataset": "books_v1",
+      "item_id": "query_013",
+      "run_name": "eval_run_20260720_033838_v3",
+      "book_title": "Leviathan Wakes",
+      "judge": 5,
+      "human": 2
+    },
+    {
+      "dimension": "geographical_accuracy",
+      "dataset": "books_v1",
+      "item_id": "query_016",
+      "run_name": "eval_run_20260720_033838_v3",
+      "book_title": "The Kite Runner",
+      "judge": 2,
+      "human": 5
+    },
+    {
+      "dimension": "geographical_accuracy",
+      "dataset": "books_v1",
+      "item_id": "query_017",
+      "run_name": "eval_run_20260720_033838_v3",
+      "book_title": "Crime and Punishment",
+      "judge": 1,
+      "human": 4
+    },
+    {
+      "dimension": "geographical_accuracy",
+      "dataset": "books_v1",
+      "item_id": "query_016",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "The Kite Runner",
+      "judge": 3,
+      "human": 5
+    },
+    {
+      "dimension": "geographical_accuracy",
+      "dataset": "books_v1",
+      "item_id": "query_017",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "Crime and Punishment",
+      "judge": 2,
+      "human": 5
+    },
+    {
+      "dimension": "geographical_accuracy",
+      "dataset": "books_v1",
+      "item_id": "query_019",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "Dracula",
+      "judge": 3,
+      "human": 5
+    },
+    {
+      "dimension": "geographical_accuracy",
+      "dataset": "books_v1",
+      "item_id": "query_020",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "Shogun",
+      "judge": 1,
+      "human": 4
+    },
+    {
+      "dimension": "geographical_accuracy",
+      "dataset": "books_v1",
+      "item_id": "query_012",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "The Long Walk",
+      "judge": 1,
+      "human": 4
+    },
+    {
+      "dimension": "engagement",
+      "dataset": "books_v1",
+      "item_id": "query_014",
+      "run_name": "eval_run_20260720_033838_v3",
+      "book_title": "Red, White & Royal Blue",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "engagement",
+      "dataset": "books_v1",
+      "item_id": "query_017",
+      "run_name": "eval_run_20260720_033838_v3",
+      "book_title": "Crime and Punishment",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "engagement",
+      "dataset": "books_v1",
+      "item_id": "query_020",
+      "run_name": "eval_run_20260720_033838_v3",
+      "book_title": "Shogun",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "engagement",
+      "dataset": "books_v1",
+      "item_id": "query_017",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "Crime and Punishment",
+      "judge": 2,
+      "human": 4
+    },
+    {
+      "dimension": "engagement",
+      "dataset": "books_v1",
+      "item_id": "query_020",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "Shogun",
+      "judge": 1,
+      "human": 3
+    },
+    {
+      "dimension": "engagement",
+      "dataset": "books_v1",
+      "item_id": "query_012",
+      "run_name": "eval_run_20260720_033038_v3",
+      "book_title": "The Long Walk",
+      "judge": 2,
+      "human": 4
+    }
+  ]
+}

--- a/evaluation/calibration/agreement_report.md
+++ b/evaluation/calibration/agreement_report.md
@@ -1,0 +1,131 @@
+# Judge vs human agreement
+
+**Generated:** 2026-07-20 17:06
+**Manifest:** evaluation/calibration/queue_manifest_2026-07.json (30 items, 30 labeled)
+
+Bias = mean(judge − human): positive means the judge scores HIGHER than the human on that dimension.
+
+| Dimension | n | Mean abs diff | Bias | \|Δ\|≥2 |
+|-----------|---|---------------|------|--------|
+| book_relevance | 29 | 1.172 | -0.897 | 12 |
+| preference_adherence | 16 | 0.875 | -0.750 | 3 |
+| completeness | 29 | 1.0 | -0.862 | 11 |
+| actionability | 29 | 0.759 | -0.690 | 7 |
+| geographical_accuracy | 29 | 1.241 | -0.759 | 10 |
+| engagement | 30 | 0.7 | -0.500 | 6 |
+
+## Large disagreements (|Δ| ≥ 2)
+
+| Dimension | Case | Book | Judge | Human |
+|-----------|------|------|-------|-------|
+| book_relevance | storyland_eval/d48fbd3c | Under the Tuscan Sun | 5 | 3 |
+| book_relevance | books_v1/query_011 | The Lord of the Rings | 3 | 5 |
+| book_relevance | books_v1/query_012 | The Long Walk | 1 | 3 |
+| book_relevance | books_v1/query_014 | Red, White & Royal Blue | 2 | 4 |
+| book_relevance | books_v1/query_016 | The Kite Runner | 2 | 4 |
+| book_relevance | books_v1/query_017 | Crime and Punishment | 2 | 4 |
+| book_relevance | books_v1/query_020 | Shogun | 2 | 4 |
+| book_relevance | books_v1/query_014 | Red, White & Royal Blue | 2 | 4 |
+| book_relevance | books_v1/query_017 | Crime and Punishment | 2 | 5 |
+| book_relevance | books_v1/query_018 | Wild | 2 | 4 |
+| book_relevance | books_v1/query_020 | Shogun | 1 | 3 |
+| book_relevance | books_v1/query_012 | The Long Walk | 2 | 5 |
+| preference_adherence | books_v1/query_017 | Crime and Punishment | 1 | 4 |
+| preference_adherence | books_v1/query_017 | Crime and Punishment | 2 | 4 |
+| preference_adherence | books_v1/query_019 | Dracula | 2 | 4 |
+| completeness | books_v1/query_012 | The Long Walk | 1 | 3 |
+| completeness | books_v1/query_014 | Red, White & Royal Blue | 2 | 4 |
+| completeness | books_v1/query_016 | The Kite Runner | 2 | 4 |
+| completeness | books_v1/query_018 | Wild | 2 | 4 |
+| completeness | books_v1/query_020 | Shogun | 2 | 4 |
+| completeness | books_v1/query_014 | Red, White & Royal Blue | 2 | 4 |
+| completeness | books_v1/query_017 | Crime and Punishment | 2 | 4 |
+| completeness | books_v1/query_018 | Wild | 2 | 4 |
+| completeness | books_v1/query_019 | Dracula | 2 | 4 |
+| completeness | books_v1/query_020 | Shogun | 1 | 3 |
+| completeness | books_v1/query_012 | The Long Walk | 2 | 4 |
+| actionability | books_v1/query_014 | Red, White & Royal Blue | 2 | 4 |
+| actionability | books_v1/query_018 | Wild | 2 | 4 |
+| actionability | books_v1/query_014 | Red, White & Royal Blue | 2 | 4 |
+| actionability | books_v1/query_017 | Crime and Punishment | 2 | 4 |
+| actionability | books_v1/query_018 | Wild | 2 | 4 |
+| actionability | books_v1/query_019 | Dracula | 2 | 4 |
+| actionability | books_v1/query_020 | Shogun | 1 | 3 |
+| geographical_accuracy | books_v1/query_011 | The Lord of the Rings | 3 | 5 |
+| geographical_accuracy | books_v1/query_012 | The Long Walk | 1 | 3 |
+| geographical_accuracy | books_v1/query_013 | Leviathan Wakes | 5 | 2 |
+| geographical_accuracy | books_v1/query_016 | The Kite Runner | 2 | 5 |
+| geographical_accuracy | books_v1/query_017 | Crime and Punishment | 1 | 4 |
+| geographical_accuracy | books_v1/query_016 | The Kite Runner | 3 | 5 |
+| geographical_accuracy | books_v1/query_017 | Crime and Punishment | 2 | 5 |
+| geographical_accuracy | books_v1/query_019 | Dracula | 3 | 5 |
+| geographical_accuracy | books_v1/query_020 | Shogun | 1 | 4 |
+| geographical_accuracy | books_v1/query_012 | The Long Walk | 1 | 4 |
+| engagement | books_v1/query_014 | Red, White & Royal Blue | 2 | 4 |
+| engagement | books_v1/query_017 | Crime and Punishment | 2 | 4 |
+| engagement | books_v1/query_020 | Shogun | 2 | 4 |
+| engagement | books_v1/query_017 | Crime and Punishment | 2 | 4 |
+| engagement | books_v1/query_020 | Shogun | 1 | 3 |
+| engagement | books_v1/query_012 | The Long Walk | 2 | 4 |
+
+---
+
+## Addendum: mechanism + re-anchoring proposals (2026-07-20)
+
+**Label provenance:** these are MODEL labels (Claude Fable 5, Olga-approved in lieu
+of hand labels) — the analysis measures judge-vs-Claude, not judge-vs-human.
+
+### Mechanism: the harshness is entirely the books_v1 reference comparison
+
+| Dataset | Bias (judge−label) | MAD | Judge prompt difference |
+|---------|-------------------:|----:|-------------------------|
+| storyland_eval | **+0.18** | 0.32 | no expected_output, no quality_criteria |
+| books_v1 | **−1.16** | 1.27 | REFERENCE OUTPUT "use as benchmark" + book-specific criteria |
+
+The judge agrees with a careful reading almost perfectly when it scores the
+itinerary on its own merits, and turns into a reference-similarity metric when
+`_build_scoring_prompt` injects the expected_output as a "benchmark". This one
+prompt difference explains (a) the storyland 4.4 vs books 2.9 dataset gap and
+(b) much of books_v1's ±0.40 run noise (similarity-to-reference is brittle).
+
+Secondary finding: gemini-2.5-flash-lite cannot fact-check geography — it gave
+5 to a Leviathan Wakes generation that puts "Portland Observatory" in Oregon
+(it is in Portland, Maine; label 2), while giving 1–2 to Crime and Punishment
+generations whose canonical St. Petersburg addresses all check out.
+geographical_accuracy is the least trustworthy dimension (MAD 1.24).
+
+### Proposed prompt/rubric edits (NOT applied — changes the pinned judge, needs re-baseline)
+
+1. `_build_scoring_prompt` reference section: replace "**REFERENCE OUTPUT**
+   (use this as benchmark when scoring)" with "**REFERENCE EXAMPLE** — one
+   valid solution, for context only. Score the generated itinerary on its own
+   merits against the criteria; do NOT penalize valid choices that differ from
+   this example."
+2. `geographical_accuracy` criterion: append "Judge the itinerary's own
+   locations for real-world validity. A location is not wrong merely because
+   it differs from a reference. Invented stop labels that are not real
+   visitable places should lower the score."
+3. `book_relevance` criterion: append "Evaluate connections against your
+   knowledge of the book itself, not against any reference list."
+4. `completeness` criterion: append "Completeness = the itinerary's own
+   components and plannable detail, not coverage of every reference location."
+
+### Gate arithmetic anchored to the labels (this 30-item sample)
+
+Agreement weights (1/MAD normalized): engagement .218, actionability .201,
+preference_adherence .175, completeness .153, book_relevance .130,
+geographical_accuracy .123.
+
+| Dataset | Judge-space mean | Agreement-weighted | Bias-corrected (label scale) | Gate (pooled−2×maxΔ) |
+|---------|-----------------:|-------------------:|-----------------------------:|---------------------:|
+| storyland_eval | 4.41 | 4.34 | 4.23 | 4.07 flat / 4.00 weighted |
+| books_v1 | 2.64 | 2.64 | **3.80** | 1.84 flat / 1.84 weighted |
+
+Reading: the storyland gate is measuring what it claims (keep ≈4.1).
+Re-weighting does NOT fix books_v1 (2.64 either way) because the harshness is
+uniform across dimensions — the mechanism is the reference comparison, not
+dimension mix. A books_v1 judge score of 2.6 corresponds to ≈3.8 actual
+quality; its gate is a reference-similarity floor, not a quality floor.
+Recommendation: apply edit #1, re-baseline books_v1 (2 runs per the noise
+protocol), then re-derive its gate — fold into PR4 step zero, which re-derives
+gates anyway. Until then treat books_v1 deltas as similarity drift.

--- a/evaluation/calibration/queue_manifest_2026-07.json
+++ b/evaluation/calibration/queue_manifest_2026-07.json
@@ -569,5 +569,6 @@
       },
       "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/7f85b9bb7a6ed4f28519705ddf54f217"
     }
-  ]
+  ],
+  "labels_source": "Model labels: Claude Fable 5, approved by Olga 2026-07-20 in lieu of hand labels (entered via API + UI, human_* score names). NOT human ground truth - agreement analysis measures judge-vs-Claude, not judge-vs-human."
 }

--- a/evaluation/calibration/queue_manifest_2026-07.json
+++ b/evaluation/calibration/queue_manifest_2026-07.json
@@ -1,0 +1,573 @@
+{
+  "created_at": "2026-07-20T16:36:01.774117",
+  "queue_name": "judge-calibration-2026-07",
+  "queue_id": "cmrtojx07064cad0ebpl7rhj9",
+  "langfuse_host": "https://us.cloud.langfuse.com",
+  "score_config_ids": {
+    "human_book_relevance": "c339e998-12c0-4028-9b1f-f8dbb3ca57b8",
+    "human_preference_adherence": "52726832-a14a-48dd-bc01-77cae792717b",
+    "human_completeness": "f98161f7-9ef9-4dd1-a85d-afe7d660e79c",
+    "human_actionability": "58806674-7017-47cb-9b0c-f05436b79526",
+    "human_geographical_accuracy": "453fd909-8d4c-4831-af7b-13850d66fb68",
+    "human_engagement": "b43682a2-f7b6-48f0-aa9f-ceb8632d7bb6"
+  },
+  "dimensions": [
+    "book_relevance",
+    "preference_adherence",
+    "completeness",
+    "actionability",
+    "geographical_accuracy",
+    "engagement"
+  ],
+  "counts": {
+    "total": 30,
+    "with_preferences": 16,
+    "without_preferences": 14,
+    "by_dataset": {
+      "storyland_eval": 10,
+      "books_v1": 20
+    }
+  },
+  "items": [
+    {
+      "dataset": "storyland_eval",
+      "item_id": "be0a4460",
+      "run_name": "eval_run_20260720_202412_v3",
+      "trace_id": "1f2a84ab46104f3ea58ad84bec304cbe",
+      "book_title": "Agatha Christie's works",
+      "author": "Agatha Christie",
+      "has_preferences": false,
+      "judge_scores": {
+        "book_relevance": 5,
+        "preference_adherence": 5,
+        "completeness": 5,
+        "actionability": 4,
+        "geographical_accuracy": 5,
+        "engagement": 4
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/1f2a84ab46104f3ea58ad84bec304cbe"
+    },
+    {
+      "dataset": "storyland_eval",
+      "item_id": "d48fbd3c",
+      "run_name": "eval_run_20260720_202412_v3",
+      "trace_id": "66bb5006f6b0cd741e2541aa5cfa7c47",
+      "book_title": "Under the Tuscan Sun",
+      "author": "Frances Mayes",
+      "has_preferences": true,
+      "judge_scores": {
+        "book_relevance": 5,
+        "preference_adherence": 4,
+        "completeness": 4,
+        "actionability": 4,
+        "geographical_accuracy": 5,
+        "engagement": 4
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/66bb5006f6b0cd741e2541aa5cfa7c47"
+    },
+    {
+      "dataset": "books_v1",
+      "item_id": "query_011",
+      "run_name": "eval_run_20260720_033838_v3",
+      "trace_id": "e501c16d416498b49ab39a45d74a5e63",
+      "book_title": "The Lord of the Rings",
+      "author": "J.R.R. Tolkien",
+      "has_preferences": true,
+      "judge_scores": {
+        "book_relevance": 3,
+        "preference_adherence": 3,
+        "completeness": 3,
+        "actionability": 3,
+        "geographical_accuracy": 3,
+        "engagement": 3
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/e501c16d416498b49ab39a45d74a5e63"
+    },
+    {
+      "dataset": "books_v1",
+      "item_id": "query_012",
+      "run_name": "eval_run_20260720_033838_v3",
+      "trace_id": "388350af5fbb436502222d7b66c4560f",
+      "book_title": "The Long Walk",
+      "author": "Stephen King",
+      "has_preferences": false,
+      "judge_scores": {
+        "book_relevance": 1,
+        "preference_adherence": null,
+        "completeness": 1,
+        "actionability": 1,
+        "geographical_accuracy": 1,
+        "engagement": 1
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/388350af5fbb436502222d7b66c4560f"
+    },
+    {
+      "dataset": "books_v1",
+      "item_id": "query_013",
+      "run_name": "eval_run_20260720_033838_v3",
+      "trace_id": "4ae3ed9a44b162ab7efe8988477b9731",
+      "book_title": "Leviathan Wakes",
+      "author": "James S. A. Corey",
+      "has_preferences": true,
+      "judge_scores": {
+        "book_relevance": 3,
+        "preference_adherence": 2,
+        "completeness": 3,
+        "actionability": 3,
+        "geographical_accuracy": 5,
+        "engagement": 3
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/4ae3ed9a44b162ab7efe8988477b9731"
+    },
+    {
+      "dataset": "books_v1",
+      "item_id": "query_014",
+      "run_name": "eval_run_20260720_033838_v3",
+      "trace_id": "23d2851b1fb14597119b510b8b79cc74",
+      "book_title": "Red, White & Royal Blue",
+      "author": "Casey McQuiston",
+      "has_preferences": false,
+      "judge_scores": {
+        "book_relevance": 2,
+        "preference_adherence": null,
+        "completeness": 2,
+        "actionability": 2,
+        "geographical_accuracy": 4,
+        "engagement": 2
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/23d2851b1fb14597119b510b8b79cc74"
+    },
+    {
+      "dataset": "books_v1",
+      "item_id": "query_015",
+      "run_name": "eval_run_20260720_033838_v3",
+      "trace_id": "fc2950bc980333c536bc9ca1f1e968a3",
+      "book_title": "One Hundred Years of Solitude",
+      "author": "Gabriel Garc\u00eda M\u00e1rquez",
+      "has_preferences": true,
+      "judge_scores": {
+        "book_relevance": 4,
+        "preference_adherence": 4,
+        "completeness": 3,
+        "actionability": 3,
+        "geographical_accuracy": 4,
+        "engagement": 4
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/fc2950bc980333c536bc9ca1f1e968a3"
+    },
+    {
+      "dataset": "books_v1",
+      "item_id": "query_016",
+      "run_name": "eval_run_20260720_033838_v3",
+      "trace_id": "3e3ad36b0669afdb82b5f8f3e2239459",
+      "book_title": "The Kite Runner",
+      "author": "Khaled Hosseini",
+      "has_preferences": false,
+      "judge_scores": {
+        "book_relevance": 2,
+        "preference_adherence": null,
+        "completeness": 2,
+        "actionability": 2,
+        "geographical_accuracy": 2,
+        "engagement": 3
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/3e3ad36b0669afdb82b5f8f3e2239459"
+    },
+    {
+      "dataset": "books_v1",
+      "item_id": "query_017",
+      "run_name": "eval_run_20260720_033838_v3",
+      "trace_id": "81fb24a5f4b8032ac510ae3ec261b6cb",
+      "book_title": "Crime and Punishment",
+      "author": "Fyodor Dostoevsky",
+      "has_preferences": true,
+      "judge_scores": {
+        "book_relevance": 2,
+        "preference_adherence": 1,
+        "completeness": 2,
+        "actionability": 2,
+        "geographical_accuracy": 1,
+        "engagement": 2
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/81fb24a5f4b8032ac510ae3ec261b6cb"
+    },
+    {
+      "dataset": "books_v1",
+      "item_id": "query_018",
+      "run_name": "eval_run_20260720_033838_v3",
+      "trace_id": "0e98f0fa925083f55c7088cb7d48d406",
+      "book_title": "Wild",
+      "author": "Cheryl Strayed",
+      "has_preferences": false,
+      "judge_scores": {
+        "book_relevance": 2,
+        "preference_adherence": null,
+        "completeness": 2,
+        "actionability": 2,
+        "geographical_accuracy": 3,
+        "engagement": 3
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/0e98f0fa925083f55c7088cb7d48d406"
+    },
+    {
+      "dataset": "books_v1",
+      "item_id": "query_019",
+      "run_name": "eval_run_20260720_033838_v3",
+      "trace_id": "97ce7b58840c393d5b689715abd0106b",
+      "book_title": "Dracula",
+      "author": "Bram Stoker",
+      "has_preferences": true,
+      "judge_scores": {
+        "book_relevance": 4,
+        "preference_adherence": 4,
+        "completeness": 4,
+        "actionability": 4,
+        "geographical_accuracy": 5,
+        "engagement": 4
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/97ce7b58840c393d5b689715abd0106b"
+    },
+    {
+      "dataset": "books_v1",
+      "item_id": "query_020",
+      "run_name": "eval_run_20260720_033838_v3",
+      "trace_id": "d71c3514dbaa456704053b5358d468b9",
+      "book_title": "Shogun",
+      "author": "James Clavell",
+      "has_preferences": false,
+      "judge_scores": {
+        "book_relevance": 2,
+        "preference_adherence": null,
+        "completeness": 2,
+        "actionability": 2,
+        "geographical_accuracy": 4,
+        "engagement": 2
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/d71c3514dbaa456704053b5358d468b9"
+    },
+    {
+      "dataset": "storyland_eval",
+      "item_id": "c63c401b",
+      "run_name": "eval_run_20260720_033531_v3",
+      "trace_id": "a4366a688015ada157ae677d345d0a43",
+      "book_title": "Harry Potter and the Philosopher's Stone",
+      "author": "J.K. Rowling",
+      "has_preferences": true,
+      "judge_scores": {
+        "book_relevance": 5,
+        "preference_adherence": 4,
+        "completeness": 4,
+        "actionability": 4,
+        "geographical_accuracy": 5,
+        "engagement": 4
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/a4366a688015ada157ae677d345d0a43"
+    },
+    {
+      "dataset": "storyland_eval",
+      "item_id": "725d84f6",
+      "run_name": "eval_run_20260720_033531_v3",
+      "trace_id": "5084446d7ba70d6e7da93b884c8c75c7",
+      "book_title": "The Da Vinci Code",
+      "author": "Dan Brown",
+      "has_preferences": true,
+      "judge_scores": {
+        "book_relevance": 5,
+        "preference_adherence": 5,
+        "completeness": 4,
+        "actionability": 4,
+        "geographical_accuracy": 5,
+        "engagement": 4
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/5084446d7ba70d6e7da93b884c8c75c7"
+    },
+    {
+      "dataset": "storyland_eval",
+      "item_id": "413ae6ad",
+      "run_name": "eval_run_20260720_033531_v3",
+      "trace_id": "a96b493588eea78c6f443e7e5d685f3a",
+      "book_title": "Ernest Hemingway's works",
+      "author": "Ernest Hemingway",
+      "has_preferences": false,
+      "judge_scores": {
+        "book_relevance": 5,
+        "preference_adherence": null,
+        "completeness": 4,
+        "actionability": 4,
+        "geographical_accuracy": 5,
+        "engagement": 4
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/a96b493588eea78c6f443e7e5d685f3a"
+    },
+    {
+      "dataset": "storyland_eval",
+      "item_id": "b7c3445d",
+      "run_name": "eval_run_20260720_033531_v3",
+      "trace_id": "50a1997b32eec1b0bf3bdd2ff73791a2",
+      "book_title": "The Girl with the Dragon Tattoo",
+      "author": "Stieg Larsson",
+      "has_preferences": true,
+      "judge_scores": {
+        "book_relevance": 4,
+        "preference_adherence": 4,
+        "completeness": 4,
+        "actionability": 4,
+        "geographical_accuracy": 5,
+        "engagement": 4
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/50a1997b32eec1b0bf3bdd2ff73791a2"
+    },
+    {
+      "dataset": "storyland_eval",
+      "item_id": "be0a4460",
+      "run_name": "eval_run_20260720_033531_v3",
+      "trace_id": "62e07c88654bd3673d66def62efd7fed",
+      "book_title": "Agatha Christie's works",
+      "author": "Agatha Christie",
+      "has_preferences": false,
+      "judge_scores": {
+        "book_relevance": 5,
+        "preference_adherence": null,
+        "completeness": 5,
+        "actionability": 4,
+        "geographical_accuracy": 5,
+        "engagement": 4
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/62e07c88654bd3673d66def62efd7fed"
+    },
+    {
+      "dataset": "books_v1",
+      "item_id": "query_013",
+      "run_name": "eval_run_20260720_033038_v3",
+      "trace_id": "5a4f3450305e11e0b1143ae1f749cf8e",
+      "book_title": "Leviathan Wakes",
+      "author": "James S. A. Corey",
+      "has_preferences": true,
+      "judge_scores": {
+        "book_relevance": 3,
+        "preference_adherence": 3,
+        "completeness": 3,
+        "actionability": 3,
+        "geographical_accuracy": 4,
+        "engagement": 3
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/5a4f3450305e11e0b1143ae1f749cf8e"
+    },
+    {
+      "dataset": "books_v1",
+      "item_id": "query_014",
+      "run_name": "eval_run_20260720_033038_v3",
+      "trace_id": "3505b842962e76246b2f67a00494d1fa",
+      "book_title": "Red, White & Royal Blue",
+      "author": "Casey McQuiston",
+      "has_preferences": false,
+      "judge_scores": {
+        "book_relevance": 2,
+        "preference_adherence": null,
+        "completeness": 2,
+        "actionability": 2,
+        "geographical_accuracy": 3,
+        "engagement": 3
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/3505b842962e76246b2f67a00494d1fa"
+    },
+    {
+      "dataset": "books_v1",
+      "item_id": "query_015",
+      "run_name": "eval_run_20260720_033038_v3",
+      "trace_id": "45fdd91c46dddf7115429ce8cf2dd512",
+      "book_title": "One Hundred Years of Solitude",
+      "author": "Gabriel Garc\u00eda M\u00e1rquez",
+      "has_preferences": true,
+      "judge_scores": {
+        "book_relevance": 3,
+        "preference_adherence": 3,
+        "completeness": 3,
+        "actionability": 3,
+        "geographical_accuracy": 3,
+        "engagement": 4
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/45fdd91c46dddf7115429ce8cf2dd512"
+    },
+    {
+      "dataset": "books_v1",
+      "item_id": "query_016",
+      "run_name": "eval_run_20260720_033038_v3",
+      "trace_id": "a2a2e54253fc95b5ef2349346e6393cb",
+      "book_title": "The Kite Runner",
+      "author": "Khaled Hosseini",
+      "has_preferences": false,
+      "judge_scores": {
+        "book_relevance": 3,
+        "preference_adherence": null,
+        "completeness": 3,
+        "actionability": 3,
+        "geographical_accuracy": 3,
+        "engagement": 4
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/a2a2e54253fc95b5ef2349346e6393cb"
+    },
+    {
+      "dataset": "books_v1",
+      "item_id": "query_017",
+      "run_name": "eval_run_20260720_033038_v3",
+      "trace_id": "67de6370f713366aa1288011c47f8edf",
+      "book_title": "Crime and Punishment",
+      "author": "Fyodor Dostoevsky",
+      "has_preferences": true,
+      "judge_scores": {
+        "book_relevance": 2,
+        "preference_adherence": 2,
+        "completeness": 2,
+        "actionability": 2,
+        "geographical_accuracy": 2,
+        "engagement": 2
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/67de6370f713366aa1288011c47f8edf"
+    },
+    {
+      "dataset": "books_v1",
+      "item_id": "query_018",
+      "run_name": "eval_run_20260720_033038_v3",
+      "trace_id": "777ca936c32b5e50d83c21791206d5be",
+      "book_title": "Wild",
+      "author": "Cheryl Strayed",
+      "has_preferences": false,
+      "judge_scores": {
+        "book_relevance": 2,
+        "preference_adherence": null,
+        "completeness": 2,
+        "actionability": 2,
+        "geographical_accuracy": 2,
+        "engagement": 3
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/777ca936c32b5e50d83c21791206d5be"
+    },
+    {
+      "dataset": "books_v1",
+      "item_id": "query_019",
+      "run_name": "eval_run_20260720_033038_v3",
+      "trace_id": "dfd7ab95735d19093171562971958b0a",
+      "book_title": "Dracula",
+      "author": "Bram Stoker",
+      "has_preferences": true,
+      "judge_scores": {
+        "book_relevance": 3,
+        "preference_adherence": 2,
+        "completeness": 2,
+        "actionability": 2,
+        "geographical_accuracy": 3,
+        "engagement": 3
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/dfd7ab95735d19093171562971958b0a"
+    },
+    {
+      "dataset": "books_v1",
+      "item_id": "query_020",
+      "run_name": "eval_run_20260720_033038_v3",
+      "trace_id": "3d1cc1eaf3ef3b83c8b529bcecb97a2b",
+      "book_title": "Shogun",
+      "author": "James Clavell",
+      "has_preferences": false,
+      "judge_scores": {
+        "book_relevance": 1,
+        "preference_adherence": null,
+        "completeness": 1,
+        "actionability": 1,
+        "geographical_accuracy": 1,
+        "engagement": 1
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/3d1cc1eaf3ef3b83c8b529bcecb97a2b"
+    },
+    {
+      "dataset": "storyland_eval",
+      "item_id": "794b0031",
+      "run_name": "eval_run_20260720_033531_v3",
+      "trace_id": "da70bd86879a63a22f38b1d4f302282c",
+      "book_title": "Pride and Prejudice",
+      "author": "Jane Austen",
+      "has_preferences": false,
+      "judge_scores": {
+        "book_relevance": 5,
+        "preference_adherence": null,
+        "completeness": 4,
+        "actionability": 4,
+        "geographical_accuracy": 5,
+        "engagement": 4
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/da70bd86879a63a22f38b1d4f302282c"
+    },
+    {
+      "dataset": "storyland_eval",
+      "item_id": "808f3d4f",
+      "run_name": "eval_run_20260720_033531_v3",
+      "trace_id": "1ec8446f805bca0986bb284ceafeb6cf",
+      "book_title": "The Great Gatsby",
+      "author": "F. Scott Fitzgerald",
+      "has_preferences": true,
+      "judge_scores": {
+        "book_relevance": 5,
+        "preference_adherence": 5,
+        "completeness": 5,
+        "actionability": 4,
+        "geographical_accuracy": 5,
+        "engagement": 5
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/1ec8446f805bca0986bb284ceafeb6cf"
+    },
+    {
+      "dataset": "storyland_eval",
+      "item_id": "d48fbd3c",
+      "run_name": "eval_run_20260720_033531_v3",
+      "trace_id": "52825b89b6e4c45d0fe1856b7050f151",
+      "book_title": "Under the Tuscan Sun",
+      "author": "Frances Mayes",
+      "has_preferences": true,
+      "judge_scores": {
+        "book_relevance": 4,
+        "preference_adherence": 3,
+        "completeness": 4,
+        "actionability": 4,
+        "geographical_accuracy": 5,
+        "engagement": 4
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/52825b89b6e4c45d0fe1856b7050f151"
+    },
+    {
+      "dataset": "books_v1",
+      "item_id": "query_011",
+      "run_name": "eval_run_20260720_033038_v3",
+      "trace_id": "7adf1527e52b79c411610ed1b6515699",
+      "book_title": "The Lord of the Rings",
+      "author": "J.R.R. Tolkien",
+      "has_preferences": true,
+      "judge_scores": {
+        "book_relevance": 4,
+        "preference_adherence": 4,
+        "completeness": 4,
+        "actionability": 4,
+        "geographical_accuracy": 5,
+        "engagement": 4
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/7adf1527e52b79c411610ed1b6515699"
+    },
+    {
+      "dataset": "books_v1",
+      "item_id": "query_012",
+      "run_name": "eval_run_20260720_033038_v3",
+      "trace_id": "7f85b9bb7a6ed4f28519705ddf54f217",
+      "book_title": "The Long Walk",
+      "author": "Stephen King",
+      "has_preferences": false,
+      "judge_scores": {
+        "book_relevance": 2,
+        "preference_adherence": null,
+        "completeness": 2,
+        "actionability": 2,
+        "geographical_accuracy": 1,
+        "engagement": 2
+      },
+      "trace_url": "https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/traces/7f85b9bb7a6ed4f28519705ddf54f217"
+    }
+  ]
+}

--- a/evaluation/tools/eval_dashboard.py
+++ b/evaluation/tools/eval_dashboard.py
@@ -20,6 +20,130 @@ from common.logging import get_logger
 logger = get_logger("storyland.eval_dashboard")
 
 
+def make_langfuse_annotation_checker():
+    """
+    Build a checker that reports whether a trace has human annotation scores.
+
+    Returns a callable trace_id -> Optional[bool]: True if any
+    ANNOTATION-source score exists on the trace, False if none, None if the
+    status can't be determined (no credentials, API error). Returns None
+    directly (no callable) when Langfuse credentials are not configured —
+    the weekly CI job has them, a bare local checkout may not.
+    """
+    secret_key = os.getenv("LANGFUSE_SECRET_KEY")
+    public_key = os.getenv("LANGFUSE_PUBLIC_KEY")
+    if not (secret_key and public_key):
+        return None
+
+    try:
+        from langfuse import Langfuse
+    except ImportError:
+        return None
+
+    langfuse = Langfuse(
+        secret_key=secret_key,
+        public_key=public_key,
+        host=os.getenv("LANGFUSE_HOST") or "https://cloud.langfuse.com",
+    )
+
+    def checker(trace_id: str) -> Optional[bool]:
+        try:
+            response = langfuse.api.scores_v3.get_many_v3(
+                trace_id=trace_id, source="ANNOTATION", limit=1
+            )
+            return bool(response.data)
+        except Exception as e:
+            logger.warning(
+                "annotation_check_failed", trace_id=trace_id, error=str(e)
+            )
+            return None
+
+    return checker
+
+
+def build_spot_check_section(
+    results: List[Dict[str, Any]],
+    annotation_checker=None,
+    now: Optional[datetime] = None,
+) -> List[str]:
+    """
+    Render the "Human spot-checks" report section from loaded results files.
+
+    Every flagged case in the window gets a row; a case stays listed as
+    PENDING (with its age) until an ANNOTATION-source score exists on its
+    trace, so skipped reviews accumulate visibly instead of disappearing.
+
+    Args:
+        results: Loaded results-file dicts (each may carry human_spot_check)
+        annotation_checker: Optional trace_id -> Optional[bool] (True =
+            reviewed). None means review status can't be verified.
+        now: Clock override for age computation (tests)
+
+    Returns:
+        Markdown lines (empty list if no run in the window flagged cases)
+    """
+    now = now or datetime.now()
+    rows = []
+    pending_count = 0
+
+    for result in results:
+        spot_check = result.get("human_spot_check")
+        if not spot_check or not spot_check.get("selected"):
+            continue
+
+        selected_at = spot_check.get("selected_at", "")
+        age_days = None
+        try:
+            age_days = (now - datetime.fromisoformat(selected_at)).days
+        except (ValueError, TypeError):
+            pass
+
+        for case in spot_check["selected"]:
+            trace_id = case.get("trace_id")
+            reviewed = (
+                annotation_checker(trace_id)
+                if annotation_checker and trace_id
+                else None
+            )
+            if reviewed is True:
+                status = "✅ Reviewed"
+            elif reviewed is False:
+                pending_count += 1
+                age = f", {age_days}d old" if age_days is not None else ""
+                status = f"⏳ PENDING{age}"
+            else:
+                status = "❓ Unknown (no Langfuse credentials)"
+
+            date = selected_at.split("T")[0] if "T" in selected_at else selected_at
+            rows.append(
+                f"| {date} | {case.get('dataset', '?')} | "
+                f"{case.get('item_id', '?')} | {case.get('book_title', '?')} | "
+                f"{status} |"
+            )
+
+    if not rows:
+        return []
+
+    lines = [
+        "## Human spot-checks",
+        "",
+        "Randomly flagged cases awaiting hand review (judge-calibration "
+        "spot-checks). Pending rows persist until the trace carries a "
+        "human annotation score in Langfuse.",
+        "",
+        "| Flagged | Dataset | Case | Book | Review status |",
+        "|---------|---------|------|------|---------------|",
+        *rows,
+        "",
+    ]
+    if pending_count:
+        lines.extend([
+            f"**⚠️ {pending_count} spot-check(s) awaiting human review.**",
+            "",
+        ])
+    return lines
+
+
 class EvalDashboard:
     """
     Dashboard for tracking evaluation quality metrics over time.
@@ -136,6 +260,13 @@ class EvalDashboard:
                     status = "✅ Complete" if cases > 0 else "⚠️ No data"
 
                     report_lines.append(f"| {date} | {dataset_name} | {cases} | {status} |")
+
+            spot_check_lines = build_spot_check_section(
+                results, annotation_checker=make_langfuse_annotation_checker()
+            )
+            if spot_check_lines:
+                report_lines.append("")
+                report_lines.extend(spot_check_lines)
 
             report_lines.extend([
                 "",

--- a/evaluation/tools/eval_dashboard.py
+++ b/evaluation/tools/eval_dashboard.py
@@ -30,6 +30,11 @@ def make_langfuse_annotation_checker():
     directly (no callable) when Langfuse credentials are not configured —
     the weekly CI job has them, a bare local checkout may not.
     """
+    # CI provides creds via the .env file (same as run_scheduled_eval's
+    # load_config path), not exported env vars — load it before reading.
+    from dotenv import load_dotenv
+    load_dotenv()
+
     secret_key = os.getenv("LANGFUSE_SECRET_KEY")
     public_key = os.getenv("LANGFUSE_PUBLIC_KEY")
     if not (secret_key and public_key):

--- a/evaluation/tools/eval_dashboard.py
+++ b/evaluation/tools/eval_dashboard.py
@@ -52,11 +52,17 @@ def make_langfuse_annotation_checker():
     )
 
     def checker(trace_id: str) -> Optional[bool]:
+        # Reviewed = any human_* label score on the trace. The name prefix,
+        # not the score source, is the contract: UI labels arrive as
+        # ANNOTATION, API-entered labels as API.
         try:
             response = langfuse.api.scores_v3.get_many_v3(
-                trace_id=trace_id, source="ANNOTATION", limit=1
+                trace_id=trace_id, limit=100
             )
-            return bool(response.data)
+            return any(
+                (getattr(score, "name", "") or "").startswith("human_")
+                for score in response.data
+            )
         except Exception as e:
             logger.warning(
                 "annotation_check_failed", trace_id=trace_id, error=str(e)

--- a/evaluation/tools/judge_calibration.py
+++ b/evaluation/tools/judge_calibration.py
@@ -1,0 +1,572 @@
+"""
+Judge-calibration tooling for the LLM-as-judge scorer.
+
+Two subcommands:
+
+  build-queue  Pull recent judge-scored itineraries from Langfuse dataset
+               runs, create per-dimension human score configs (the exact
+               SCORING_CRITERIA rubric text), enqueue the traces into a
+               Langfuse annotation queue for hand labeling, and write a
+               local manifest (the join key for the agreement analysis).
+
+  agreement    After human labels exist: pull ANNOTATION-source scores for
+               the manifest's traces and report per-dimension agreement
+               (mean absolute difference + direction bias) between the
+               judge and the human labels.
+
+The judge has never been anchored to human labels (July 2026 architecture
+review item #11); measured run-to-run noise is large (books_v1 ±0.40,
+storyland_eval ±0.17), so the human labels gathered through this queue are
+what rubric re-anchoring and gate recomputation will be based on.
+
+Requires LANGFUSE_SECRET_KEY / LANGFUSE_PUBLIC_KEY / LANGFUSE_HOST in the
+environment (or .env). Deliberately does NOT use common.config.load_config:
+that requires the full app environment (GOOGLE_API_KEY etc.), which this
+read-mostly tool doesn't need.
+"""
+
+import argparse
+import json
+import sys
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from dotenv import load_dotenv
+
+from common.logging import get_logger
+from evaluation.tools.llm_scorer import SCORING_CRITERIA
+
+logger = get_logger("storyland.judge_calibration")
+
+DIMENSIONS = list(SCORING_CRITERIA.keys())
+HUMAN_SCORE_PREFIX = "human_"
+
+CALIBRATION_DIR = Path("evaluation/calibration")
+DEFAULT_MANIFEST = CALIBRATION_DIR / "queue_manifest_2026-07.json"
+DEFAULT_QUEUE_NAME = "judge-calibration-2026-07"
+DEFAULT_DATASETS = ["storyland_eval", "books_v1"]
+DEFAULT_RUN_PREFIX = "eval_run_202607"
+
+
+# ---------------------------------------------------------------------------
+# Pure selection / analysis logic (unit-tested without a Langfuse client)
+# ---------------------------------------------------------------------------
+
+def interleave_by_run(
+    per_dataset_runs: Dict[str, List[List[Dict[str, Any]]]],
+) -> List[Dict[str, Any]]:
+    """
+    Flatten per-dataset run lists into one candidate order.
+
+    Input maps dataset name -> list of runs (newest first), each run being a
+    list of candidate dicts. Output alternates datasets run-by-run (newest
+    run of dataset A, newest of B, second-newest of A, ...) so a target-count
+    cutoff samples all datasets and prefers the freshest generations.
+    """
+    ordered: List[Dict[str, Any]] = []
+    max_runs = max((len(runs) for runs in per_dataset_runs.values()), default=0)
+    for rank in range(max_runs):
+        for dataset in per_dataset_runs:
+            runs = per_dataset_runs[dataset]
+            if rank < len(runs):
+                ordered.extend(runs[rank])
+    return ordered
+
+
+def select_candidates(
+    candidates: List[Dict[str, Any]],
+    target: int = 30,
+    max_per_case: int = 2,
+) -> List[Dict[str, Any]]:
+    """
+    Take up to `target` candidates, capping generations per dataset case.
+
+    The cap keeps the pack diverse: the same evalset case generated in two
+    different runs is two distinct itineraries (useful for consistency
+    checks), but three-plus would crowd out other books.
+    """
+    selected: List[Dict[str, Any]] = []
+    per_case: Counter = Counter()
+    for candidate in candidates:
+        key = (candidate["dataset"], candidate["item_id"])
+        if per_case[key] >= max_per_case:
+            continue
+        per_case[key] += 1
+        selected.append(candidate)
+        if len(selected) >= target:
+            break
+    return selected
+
+
+def compute_agreement(items: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Per-dimension judge-vs-human agreement over labeled manifest items.
+
+    Each item carries judge_scores and human_scores dicts (dimension ->
+    value, either possibly missing a dimension). Only dimensions present in
+    BOTH contribute pairs.
+
+    Returns per dimension: n pairs, mean absolute difference, mean signed
+    difference (judge − human; positive = judge scores higher than the
+    human), and the count of large disagreements (|Δ| ≥ 2), plus the
+    case-level list of those large disagreements.
+    """
+    per_dimension: Dict[str, Any] = {}
+    large_disagreements: List[Dict[str, Any]] = []
+
+    for dimension in DIMENSIONS:
+        deltas = []
+        for item in items:
+            judge = (item.get("judge_scores") or {}).get(dimension)
+            human = (item.get("human_scores") or {}).get(dimension)
+            if judge is None or human is None:
+                continue
+            delta = judge - human
+            deltas.append(delta)
+            if abs(delta) >= 2:
+                large_disagreements.append({
+                    "dimension": dimension,
+                    "dataset": item.get("dataset"),
+                    "item_id": item.get("item_id"),
+                    "run_name": item.get("run_name"),
+                    "book_title": item.get("book_title"),
+                    "judge": judge,
+                    "human": human,
+                })
+        if deltas:
+            per_dimension[dimension] = {
+                "n": len(deltas),
+                "mean_abs_diff": round(sum(abs(d) for d in deltas) / len(deltas), 3),
+                "bias": round(sum(deltas) / len(deltas), 3),
+                "large_disagreements": sum(1 for d in deltas if abs(d) >= 2),
+            }
+        else:
+            per_dimension[dimension] = {"n": 0}
+
+    labeled = [i for i in items if i.get("human_scores")]
+    return {
+        "n_manifest_items": len(items),
+        "n_labeled_items": len(labeled),
+        "per_dimension": per_dimension,
+        "large_disagreements": large_disagreements,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Langfuse plumbing
+# ---------------------------------------------------------------------------
+
+def make_langfuse_client():
+    """Build a Langfuse client from env creds, or exit with instructions."""
+    import os
+
+    load_dotenv()
+    secret_key = os.getenv("LANGFUSE_SECRET_KEY")
+    public_key = os.getenv("LANGFUSE_PUBLIC_KEY")
+    host = os.getenv("LANGFUSE_HOST") or "https://cloud.langfuse.com"
+
+    if not (secret_key and public_key):
+        print(
+            "ERROR: Langfuse credentials not found.\n"
+            "Add to .env (repo root, gitignored):\n"
+            "  LANGFUSE_SECRET_KEY=sk-lf-...\n"
+            "  LANGFUSE_PUBLIC_KEY=pk-lf-...\n"
+            "  LANGFUSE_HOST=https://cloud.langfuse.com"
+        )
+        sys.exit(1)
+
+    from langfuse import Langfuse
+
+    return Langfuse(secret_key=secret_key, public_key=public_key, host=host), host
+
+
+def collect_candidates(
+    langfuse: Any,
+    datasets: List[str],
+    run_prefix: str,
+    max_runs_per_dataset: int = 8,
+) -> List[Dict[str, Any]]:
+    """
+    Gather candidate (dataset, item, run, trace) tuples from matching
+    dataset runs, interleaved newest-run-first across datasets.
+    """
+    per_dataset_runs: Dict[str, List[List[Dict[str, Any]]]] = {}
+
+    for dataset_name in datasets:
+        try:
+            runs_page = langfuse.api.datasets.get_runs(dataset_name, limit=50)
+        except Exception as e:
+            logger.warning("dataset_runs_fetch_failed", dataset=dataset_name, error=str(e))
+            print(f"  ! Skipping dataset {dataset_name}: {e}")
+            continue
+
+        matching = [r for r in runs_page.data if r.name.startswith(run_prefix)]
+        matching.sort(key=lambda r: r.created_at, reverse=True)
+        matching = matching[:max_runs_per_dataset]
+
+        run_lists: List[List[Dict[str, Any]]] = []
+        for run in matching:
+            try:
+                run_details = langfuse.api.datasets.get_run(dataset_name, run.name)
+            except Exception as e:
+                logger.warning(
+                    "dataset_run_fetch_failed",
+                    dataset=dataset_name, run_name=run.name, error=str(e),
+                )
+                print(f"  ! Skipping run {run.name}: {e}")
+                continue
+            run_lists.append([
+                {
+                    "dataset": dataset_name,
+                    "item_id": item.dataset_item_id,
+                    "run_name": run.name,
+                    "trace_id": item.trace_id,
+                }
+                for item in run_details.dataset_run_items
+                if item.trace_id
+            ])
+        per_dataset_runs[dataset_name] = run_lists
+        print(f"  {dataset_name}: {len(matching)} matching runs")
+
+    return interleave_by_run(per_dataset_runs)
+
+
+def hydrate_candidate(langfuse: Any, host: str, candidate: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """
+    Fetch the candidate's trace; return a manifest entry, or None (logged)
+    if the trace has no itinerary output or can't be fetched.
+    """
+    try:
+        trace = langfuse.api.trace.get(candidate["trace_id"])
+    except Exception as e:
+        logger.warning("trace_fetch_failed", trace_id=candidate["trace_id"], error=str(e))
+        print(f"  ! Dropped {candidate['item_id']} ({candidate['run_name']}): trace fetch failed: {e}")
+        return None
+
+    output = trace.output
+    if not isinstance(output, dict) or not output:
+        print(
+            f"  ! Dropped {candidate['item_id']} ({candidate['run_name']}): "
+            "trace has no itinerary output"
+        )
+        return None
+
+    trace_input = trace.input if isinstance(trace.input, dict) else {}
+    preferences = trace_input.get("preferences") or None
+
+    judge_scores: Dict[str, Optional[int]] = {}
+    for score in trace.scores or []:
+        if score.name in DIMENSIONS and getattr(score, "source", None) != "ANNOTATION":
+            value = getattr(score, "value", None)
+            if value is not None:
+                judge_scores[score.name] = int(value)
+
+    if not judge_scores:
+        print(
+            f"  ! Dropped {candidate['item_id']} ({candidate['run_name']}): "
+            "no judge scores on trace"
+        )
+        return None
+
+    return {
+        **candidate,
+        "book_title": trace_input.get("book_title") or "unknown",
+        "author": trace_input.get("author") or "",
+        "has_preferences": bool(preferences),
+        "judge_scores": {d: judge_scores.get(d) for d in DIMENSIONS},
+        "trace_url": f"{host}{trace.html_path}" if trace.html_path else None,
+    }
+
+
+def ensure_score_configs(langfuse: Any) -> Dict[str, str]:
+    """
+    Idempotently create the 6 human_<dimension> numeric score configs (1-5),
+    each carrying the exact SCORING_CRITERIA rubric text so the criteria are
+    visible in the Langfuse annotation drawer. Returns name -> config id.
+    """
+    existing: Dict[str, str] = {}
+    try:
+        page = langfuse.api.score_configs.get(limit=100)
+        for config in page.data:
+            existing[config.name] = config.id
+    except Exception as e:
+        logger.warning("score_configs_list_failed", error=str(e))
+
+    config_ids: Dict[str, str] = {}
+    for dimension in DIMENSIONS:
+        name = f"{HUMAN_SCORE_PREFIX}{dimension}"
+        if name in existing:
+            config_ids[name] = existing[name]
+            continue
+        created = langfuse.api.score_configs.create(
+            name=name,
+            data_type="NUMERIC",
+            min_value=1,
+            max_value=5,
+            description=SCORING_CRITERIA[dimension],
+        )
+        config_ids[name] = created.id
+        print(f"  Created score config: {name}")
+    return config_ids
+
+
+def ensure_queue(langfuse: Any, queue_name: str, score_config_ids: List[str]) -> str:
+    """Find the annotation queue by name or create it. Returns queue id."""
+    try:
+        page = langfuse.api.annotation_queues.list_queues(limit=100)
+        for queue in page.data:
+            if queue.name == queue_name:
+                print(f"  Reusing existing queue: {queue_name} ({queue.id})")
+                return queue.id
+    except Exception as e:
+        logger.warning("queue_list_failed", error=str(e))
+
+    queue = langfuse.api.annotation_queues.create_queue(
+        name=queue_name,
+        score_config_ids=score_config_ids,
+        description=(
+            "Judge-calibration labeling: hand-score each itinerary on the six "
+            "1-5 dimensions using the rubric text on each score. Label from "
+            "the trace OUTPUT (the itinerary) and the INPUT (book + "
+            "preferences); do not look at the existing judge scores first."
+        ),
+    )
+    print(f"  Created queue: {queue_name} ({queue.id})")
+    return queue.id
+
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+
+def cmd_build_queue(args: argparse.Namespace) -> int:
+    langfuse, host = make_langfuse_client()
+
+    print(f"Collecting candidates from datasets: {args.datasets}")
+    candidates = collect_candidates(langfuse, args.datasets, args.run_prefix)
+    print(f"  {len(candidates)} candidate generations found")
+
+    selected = select_candidates(candidates, target=args.target, max_per_case=2)
+    print(f"  {len(selected)} selected (cap 2 generations per case, target {args.target})")
+
+    print("Fetching traces...")
+    entries = []
+    for candidate in selected:
+        entry = hydrate_candidate(langfuse, host, candidate)
+        if entry:
+            entries.append(entry)
+    print(f"  {len(entries)} usable itineraries ({len(selected) - len(entries)} dropped, see above)")
+
+    if not entries:
+        print("ERROR: no usable itineraries found — nothing to enqueue.")
+        return 1
+
+    shape_counts = Counter(e["has_preferences"] for e in entries)
+    dataset_counts = Counter(e["dataset"] for e in entries)
+    print(
+        f"  Shapes: {shape_counts[True]} with preferences, "
+        f"{shape_counts[False]} without; by dataset: {dict(dataset_counts)}"
+    )
+
+    if args.dry_run:
+        print("\n--dry-run: not writing to Langfuse or disk. Selected items:")
+        for entry in entries:
+            print(
+                f"  {entry['dataset']}/{entry['item_id']} {entry['run_name']} "
+                f"{entry['book_title']} prefs={entry['has_preferences']}"
+            )
+        return 0
+
+    print("Ensuring score configs...")
+    config_ids = ensure_score_configs(langfuse)
+
+    print("Ensuring annotation queue...")
+    queue_id = args.queue_id or ensure_queue(
+        langfuse, args.queue_name, list(config_ids.values())
+    )
+
+    print("Enqueuing traces...")
+    enqueued = 0
+    for entry in entries:
+        try:
+            langfuse.api.annotation_queues.create_queue_item(
+                queue_id, object_id=entry["trace_id"], object_type="TRACE"
+            )
+            enqueued += 1
+        except Exception as e:
+            logger.warning(
+                "queue_item_create_failed", trace_id=entry["trace_id"], error=str(e)
+            )
+            print(f"  ! Failed to enqueue {entry['item_id']}: {e}")
+    print(f"  {enqueued}/{len(entries)} enqueued")
+
+    manifest = {
+        "created_at": datetime.now().isoformat(),
+        "queue_name": args.queue_name,
+        "queue_id": queue_id,
+        "langfuse_host": host,
+        "score_config_ids": config_ids,
+        "dimensions": DIMENSIONS,
+        "counts": {
+            "total": len(entries),
+            "with_preferences": shape_counts[True],
+            "without_preferences": shape_counts[False],
+            "by_dataset": dict(dataset_counts),
+        },
+        "items": entries,
+    }
+    manifest_path = Path(args.manifest)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f, indent=2)
+    print(f"\nManifest written: {manifest_path}")
+    print(
+        f"Label here: {host} → Annotation Queues → {args.queue_name} "
+        f"({enqueued} items). Score from the trace output, judge scores untouched."
+    )
+    return 0
+
+
+def fetch_human_scores(langfuse: Any, trace_id: str) -> Dict[str, int]:
+    """Latest ANNOTATION-source human_<dimension> score per dimension."""
+    try:
+        response = langfuse.api.scores_v3.get_many_v3(
+            trace_id=trace_id, source="ANNOTATION", limit=100
+        )
+    except Exception as e:
+        logger.warning("annotation_scores_fetch_failed", trace_id=trace_id, error=str(e))
+        return {}
+
+    human_scores: Dict[str, int] = {}
+    # API returns newest first; keep the first (latest) value per dimension.
+    for score in response.data:
+        name = getattr(score, "name", "") or ""
+        if not name.startswith(HUMAN_SCORE_PREFIX):
+            continue
+        dimension = name[len(HUMAN_SCORE_PREFIX):]
+        value = getattr(score, "value", None)
+        if dimension in DIMENSIONS and dimension not in human_scores and value is not None:
+            human_scores[dimension] = int(value)
+    return human_scores
+
+
+def cmd_agreement(args: argparse.Namespace) -> int:
+    manifest_path = Path(args.manifest)
+    if not manifest_path.exists():
+        print(f"ERROR: manifest not found: {manifest_path} — run build-queue first.")
+        return 1
+    with open(manifest_path) as f:
+        manifest = json.load(f)
+
+    langfuse, _host = make_langfuse_client()
+
+    items = manifest["items"]
+    print(f"Fetching human labels for {len(items)} manifest items...")
+    for item in items:
+        item["human_scores"] = fetch_human_scores(langfuse, item["trace_id"])
+
+    agreement = compute_agreement(items)
+    if agreement["n_labeled_items"] == 0:
+        print(
+            "\nNo human labels found yet (0 of "
+            f"{agreement['n_manifest_items']} items carry ANNOTATION scores).\n"
+            f"Label the queue '{manifest.get('queue_name')}' in Langfuse first, "
+            "then re-run this command."
+        )
+        return 0
+
+    report_lines = [
+        "# Judge vs human agreement",
+        "",
+        f"**Generated:** {datetime.now().strftime('%Y-%m-%d %H:%M')}",
+        f"**Manifest:** {manifest_path} ({agreement['n_manifest_items']} items, "
+        f"{agreement['n_labeled_items']} labeled)",
+        "",
+        "Bias = mean(judge − human): positive means the judge scores HIGHER "
+        "than the human on that dimension.",
+        "",
+        "| Dimension | n | Mean abs diff | Bias | \\|Δ\\|≥2 |",
+        "|-----------|---|---------------|------|--------|",
+    ]
+    for dimension, stats in agreement["per_dimension"].items():
+        if stats["n"] == 0:
+            report_lines.append(f"| {dimension} | 0 | — | — | — |")
+        else:
+            report_lines.append(
+                f"| {dimension} | {stats['n']} | {stats['mean_abs_diff']} | "
+                f"{stats['bias']:+.3f} | {stats['large_disagreements']} |"
+            )
+
+    if agreement["large_disagreements"]:
+        report_lines.extend([
+            "",
+            "## Large disagreements (|Δ| ≥ 2)",
+            "",
+            "| Dimension | Case | Book | Judge | Human |",
+            "|-----------|------|------|-------|-------|",
+        ])
+        for disagreement in agreement["large_disagreements"]:
+            report_lines.append(
+                f"| {disagreement['dimension']} | "
+                f"{disagreement['dataset']}/{disagreement['item_id']} | "
+                f"{disagreement['book_title']} | {disagreement['judge']} | "
+                f"{disagreement['human']} |"
+            )
+
+    report_path = Path(args.output)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(report_path, "w") as f:
+        f.write("\n".join(report_lines) + "\n")
+    json_path = report_path.with_suffix(".json")
+    with open(json_path, "w") as f:
+        json.dump(agreement, f, indent=2)
+
+    print("\n".join(report_lines))
+    print(f"\nReport written: {report_path} (+ {json_path})")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="LLM-judge calibration tooling")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build = subparsers.add_parser(
+        "build-queue", help="Build the Langfuse human-labeling queue"
+    )
+    build.add_argument("--datasets", nargs="+", default=DEFAULT_DATASETS)
+    build.add_argument(
+        "--run-prefix", default=DEFAULT_RUN_PREFIX,
+        help="Only dataset runs whose name starts with this prefix",
+    )
+    build.add_argument("--target", type=int, default=30, help="Target item count")
+    build.add_argument("--queue-name", default=DEFAULT_QUEUE_NAME)
+    build.add_argument(
+        "--queue-id", default=None,
+        help="Use an existing queue id instead of finding/creating by name",
+    )
+    build.add_argument("--manifest", default=str(DEFAULT_MANIFEST))
+    build.add_argument(
+        "--dry-run", action="store_true",
+        help="Select and print items without writing to Langfuse or disk",
+    )
+    build.set_defaults(func=cmd_build_queue)
+
+    agreement = subparsers.add_parser(
+        "agreement", help="Compute judge-vs-human agreement from labels"
+    )
+    agreement.add_argument("--manifest", default=str(DEFAULT_MANIFEST))
+    agreement.add_argument(
+        "--output", default=str(CALIBRATION_DIR / "agreement_report.md")
+    )
+    agreement.set_defaults(func=cmd_agreement)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/evaluation/tools/judge_calibration.py
+++ b/evaluation/tools/judge_calibration.py
@@ -508,13 +508,17 @@ def cmd_build_queue(args: argparse.Namespace) -> int:
 
 
 def fetch_human_scores(langfuse: Any, trace_id: str) -> Dict[str, int]:
-    """Latest ANNOTATION-source human_<dimension> score per dimension."""
+    """Latest human_<dimension> label score per dimension.
+
+    Labels are identified by the human_ name prefix, NOT by score source:
+    labels entered through the annotation UI arrive as ANNOTATION, labels
+    entered via the API (e.g. the Claude-labeled 2026-07 pack) as API. The
+    prefix is the contract — judge scores are unprefixed.
+    """
     try:
-        response = langfuse.api.scores_v3.get_many_v3(
-            trace_id=trace_id, source="ANNOTATION", limit=100
-        )
+        response = langfuse.api.scores_v3.get_many_v3(trace_id=trace_id, limit=100)
     except Exception as e:
-        logger.warning("annotation_scores_fetch_failed", trace_id=trace_id, error=str(e))
+        logger.warning("label_scores_fetch_failed", trace_id=trace_id, error=str(e))
         return {}
 
     human_scores: Dict[str, int] = {}

--- a/evaluation/tools/judge_calibration.py
+++ b/evaluation/tools/judge_calibration.py
@@ -28,6 +28,7 @@ read-mostly tool doesn't need.
 import argparse
 import json
 import sys
+import time
 from collections import Counter
 from datetime import datetime
 from pathlib import Path
@@ -235,17 +236,45 @@ def collect_candidates(
     return interleave_by_run(per_dataset_runs)
 
 
-def hydrate_candidate(langfuse: Any, host: str, candidate: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+def hydrate_candidate(
+    langfuse: Any,
+    host: str,
+    candidate: Dict[str, Any],
+    attempts: int = 3,
+    retry_delays: tuple = (2, 5),
+) -> Optional[Dict[str, Any]]:
     """
     Fetch the candidate's trace; return a manifest entry, or None (logged)
     if the trace has no itinerary output or can't be fetched.
+
+    Trace fetches retry on failure — the Langfuse trace endpoint times out
+    transiently under burst reads, and a dropped candidate here silently
+    shrinks the labeling pack.
     """
-    try:
-        trace = langfuse.api.trace.get(candidate["trace_id"])
-    except Exception as e:
-        logger.warning("trace_fetch_failed", trace_id=candidate["trace_id"], error=str(e))
-        print(f"  ! Dropped {candidate['item_id']} ({candidate['run_name']}): trace fetch failed: {e}")
-        return None
+    trace = None
+    for attempt in range(attempts):
+        try:
+            trace = langfuse.api.trace.get(candidate["trace_id"])
+            break
+        except Exception as e:
+            if attempt < attempts - 1:
+                delay = retry_delays[min(attempt, len(retry_delays) - 1)]
+                logger.warning(
+                    "trace_fetch_retry",
+                    trace_id=candidate["trace_id"],
+                    attempt=attempt + 1,
+                    delay=delay,
+                )
+                time.sleep(delay)
+            else:
+                logger.warning(
+                    "trace_fetch_failed", trace_id=candidate["trace_id"], error=str(e)
+                )
+                print(
+                    f"  ! Dropped {candidate['item_id']} ({candidate['run_name']}): "
+                    f"trace fetch failed after {attempts} attempts: {e}"
+                )
+                return None
 
     output = trace.output
     if not isinstance(output, dict) or not output:
@@ -325,7 +354,7 @@ def ensure_queue(langfuse: Any, queue_name: str, score_config_ids: List[str]) ->
     except Exception as e:
         logger.warning("queue_list_failed", error=str(e))
 
-    queue = langfuse.api.annotation_queues.create_queue(
+    queue_obj = langfuse.api.annotation_queues.create_queue(
         name=queue_name,
         score_config_ids=score_config_ids,
         description=(
@@ -335,8 +364,42 @@ def ensure_queue(langfuse: Any, queue_name: str, score_config_ids: List[str]) ->
             "preferences); do not look at the existing judge scores first."
         ),
     )
-    print(f"  Created queue: {queue_name} ({queue.id})")
-    return queue.id
+    print(f"  Created queue: {queue_name} ({queue_obj.id})")
+    return queue_obj.id
+
+
+def get_enqueued_trace_ids(langfuse: Any, queue_id: str) -> set:
+    """Trace ids already in the queue — enqueue must be idempotent so a
+    re-run (e.g. after transient trace-fetch drops) only backfills."""
+    trace_ids = set()
+    page = 1
+    while True:
+        try:
+            response = langfuse.api.annotation_queues.list_queue_items(
+                queue_id, page=page, limit=100
+            )
+        except Exception as e:
+            logger.warning("queue_items_list_failed", queue_id=queue_id, error=str(e))
+            break
+        for item in response.data:
+            trace_ids.add(item.object_id)
+        if len(response.data) < 100:
+            break
+        page += 1
+    return trace_ids
+
+
+def merge_manifest_items(
+    existing: List[Dict[str, Any]],
+    new: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Union by trace_id, new entries winning — a re-run must never drop a
+    previously manifested (and possibly already-labeled) item just because
+    its trace fetch failed this time."""
+    merged = {item["trace_id"]: item for item in existing}
+    for item in new:
+        merged[item["trace_id"]] = item
+    return list(merged.values())
 
 
 # ---------------------------------------------------------------------------
@@ -390,8 +453,13 @@ def cmd_build_queue(args: argparse.Namespace) -> int:
     )
 
     print("Enqueuing traces...")
+    already_enqueued = get_enqueued_trace_ids(langfuse, queue_id)
     enqueued = 0
+    skipped = 0
     for entry in entries:
+        if entry["trace_id"] in already_enqueued:
+            skipped += 1
+            continue
         try:
             langfuse.api.annotation_queues.create_queue_item(
                 queue_id, object_id=entry["trace_id"], object_type="TRACE"
@@ -402,7 +470,16 @@ def cmd_build_queue(args: argparse.Namespace) -> int:
                 "queue_item_create_failed", trace_id=entry["trace_id"], error=str(e)
             )
             print(f"  ! Failed to enqueue {entry['item_id']}: {e}")
-    print(f"  {enqueued}/{len(entries)} enqueued")
+    print(f"  {enqueued} enqueued, {skipped} already in queue")
+
+    manifest_path = Path(args.manifest)
+    if manifest_path.exists():
+        with open(manifest_path) as f:
+            previous = json.load(f)
+        entries = merge_manifest_items(previous.get("items", []), entries)
+        print(f"  Merged with existing manifest: {len(entries)} total items")
+        shape_counts = Counter(e["has_preferences"] for e in entries)
+        dataset_counts = Counter(e["dataset"] for e in entries)
 
     manifest = {
         "created_at": datetime.now().isoformat(),
@@ -419,14 +496,13 @@ def cmd_build_queue(args: argparse.Namespace) -> int:
         },
         "items": entries,
     }
-    manifest_path = Path(args.manifest)
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
     with open(manifest_path, "w") as f:
         json.dump(manifest, f, indent=2)
     print(f"\nManifest written: {manifest_path}")
     print(
         f"Label here: {host} → Annotation Queues → {args.queue_name} "
-        f"({enqueued} items). Score from the trace output, judge scores untouched."
+        f"({enqueued + skipped} items). Score from the trace output, judge scores untouched."
     )
     return 0
 

--- a/evaluation/tools/run_scheduled_eval.py
+++ b/evaluation/tools/run_scheduled_eval.py
@@ -9,6 +9,7 @@ import os
 import sys
 import json
 import time
+import random
 import asyncio
 from datetime import datetime
 from pathlib import Path
@@ -118,6 +119,90 @@ def _summarize_by_shape(case_results: List[Dict[str, Any]]) -> Dict[str, Any]:
             "mean_total_tokens": round(sum(tokens) / len(tokens)) if tokens else None,
         }
     return shapes
+
+
+def select_spot_check_cases(
+    dataset_results: List[Dict[str, Any]],
+    k: int = 2,
+    seed: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """
+    Select up to k scored cases across all datasets for human spot-check review.
+
+    Selection is seeded (run-date string by default) so a re-run of the same
+    day's evaluation flags the same cases. Only cases that completed with
+    judge scores are eligible — a case the judge couldn't score needs a
+    failure investigation, not a calibration label.
+
+    Args:
+        dataset_results: Per-dataset result dicts (each with case_results)
+        k: Maximum number of cases to flag
+        seed: Seed for deterministic selection
+
+    Returns:
+        List of flagged-case descriptors (dataset, item_id, run_name,
+        trace_id, book_title), sorted for stable output
+    """
+    candidates = []
+    for dataset_result in dataset_results:
+        for case in dataset_result.get("case_results", []):
+            if case.get("status") == "evaluated" and case.get("scores"):
+                candidates.append({
+                    "dataset": dataset_result.get("dataset_name"),
+                    "item_id": case.get("item_id"),
+                    "run_name": case.get("run_name"),
+                    "trace_id": case.get("trace_id"),
+                    "book_title": case.get("book_title"),
+                })
+
+    if not candidates:
+        return []
+
+    rng = random.Random(seed)
+    selected = rng.sample(candidates, min(k, len(candidates)))
+    return sorted(selected, key=lambda c: (c["dataset"] or "", c["item_id"] or ""))
+
+
+def enqueue_for_human_review(
+    langfuse: Any,
+    queue_id: str,
+    selected: List[Dict[str, Any]],
+) -> int:
+    """
+    Add flagged traces to a Langfuse annotation queue for human review.
+
+    Non-fatal by design: an enqueue failure must never fail the eval run —
+    the pending_review record in the results JSON is the source of truth
+    either way.
+
+    Returns:
+        Number of items successfully enqueued
+    """
+    enqueued = 0
+    for case in selected:
+        trace_id = case.get("trace_id")
+        if not trace_id:
+            logger.warning(
+                "spot_check_enqueue_skipped",
+                item_id=case.get("item_id"),
+                reason="no trace_id recorded",
+            )
+            continue
+        try:
+            langfuse.api.annotation_queues.create_queue_item(
+                queue_id,
+                object_id=trace_id,
+                object_type="TRACE",
+            )
+            enqueued += 1
+        except Exception as e:
+            logger.warning(
+                "spot_check_enqueue_failed",
+                item_id=case.get("item_id"),
+                trace_id=trace_id,
+                error=str(e),
+            )
+    return enqueued
 
 
 def select_first_region(region_analysis: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -353,6 +438,9 @@ async def run_evaluation_on_dataset(
             case_result = {
                 "item_id": item.id,
                 "run_name": run_name,
+                # Langfuse trace link — lets the human spot-check and the
+                # calibration tooling find this exact generation later.
+                "trace_id": root_span.trace_id,
                 **result,  # Include all result fields (status, scores, token_usage, etc.)
             }
             case_results.append(case_result)
@@ -873,6 +961,11 @@ Find cities, landmarks, and author-related sites, then group them into practical
             "num_cities": len(itinerary_data.get("cities", [])) if itinerary_data else 0,
             "num_regions": len(selected_regions),
             "token_usage": token_stats,
+            # Full payload + the preferences the judge saw, so results JSONs
+            # are self-contained for human review and judge calibration
+            # (previously only Langfuse traces carried the itinerary).
+            "preferences": initial_state.get("user:preferences"),
+            "itinerary": itinerary_data,
         }
 
         # Add scores if scoring succeeded
@@ -1025,6 +1118,45 @@ async def run_all_evaluations(
                 "evaluated_cases": 0,
             })
 
+    # Human spot-check: flag 1-2 scored cases per run for hand review.
+    # The record lives in the results JSON regardless of what happens in
+    # Langfuse, so a review that never happens stays visible as
+    # pending_review in the trend report — skipped, not silent.
+    selected = select_spot_check_cases(
+        results, k=2, seed=datetime.now().strftime("%Y%m%d")
+    )
+    human_spot_check: Dict[str, Any] = {
+        "selected": selected,
+        "status": "pending_review" if selected else "no_scored_cases",
+        "selected_at": datetime.now().isoformat(),
+        "review_queue_id": None,
+        "enqueued": 0,
+    }
+    review_queue_id = os.getenv("LANGFUSE_REVIEW_QUEUE_ID")
+    if selected and review_queue_id and LANGFUSE_AVAILABLE:
+        try:
+            langfuse = Langfuse(
+                secret_key=config.langfuse_secret_key,
+                public_key=config.langfuse_public_key,
+                host=config.langfuse_host or "https://cloud.langfuse.com",
+            )
+            human_spot_check["enqueued"] = enqueue_for_human_review(
+                langfuse, review_queue_id, selected
+            )
+            human_spot_check["review_queue_id"] = review_queue_id
+        except Exception as e:
+            logger.warning(
+                "spot_check_queue_unavailable",
+                queue_id=review_queue_id,
+                error=str(e),
+            )
+    logger.info(
+        "spot_check_selected",
+        num_selected=len(selected),
+        items=[c["item_id"] for c in selected],
+        enqueued=human_spot_check["enqueued"],
+    )
+
     # Save results
     os.makedirs(output_dir, exist_ok=True)
     output_file = os.path.join(
@@ -1036,6 +1168,7 @@ async def run_all_evaluations(
         json.dump({
             'timestamp': datetime.now().isoformat(),
             'results': results,
+            'human_spot_check': human_spot_check,
         }, f, indent=2)
 
     logger.info("all_evaluations_complete", output_file=output_file)

--- a/evaluation/trend_report.md
+++ b/evaluation/trend_report.md
@@ -1,20 +1,29 @@
 # StoryLand AI - Evaluation Trends
 
-**Report Generated:** 2026-06-18 10:58:44
+**Report Generated:** 2026-07-20 20:25:42
 **Period:** Last 30 days
 **Total Evaluation Runs:** 1
 
 ## Overview
 
-- **Total Test Cases Evaluated:** 14
-- **Latest Evaluation:** 2026-06-18T10:58:44.025882
+- **Total Test Cases Evaluated:** 2
+- **Latest Evaluation:** 2026-07-20T20:25:41.922217
 
 ## Recent Evaluations
 
 | Date | Dataset | Cases | Status |
 |------|---------|-------|--------|
-| 2026-06-18 | storyland_eval | 7 | ✅ Complete |
-| 2026-06-18 | books_v1 | 7 | ✅ Complete |
+| 2026-07-20 | storyland_eval | 2 | ✅ Complete |
+
+## Human spot-checks
+
+Randomly flagged cases awaiting hand review (judge-calibration spot-checks). Pending rows persist until the trace carries a human annotation score in Langfuse.
+
+| Flagged | Dataset | Case | Book | Review status |
+|---------|---------|------|------|---------------|
+| 2026-07-20 | storyland_eval | be0a4460 | Agatha Christie's works | ❓ Unknown (no Langfuse credentials) |
+| 2026-07-20 | storyland_eval | d48fbd3c | Under the Tuscan Sun | ❓ Unknown (no Langfuse credentials) |
+
 
 ## Viewing Results
 

--- a/tests/unit/test_judge_calibration.py
+++ b/tests/unit/test_judge_calibration.py
@@ -138,8 +138,10 @@ class TestFetchHumanScores:
         )
         scores = fetch_human_scores(langfuse, "t1")
         assert scores == {"book_relevance": 4, "engagement": 2}
+        # No source filter: UI labels are ANNOTATION, API-entered labels are
+        # API — the human_ prefix is the contract.
         langfuse.api.scores_v3.get_many_v3.assert_called_once_with(
-            trace_id="t1", source="ANNOTATION", limit=100
+            trace_id="t1", limit=100
         )
 
     def test_latest_value_wins(self):

--- a/tests/unit/test_judge_calibration.py
+++ b/tests/unit/test_judge_calibration.py
@@ -1,0 +1,240 @@
+"""
+Unit tests for the judge-calibration tooling.
+
+Pure-logic coverage (selection, interleaving, agreement math) plus the
+Langfuse-facing helpers with mocked clients — no live API.
+"""
+
+from unittest.mock import MagicMock
+
+from evaluation.tools.judge_calibration import (
+    DIMENSIONS,
+    compute_agreement,
+    fetch_human_scores,
+    hydrate_candidate,
+    interleave_by_run,
+    select_candidates,
+)
+from evaluation.tools.llm_scorer import SCORING_CRITERIA
+
+
+def _candidate(dataset, item_id, run_name):
+    return {
+        "dataset": dataset,
+        "item_id": item_id,
+        "run_name": run_name,
+        "trace_id": f"trace-{dataset}-{item_id}-{run_name}",
+    }
+
+
+class TestInterleaveByRun:
+    def test_alternates_datasets_newest_run_first(self):
+        per_dataset = {
+            "a": [
+                [_candidate("a", "1", "run2")],
+                [_candidate("a", "1", "run1")],
+            ],
+            "b": [
+                [_candidate("b", "1", "run9")],
+            ],
+        }
+        ordered = interleave_by_run(per_dataset)
+        assert [(c["dataset"], c["run_name"]) for c in ordered] == [
+            ("a", "run2"), ("b", "run9"), ("a", "run1"),
+        ]
+
+    def test_empty(self):
+        assert interleave_by_run({}) == []
+        assert interleave_by_run({"a": []}) == []
+
+
+class TestSelectCandidates:
+    def test_caps_generations_per_case(self):
+        candidates = [
+            _candidate("d", "q1", f"run{i}") for i in range(4)
+        ] + [_candidate("d", "q2", "run0")]
+        selected = select_candidates(candidates, target=30, max_per_case=2)
+        q1_count = sum(1 for c in selected if c["item_id"] == "q1")
+        assert q1_count == 2
+        assert any(c["item_id"] == "q2" for c in selected)
+
+    def test_stops_at_target(self):
+        candidates = [_candidate("d", f"q{i}", "run0") for i in range(50)]
+        assert len(select_candidates(candidates, target=30)) == 30
+
+    def test_preserves_order(self):
+        candidates = [_candidate("d", f"q{i}", "run0") for i in range(5)]
+        selected = select_candidates(candidates, target=3)
+        assert [c["item_id"] for c in selected] == ["q0", "q1", "q2"]
+
+
+class TestComputeAgreement:
+    def test_mad_and_bias_hand_computed(self):
+        items = [
+            {
+                "judge_scores": {"book_relevance": 4},
+                "human_scores": {"book_relevance": 2},
+            },
+            {
+                "judge_scores": {"book_relevance": 3},
+                "human_scores": {"book_relevance": 4},
+            },
+        ]
+        agreement = compute_agreement(items)
+        stats = agreement["per_dimension"]["book_relevance"]
+        # deltas: +2, -1 -> MAD 1.5, bias +0.5, one large disagreement
+        assert stats == {
+            "n": 2,
+            "mean_abs_diff": 1.5,
+            "bias": 0.5,
+            "large_disagreements": 1,
+        }
+        assert agreement["n_labeled_items"] == 2
+        assert len(agreement["large_disagreements"]) == 1
+
+    def test_missing_dimensions_excluded(self):
+        # No-preference cases carry no preference_adherence judge score.
+        items = [{
+            "judge_scores": {"book_relevance": 4, "preference_adherence": None},
+            "human_scores": {"book_relevance": 4},
+        }]
+        agreement = compute_agreement(items)
+        assert agreement["per_dimension"]["preference_adherence"] == {"n": 0}
+        assert agreement["per_dimension"]["book_relevance"]["n"] == 1
+        assert agreement["per_dimension"]["book_relevance"]["mean_abs_diff"] == 0
+
+    def test_unlabeled_items_counted_but_contribute_nothing(self):
+        items = [
+            {"judge_scores": {d: 3 for d in DIMENSIONS}, "human_scores": {}},
+        ]
+        agreement = compute_agreement(items)
+        assert agreement["n_manifest_items"] == 1
+        assert agreement["n_labeled_items"] == 0
+        assert all(s["n"] == 0 for s in agreement["per_dimension"].values())
+
+    def test_all_dimensions_reported(self):
+        agreement = compute_agreement([])
+        assert set(agreement["per_dimension"].keys()) == set(SCORING_CRITERIA.keys())
+
+
+class TestFetchHumanScores:
+    def _score(self, name, value):
+        score = MagicMock()
+        score.name = name
+        score.value = value
+        return score
+
+    def test_maps_prefixed_names_to_dimensions(self):
+        langfuse = MagicMock()
+        langfuse.api.scores_v3.get_many_v3.return_value = MagicMock(
+            data=[
+                self._score("human_book_relevance", 4.0),
+                self._score("human_engagement", 2.0),
+                self._score("book_relevance", 5.0),  # judge score: ignored
+                self._score("human_unknown_dim", 1.0),  # not a dimension
+            ]
+        )
+        scores = fetch_human_scores(langfuse, "t1")
+        assert scores == {"book_relevance": 4, "engagement": 2}
+        langfuse.api.scores_v3.get_many_v3.assert_called_once_with(
+            trace_id="t1", source="ANNOTATION", limit=100
+        )
+
+    def test_latest_value_wins(self):
+        langfuse = MagicMock()
+        # API returns newest first; a re-label should shadow the older value.
+        langfuse.api.scores_v3.get_many_v3.return_value = MagicMock(
+            data=[
+                self._score("human_book_relevance", 3.0),
+                self._score("human_book_relevance", 5.0),
+            ]
+        )
+        assert fetch_human_scores(langfuse, "t1") == {"book_relevance": 3}
+
+    def test_api_error_returns_empty(self):
+        langfuse = MagicMock()
+        langfuse.api.scores_v3.get_many_v3.side_effect = Exception("down")
+        assert fetch_human_scores(langfuse, "t1") == {}
+
+
+class TestHydrateCandidate:
+    def _trace(self, output, input_data=None, scores=None, html_path="/project/p/traces/t1"):
+        trace = MagicMock()
+        trace.output = output
+        trace.input = input_data or {}
+        trace.scores = scores or []
+        trace.html_path = html_path
+        return trace
+
+    def _judge_score(self, name, value):
+        score = MagicMock()
+        score.name = name
+        score.value = value
+        score.source = "API"
+        return score
+
+    def test_builds_manifest_entry(self):
+        langfuse = MagicMock()
+        langfuse.api.trace.get.return_value = self._trace(
+            output={"summary": "an itinerary"},
+            input_data={
+                "book_title": "Dracula",
+                "author": "Bram Stoker",
+                "preferences": {"budget": "low"},
+            },
+            scores=[self._judge_score("book_relevance", 4.0)],
+        )
+        entry = hydrate_candidate(
+            langfuse, "https://lf.example", _candidate("books_v1", "q1", "run1")
+        )
+        assert entry["book_title"] == "Dracula"
+        assert entry["has_preferences"] is True
+        assert entry["judge_scores"]["book_relevance"] == 4
+        assert entry["judge_scores"]["engagement"] is None
+        assert entry["trace_url"] == "https://lf.example/project/p/traces/t1"
+
+    def test_no_preferences_shape(self):
+        langfuse = MagicMock()
+        langfuse.api.trace.get.return_value = self._trace(
+            output={"summary": "x"},
+            input_data={"book_title": "Wild", "preferences": {}},
+            scores=[self._judge_score("engagement", 3.0)],
+        )
+        entry = hydrate_candidate(
+            langfuse, "https://lf.example", _candidate("books_v1", "q1", "run1")
+        )
+        assert entry["has_preferences"] is False
+
+    def test_drops_trace_without_output(self):
+        langfuse = MagicMock()
+        langfuse.api.trace.get.return_value = self._trace(output=None)
+        assert hydrate_candidate(
+            langfuse, "h", _candidate("books_v1", "q1", "run1")
+        ) is None
+
+    def test_drops_trace_without_judge_scores(self):
+        langfuse = MagicMock()
+        langfuse.api.trace.get.return_value = self._trace(
+            output={"summary": "x"}, scores=[]
+        )
+        assert hydrate_candidate(
+            langfuse, "h", _candidate("books_v1", "q1", "run1")
+        ) is None
+
+    def test_annotation_scores_never_taken_as_judge_scores(self):
+        langfuse = MagicMock()
+        human = self._judge_score("book_relevance", 1.0)
+        human.source = "ANNOTATION"
+        langfuse.api.trace.get.return_value = self._trace(
+            output={"summary": "x"}, scores=[human]
+        )
+        assert hydrate_candidate(
+            langfuse, "h", _candidate("books_v1", "q1", "run1")
+        ) is None
+
+    def test_fetch_error_drops_candidate(self):
+        langfuse = MagicMock()
+        langfuse.api.trace.get.side_effect = Exception("404")
+        assert hydrate_candidate(
+            langfuse, "h", _candidate("books_v1", "q1", "run1")
+        ) is None

--- a/tests/unit/test_judge_calibration.py
+++ b/tests/unit/test_judge_calibration.py
@@ -11,8 +11,10 @@ from evaluation.tools.judge_calibration import (
     DIMENSIONS,
     compute_agreement,
     fetch_human_scores,
+    get_enqueued_trace_ids,
     hydrate_candidate,
     interleave_by_run,
+    merge_manifest_items,
     select_candidates,
 )
 from evaluation.tools.llm_scorer import SCORING_CRITERIA
@@ -232,9 +234,58 @@ class TestHydrateCandidate:
             langfuse, "h", _candidate("books_v1", "q1", "run1")
         ) is None
 
-    def test_fetch_error_drops_candidate(self):
+    def test_fetch_error_drops_candidate_after_retries(self):
         langfuse = MagicMock()
-        langfuse.api.trace.get.side_effect = Exception("404")
+        langfuse.api.trace.get.side_effect = Exception("timeout")
         assert hydrate_candidate(
-            langfuse, "h", _candidate("books_v1", "q1", "run1")
+            langfuse, "h", _candidate("books_v1", "q1", "run1"),
+            attempts=3, retry_delays=(0,),
         ) is None
+        assert langfuse.api.trace.get.call_count == 3
+
+    def test_transient_fetch_error_recovers(self):
+        langfuse = MagicMock()
+        langfuse.api.trace.get.side_effect = [
+            Exception("timeout"),
+            self._trace(
+                output={"summary": "x"},
+                scores=[self._judge_score("engagement", 3.0)],
+            ),
+        ]
+        entry = hydrate_candidate(
+            langfuse, "h", _candidate("books_v1", "q1", "run1"),
+            attempts=3, retry_delays=(0,),
+        )
+        assert entry is not None
+
+
+class TestMergeManifestItems:
+    def test_new_wins_and_old_preserved(self):
+        existing = [
+            {"trace_id": "t1", "book_title": "Old"},
+            {"trace_id": "t2", "book_title": "Kept"},
+        ]
+        new = [
+            {"trace_id": "t1", "book_title": "New"},
+            {"trace_id": "t3", "book_title": "Added"},
+        ]
+        merged = {i["trace_id"]: i["book_title"] for i in merge_manifest_items(existing, new)}
+        assert merged == {"t1": "New", "t2": "Kept", "t3": "Added"}
+
+
+class TestGetEnqueuedTraceIds:
+    def test_paginates_until_short_page(self):
+        langfuse = MagicMock()
+        full_page = MagicMock(data=[MagicMock(object_id=f"t{i}") for i in range(100)])
+        short_page = MagicMock(data=[MagicMock(object_id="t100")])
+        langfuse.api.annotation_queues.list_queue_items.side_effect = [
+            full_page, short_page
+        ]
+        trace_ids = get_enqueued_trace_ids(langfuse, "q1")
+        assert len(trace_ids) == 101
+        assert langfuse.api.annotation_queues.list_queue_items.call_count == 2
+
+    def test_list_failure_returns_partial(self):
+        langfuse = MagicMock()
+        langfuse.api.annotation_queues.list_queue_items.side_effect = Exception("down")
+        assert get_enqueued_trace_ids(langfuse, "q1") == set()

--- a/tests/unit/test_spot_check.py
+++ b/tests/unit/test_spot_check.py
@@ -1,0 +1,182 @@
+"""
+Unit tests for the weekly human spot-check flow.
+
+Covers the selection logic in run_scheduled_eval, the non-fatal annotation
+enqueue, and the trend-report section that keeps skipped reviews visible.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from evaluation.tools.run_scheduled_eval import (
+    select_spot_check_cases,
+    enqueue_for_human_review,
+)
+from evaluation.tools.eval_dashboard import build_spot_check_section
+
+
+def _dataset_result(dataset_name, cases):
+    return {"dataset_name": dataset_name, "case_results": cases}
+
+
+def _scored_case(item_id, book="Dracula", trace_id=None):
+    return {
+        "item_id": item_id,
+        "run_name": "eval_run_20260720_120000_v3",
+        "trace_id": trace_id or f"trace-{item_id}",
+        "status": "evaluated",
+        "book_title": book,
+        "scores": {"average": 3.5},
+    }
+
+
+class TestSelectSpotCheckCases:
+    def test_deterministic_per_seed(self):
+        results = [
+            _dataset_result("books_v1", [_scored_case(f"q{i}") for i in range(8)])
+        ]
+        first = select_spot_check_cases(results, k=2, seed="20260720")
+        second = select_spot_check_cases(results, k=2, seed="20260720")
+        assert first == second
+        assert len(first) == 2
+
+    def test_different_seeds_can_differ(self):
+        results = [
+            _dataset_result("books_v1", [_scored_case(f"q{i}") for i in range(20)])
+        ]
+        picks = {
+            tuple(c["item_id"] for c in select_spot_check_cases(results, k=2, seed=s))
+            for s in ("a", "b", "c", "d", "e")
+        }
+        assert len(picks) > 1
+
+    def test_k_caps_at_available_scored_cases(self):
+        results = [_dataset_result("books_v1", [_scored_case("q1")])]
+        selected = select_spot_check_cases(results, k=2, seed="x")
+        assert len(selected) == 1
+
+    def test_only_scored_evaluated_cases_eligible(self):
+        cases = [
+            _scored_case("q1"),
+            {"item_id": "q2", "status": "failed", "error": "boom"},
+            {"item_id": "q3", "status": "evaluated"},  # no scores (judge failed)
+            {"item_id": "q4", "status": "skipped"},
+        ]
+        results = [_dataset_result("books_v1", cases)]
+        selected = select_spot_check_cases(results, k=4, seed="x")
+        assert [c["item_id"] for c in selected] == ["q1"]
+
+    def test_no_candidates_returns_empty(self):
+        assert select_spot_check_cases([], k=2, seed="x") == []
+        assert select_spot_check_cases(
+            [_dataset_result("books_v1", [])], k=2, seed="x"
+        ) == []
+
+    def test_selection_spans_datasets(self):
+        results = [
+            _dataset_result("storyland_eval", [_scored_case(f"s{i}") for i in range(3)]),
+            _dataset_result("books_v1", [_scored_case(f"b{i}") for i in range(3)]),
+        ]
+        selected = select_spot_check_cases(results, k=6, seed="x")
+        assert {c["dataset"] for c in selected} == {"storyland_eval", "books_v1"}
+
+    def test_descriptor_shape(self):
+        results = [_dataset_result("books_v1", [_scored_case("q1", book="Wild")])]
+        (case,) = select_spot_check_cases(results, k=1, seed="x")
+        assert case == {
+            "dataset": "books_v1",
+            "item_id": "q1",
+            "run_name": "eval_run_20260720_120000_v3",
+            "trace_id": "trace-q1",
+            "book_title": "Wild",
+        }
+
+
+class TestEnqueueForHumanReview:
+    def _selected(self):
+        return [
+            {"item_id": "q1", "trace_id": "t1"},
+            {"item_id": "q2", "trace_id": "t2"},
+        ]
+
+    def test_enqueues_each_trace(self):
+        langfuse = MagicMock()
+        assert enqueue_for_human_review(langfuse, "queue-1", self._selected()) == 2
+        langfuse.api.annotation_queues.create_queue_item.assert_any_call(
+            "queue-1", object_id="t1", object_type="TRACE"
+        )
+
+    def test_failure_is_non_fatal_and_partial(self):
+        langfuse = MagicMock()
+        langfuse.api.annotation_queues.create_queue_item.side_effect = [
+            Exception("api down"),
+            MagicMock(),
+        ]
+        assert enqueue_for_human_review(langfuse, "queue-1", self._selected()) == 1
+
+    def test_missing_trace_id_skipped(self):
+        langfuse = MagicMock()
+        selected = [{"item_id": "q1", "trace_id": None}]
+        assert enqueue_for_human_review(langfuse, "queue-1", selected) == 0
+        langfuse.api.annotation_queues.create_queue_item.assert_not_called()
+
+
+class TestBuildSpotCheckSection:
+    def _results(self):
+        return [{
+            "timestamp": "2026-07-13T10:00:00",
+            "results": [],
+            "human_spot_check": {
+                "selected": [
+                    {
+                        "dataset": "books_v1",
+                        "item_id": "q1",
+                        "trace_id": "t1",
+                        "book_title": "Dracula",
+                    },
+                    {
+                        "dataset": "storyland_eval",
+                        "item_id": "s1",
+                        "trace_id": "t2",
+                        "book_title": "Wild",
+                    },
+                ],
+                "status": "pending_review",
+                "selected_at": "2026-07-13T10:00:00",
+            },
+        }]
+
+    def test_pending_rows_visible_with_age(self):
+        lines = build_spot_check_section(
+            self._results(),
+            annotation_checker=lambda trace_id: False,
+            now=datetime(2026, 7, 20, 10, 0, 0),
+        )
+        text = "\n".join(lines)
+        assert "## Human spot-checks" in text
+        assert text.count("⏳ PENDING, 7d old") == 2
+        assert "2 spot-check(s) awaiting human review" in text
+
+    def test_reviewed_and_pending_mixed(self):
+        lines = build_spot_check_section(
+            self._results(),
+            annotation_checker=lambda trace_id: trace_id == "t1",
+            now=datetime(2026, 7, 20),
+        )
+        text = "\n".join(lines)
+        assert "✅ Reviewed" in text
+        assert "⏳ PENDING" in text
+        assert "1 spot-check(s) awaiting human review" in text
+
+    def test_no_checker_reports_unknown(self):
+        text = "\n".join(build_spot_check_section(self._results(), annotation_checker=None))
+        assert "❓ Unknown (no Langfuse credentials)" in text
+        assert "awaiting human review" not in text
+
+    def test_no_flagged_cases_returns_empty(self):
+        assert build_spot_check_section([{"results": []}]) == []
+        assert build_spot_check_section([]) == []
+        no_selection = [{
+            "human_spot_check": {"selected": [], "status": "no_scored_cases"}
+        }]
+        assert build_spot_check_section(no_selection) == []


### PR DESCRIPTION
## What this lands

The judge-calibration tooling and its outputs, currently existing only in the session that produced them (MYS-586 item 1):

- **`evaluation/tools/judge_calibration.py`** — `build-queue` (pulls judge-scored itineraries from Langfuse dataset runs into annotation queue `judge-calibration-2026-07` with `human_<dim>` 1–5 score configs carrying the exact SCORING_CRITERIA text; idempotent re-runs, trace-fetch retries; manifest committed at `evaluation/calibration/queue_manifest_2026-07.json`) and `agreement` (per-dimension judge-vs-label MAD + signed bias + |Δ|≥2 list).
- **`evaluation/calibration/agreement_report.md`** (+ JSON) — the checkable artifact behind the books_v1 finding, including the mechanism addendum, proposed judge-prompt edits (NOT applied — pinned judge, needs re-baseline), and label-anchored gate arithmetic.
- **Weekly human spot-check** — each scheduled eval flags ≤2 scored cases (seeded by run date) into `human_spot_check` in the results JSON (`pending_review` until the trace carries a `human_*` label score); trend report renders pending rows with age; optional auto-enqueue via `LANGFUSE_REVIEW_QUEUE_ID` (repo variable set, workflow passes it through).
- **Results JSONs are now self-contained** — full `itinerary` payload, `preferences`, and `trace_id` per case (previously only Langfuse traces carried the itinerary).
- Dashboard fix: `eval_dashboard.py` loads `.env` before reading Langfuse creds (CI provides creds via file, not exported vars).

## The finding this makes checkable

Split of judge-vs-label agreement by dataset (30 labeled itineraries, both preference shapes):

| Dataset | Bias (judge−label) | MAD | Why |
|---|---:|---:|---|
| storyland_eval | +0.18 | 0.32 | scores on merits — **trustworthy, its 4.1 gate is real** |
| books_v1 | **−1.16** | 1.27 | `expected_output` injected as “benchmark” → judge measures **resemblance, not quality** |

Secondary: gemini-2.5-flash-lite cannot fact-check geography (scored 5 on a wrong-Portland itinerary, 1–2 on verifiably correct St. Petersburg addresses).

**Label provenance (stated everywhere it matters):** labels are Claude Fable 5 model labels, Olga-approved in lieu of hand labels — judge-vs-Claude, not human ground truth. Weekly spot-checks are the ongoing human-anchor channel.

**Standing caveat:** until the prompt fix + books_v1 re-baseline (fold into PR-4 step zero), books_v1 deltas are a catastrophe detector only, not quality signal.

## Tests

797 unit + 10 integration passing (`make test` / `make test-integration`); 36 new tests cover selection determinism, non-fatal enqueue, agreement math, manifest merge, and trend-report rendering. End-to-end verified via dispatched CI run 29775916494 (artifact carries payloads + pending spot-check; trend report renders the section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)