### PR TITLE
fix(eval): judge scores merits not resemblance + re-baseline (MYS-586 items 2-3)

### DIFF
--- a/evaluation/calibration/rebaseline_2026-07.md
+++ b/evaluation/calibration/rebaseline_2026-07.md
@@ -1,0 +1,90 @@
+# Re-baseline under the merits-not-resemblance judge (MYS-586 items 2–3)
+
+**Date:** 2026-07-21 · **Judge:** gemini-2.5-flash-lite (pinned), prompt as of this
+branch (reference reframed as example + 3 criteria re-anchors) · **System under
+test:** gemini-3.1-flash-lite (main's CI default) · **Runs:** CI dispatches
+29792373877 / 29792389935, 18 cases each (storyland_eval 8 + books_v1 10),
+same config, per the two-run noise protocol.
+
+Label caveat (carried from the calibration): comparisons against "labels" below
+are against **Claude Fable 5 model labels (Olga-approved)** — a second model's
+careful reading, not human ground truth. Read "bias" as *divergence from a
+second model*, not as error against truth.
+
+## Run results
+
+| Dataset | Run 1 avg | Run 2 avg | Pooled | maxΔ (this pair) | tokens/case |
+|---|---:|---:|---:|---:|---:|
+| storyland_eval | 4.362 | 4.379 | **4.37** | 0.017 | ~18.0k |
+| books_v1 | 3.024 | 2.861 | **2.94** | 0.163 | ~17.1k |
+
+Per-shape (books_v1): with_preferences 3.37 / 3.60, without_preferences 2.68 / 2.12
+— the preference-free (prod-shape) cells run markedly lower and noisier; worth its
+own look before any per-shape gate hardens.
+
+## Gates (rule: pooled − 2×maxΔ)
+
+maxΔ from a single run-pair is an optimistic noise estimate (storyland's 0.017
+here vs 0.17 historically measured). Two derivations recorded; **recommend the
+conservative one** until the weekly runs accumulate more same-config pairs:
+
+| Dataset | Pooled | Gate (this pair's maxΔ) | Gate (conservative: historical maxΔ 0.17 / 0.40) |
+|---|---:|---:|---:|
+| storyland_eval | 4.37 | 4.34 | **≥ 4.03** |
+| books_v1 | 2.94 | 2.62 | **≥ 2.14** |
+
+These supersede the interim constants (storyland ≥ 4.10 on pooled 4.44 under the
+old judge + old system model; books ≥ 2.08 on pooled 2.88). Both judge and
+system model changed — no delta against pre-fix numbers is meaningful.
+
+## mechanism:
+
+- **Dimension mix (books_v1, run1→run2):** book_relevance 2.8→2.8,
+  preference_adherence 3.4→3.4, completeness 2.9→2.8, actionability 2.9→2.7,
+  geographical_accuracy 3.1→3.0, engagement 3.4→3.1. No single-dimension
+  collapse; the run-to-run spread is level, not mix.
+- **Token profile:** 16.9k–17.2k total/case books, 17.7k–18.3k storyland —
+  consistent across runs, no truncation signature.
+- **Level did NOT lift on books_v1** (2.94 vs the old 2.88 band) despite the
+  prompt fix. The controlled experiment below explains why: the fix as shipped
+  removes only the smaller of two similarity mechanisms.
+
+## Controlled re-judge: same 30 labeled itineraries, judge variants
+
+Isolates the judge change from the generation change (new CI runs judge *new*
+3.1-flash-lite generations; this section re-judges the exact payloads the labels
+were made on). storyland_eval under the new prompt: **+0.18 / MAD 0.32 —
+unchanged**, the control holds and the criteria re-anchors did no damage.
+
+books_v1 (20 items, 110 dimension-pairs per config):
+
+| Judge config | Bias (judge − label) | MAD |
+|---|---:|---:|
+| Old prompt (reference-as-benchmark + quality_criteria) | −1.16 | 1.27 |
+| New prompt (reference-as-example + quality_criteria) — **shipped in this PR** | −0.95 | 1.16 |
+| Ablation A: reference removed, quality_criteria kept | −0.72 | 0.95 |
+| Ablation B: quality_criteria removed, reference kept (example framing) | **+0.07** | **0.45** |
+
+**Finding: the dominant similarity mechanism is the book-specific
+`quality_criteria` injection, not the reference output.** The benchmark framing
+was worth ~0.2 of the ~1.35 divergence gap; the reference's mere presence
+another ~0.2; the per-dimension "Book-specific requirement:" blocks carry the
+rest. With them removed, books_v1 agreement (+0.07 / 0.45) essentially matches
+reference-free storyland_eval — the qc blocks are a reference in checklist
+form, grading compliance with expected specifics rather than quality.
+
+## Decision needed (not taken in this PR)
+
+What should books_v1's judge measure? Options, in increasing order of change:
+
+1. **Keep qc as-is** — books_v1 stays a compliance gate; gates above stand;
+   never read its deltas as quality.
+2. **Reframe qc** in `_criterion_block` as "aspects worth considering, not
+   requirements" — partial, would need its own ablation.
+3. **Split the quantities** — score quality without qc (ablation-B config) and
+   report qc coverage as a separate score (e.g. `criteria_coverage`), so
+   quality and compliance stop sharing one number. Cleanest; touches the
+   dataset's intent, so it's a dataset-owner call.
+
+Until that call, the standing caveat holds: books_v1 judge deltas are a
+catastrophe detector, not quality signal.

--- a/evaluation/tools/llm_scorer.py
+++ b/evaluation/tools/llm_scorer.py
@@ -27,7 +27,8 @@ SCORING_CRITERIA = {
     "book_relevance": (
         "Evaluate if the travel itinerary locations are directly connected to the book's "
         "settings, themes, characters, or author. Each suggested place should have a clear "
-        "and meaningful connection to the literary work.\n\n"
+        "and meaningful connection to the literary work. Evaluate connections against "
+        "your knowledge of the book itself, not against any reference list of locations.\n\n"
         "Score 1-5 where:\n"
         "5 = All locations strongly connected to book\n"
         "4 = Most locations clearly relevant\n"
@@ -49,7 +50,8 @@ SCORING_CRITERIA = {
     "completeness": (
         "Evaluate if the response includes a comprehensive itinerary with cities, landmarks, "
         "and author-related sites. The itinerary should provide enough detail for the traveler "
-        "to plan their trip.\n\n"
+        "to plan their trip. Completeness means the itinerary's own components and plannable "
+        "detail — not coverage of every location a reference might include.\n\n"
         "Score 1-5 where:\n"
         "5 = Comprehensive with all components\n"
         "4 = Good coverage of main elements\n"
@@ -71,7 +73,10 @@ SCORING_CRITERIA = {
     "geographical_accuracy": (
         "Evaluate if the locations mentioned are real places that can be visited. "
         "Cities and landmarks should be correctly associated with their countries. "
-        "The geographical information should be accurate.\n\n"
+        "The geographical information should be accurate. Judge the itinerary's own "
+        "locations for real-world validity: a location is not wrong merely because it "
+        "differs from a reference, and invented stop labels that are not real visitable "
+        "places should lower the score.\n\n"
         "Score 1-5 where:\n"
         "5 = All locations accurate and real\n"
         "4 = Minor geographical details off\n"
@@ -158,7 +163,15 @@ def _build_scoring_prompt(
 
     # Format expected output section (only when provided)
     if expected_output:
-        reference_section = f"**REFERENCE OUTPUT** (use this as benchmark when scoring):\n{json.dumps(expected_output, indent=2)}\n"
+        # Calibration finding (MYS-586): "use as benchmark" turned the judge
+        # into a reference-similarity metric on books_v1 (divergence ~1.2 vs
+        # a second model's read; ~0.2 on reference-free storyland_eval).
+        reference_section = (
+            "**REFERENCE EXAMPLE** — one valid solution, for context only. "
+            "Score the generated itinerary on its own merits against the "
+            "criteria; do NOT penalize valid choices that differ from this "
+            f"example:\n{json.dumps(expected_output, indent=2)}\n"
+        )
     else:
         reference_section = ""
 

--- a/evaluation/trend_report.md
+++ b/evaluation/trend_report.md
@@ -1,19 +1,20 @@
 # StoryLand AI - Evaluation Trends
 
-**Report Generated:** 2026-07-20 20:25:42
+**Report Generated:** 2026-07-21 01:17:33
 **Period:** Last 30 days
 **Total Evaluation Runs:** 1
 
 ## Overview
 
-- **Total Test Cases Evaluated:** 2
-- **Latest Evaluation:** 2026-07-20T20:25:41.922217
+- **Total Test Cases Evaluated:** 18
+- **Latest Evaluation:** 2026-07-21T01:17:32.923787
 
 ## Recent Evaluations
 
 | Date | Dataset | Cases | Status |
 |------|---------|-------|--------|
-| 2026-07-20 | storyland_eval | 2 | ✅ Complete |
+| 2026-07-21 | storyland_eval | 8 | ✅ Complete |
+| 2026-07-21 | books_v1 | 10 | ✅ Complete |
 
 ## Human spot-checks
 
@@ -21,8 +22,10 @@ Randomly flagged cases awaiting hand review (judge-calibration spot-checks). Pen
 
 | Flagged | Dataset | Case | Book | Review status |
 |---------|---------|------|------|---------------|
-| 2026-07-20 | storyland_eval | be0a4460 | Agatha Christie's works | ❓ Unknown (no Langfuse credentials) |
-| 2026-07-20 | storyland_eval | d48fbd3c | Under the Tuscan Sun | ❓ Unknown (no Langfuse credentials) |
+| 2026-07-21 | books_v1 | query_014 | Red, White & Royal Blue | ⏳ PENDING, 0d old |
+| 2026-07-21 | storyland_eval | 725d84f6 | The Da Vinci Code | ⏳ PENDING, 0d old |
+
+**⚠️ 2 spot-check(s) awaiting human review.**
 
 
 ## Viewing Results

--- a/tests/unit/test_llm_scorer.py
+++ b/tests/unit/test_llm_scorer.py
@@ -373,12 +373,16 @@ class TestBuildScoringPromptWithExpectedOutput:
             itinerary={"cities": ["Matamata"]},
             expected_output=expected_output,
         )
-        assert "REFERENCE OUTPUT" in prompt
+        assert "REFERENCE EXAMPLE" in prompt
+        # MYS-586: the reference must be framed as context, never a benchmark
+        # to resemble — that framing made books_v1 a similarity metric.
+        assert "benchmark" not in prompt
+        assert "do NOT penalize valid choices" in prompt
         assert "Matamata" in prompt
         assert "10-14 days" in prompt
 
     def test_no_expected_output_no_reference_section(self):
-        """No REFERENCE OUTPUT section when expected_output is None."""
+        """No reference section when expected_output is None."""
         prompt = _build_scoring_prompt(
             book_title="The Lord of the Rings",
             author="J.R.R. Tolkien",
@@ -386,4 +390,4 @@ class TestBuildScoringPromptWithExpectedOutput:
             itinerary={"cities": ["Matamata"]},
             expected_output=None,
         )
-        assert "REFERENCE OUTPUT" not in prompt
+        assert "REFERENCE EXAMPLE" not in prompt


### PR DESCRIPTION
## What this does

- Applies the calibration addendum's judge-prompt edits: reference reframed from benchmark to **example, context only, no penalty for valid divergence**; book_relevance / completeness / geographical_accuracy re-anchored to the itinerary's own merits. The old benchmark-framing test now asserts the inverse (`benchmark` must not appear) — the mechanism's regression guard.
- Two-run re-baseline on this branch (CI dispatches 29792373877 / 29792389935, system = main's gemini-3.1-flash-lite, judge pinned 2.5-flash-lite): **storyland 4.37 pooled (maxΔ 0.017), books_v1 2.94 (maxΔ 0.163)**. Conservative gates (historical maxΔ until more pairs accrue): **storyland ≥ 4.03, books_v1 ≥ 2.14**. Full report with per-shape cells and the required mechanism section: `evaluation/calibration/rebaseline_2026-07.md`.

## The finding the re-baseline forced

books_v1's level did **not** lift under the fix — and a controlled re-judge of the same 30 labeled itineraries shows why. Divergence from the labels (Claude model labels, Olga-approved — second-model reading, not ground truth):

| books_v1 judge config | Bias | MAD |
|---|---:|---:|
| Old (benchmark ref + quality_criteria) | −1.16 | 1.27 |
| New (example ref + qc) — this PR | −0.95 | 1.16 |
| A: ref removed, qc kept | −0.72 | 0.95 |
| B: qc removed, ref kept | **+0.07** | **0.45** |

**The dominant similarity mechanism is the book-specific `quality_criteria` injection, not the reference** — a reference in checklist form. With qc removed, books_v1 agreement matches reference-free storyland_eval (+0.18 / 0.32, unchanged under the new prompt — the control held).

## Decision flagged, not taken

What should books_v1 measure? Keep qc (compliance gate), reframe it, or split quality from `criteria_coverage` as separate scores (cleanest; dataset-owner call). Until decided, the standing caveat stands: books_v1 deltas = catastrophe detector only.

## Tests

875 unit + 10 integration passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)