### PR TITLE
feat(eval): split quality from criteria_coverage + re-baseline (MYS-586)

### DIFF
--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -213,11 +213,12 @@ of eval numbers needs:
 - **The storyland_eval judge is trustworthy** (±0.3 of a careful independent
   reading; stable across the MYS-586 prompt changes). Trusting the judge and
   trusting the gate are different claims — the gate is still loose.
-- **books_v1 deltas are not quality signal** until re-baselined under the
-  quality/`criteria_coverage` split. Under the pre-split judge they were
-  dominated by similarity-to-reference mechanics. A different-but-good
-  itinerary scored low; a model change that writes differently will move the
-  number without quality moving.
+- **books_v1 quality deltas are believable post-split** (re-baselined
+  2026-07-21, pooled 3.90: `rebaseline_split_2026-07.md`). The split-config
+  judge matched the second-model reading at +0.07 bias / 0.45 MAD; pre-split
+  numbers (≤2.94-era) were similarity-dominated and are not comparable.
+  `criteria_coverage` is the separate compliance read (~2.3–2.4 currently) —
+  never blend it back into quality when quoting either.
 - **The judge cannot fact-check geography.** `geographical_accuracy` scored 5
   on an itinerary placing "Portland Observatory" in Oregon (it's in Maine) and
   1–2 on verifiably correct St. Petersburg addresses. Deterministic checks

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -190,6 +190,45 @@ Each evaluation is scored on 6 dimensions (1-5 scale):
 
 LLM-as-judge scoring is implemented in `evaluation/tools/llm_scorer.py` using Gemini to evaluate itineraries against these criteria.
 
+For books_v1, the dataset's book-specific `quality_criteria` are **not** injected
+into the quality judge — they are scored separately as **`criteria_coverage`**
+(1–5, compliance with the listed criteria only, never blended into the quality
+average). The MYS-586 ablation showed the injection made the judge grade
+compliance-with-specifics rather than quality (divergence vs a second model's
+reading: −0.95 with injection, +0.07 without). One number carrying two meanings
+means a reader can't tell which half moved. The local-atmosphere runner still
+injects its criteria into the judge deliberately (radius adherence rides on it).
+
+### Gate status & caveats (post-calibration, 2026-07)
+
+Full evidence: `evaluation/calibration/agreement_report.md` and
+`evaluation/calibration/rebaseline_2026-07.md`. The short version every reader
+of eval numbers needs:
+
+- **Both dataset gates are catastrophe detectors, not quality floors.** The
+  conservative derivation (pooled − 2×historical maxΔ) puts storyland_eval at
+  ≥ 4.03 against a pooled 4.37 and books_v1 at ≥ 2.14 against 2.94 — far below
+  their means by construction. Passing a gate means "no catastrophe," nothing
+  more.
+- **The storyland_eval judge is trustworthy** (±0.3 of a careful independent
+  reading; stable across the MYS-586 prompt changes). Trusting the judge and
+  trusting the gate are different claims — the gate is still loose.
+- **books_v1 deltas are not quality signal** until re-baselined under the
+  quality/`criteria_coverage` split. Under the pre-split judge they were
+  dominated by similarity-to-reference mechanics. A different-but-good
+  itinerary scored low; a model change that writes differently will move the
+  number without quality moving.
+- **The judge cannot fact-check geography.** `geographical_accuracy` scored 5
+  on an itinerary placing "Portland Observatory" in Oregon (it's in Maine) and
+  1–2 on verifiably correct St. Petersburg addresses. Deterministic checks
+  (e.g. the local-atmosphere radius gate) are the instrument for geographic
+  claims; never cite this dimension alone as evidence of a geographic error.
+- **The 2026-07 calibration labels are model labels** (Claude Fable 5,
+  Olga-approved), not human ground truth: agreement numbers are
+  judge-vs-second-model divergence. Weekly spot-checks are the channel where
+  true human anchors accumulate — a flagged case stays `pending_review` until
+  a real `human_*` score lands, so the absence of human anchors stays visible.
+
 ### Judge Calibration (human labels)
 
 The judge has never been anchored to human labels, and its run-to-run noise is

--- a/evaluation/calibration/rebaseline_split_2026-07.md
+++ b/evaluation/calibration/rebaseline_split_2026-07.md
@@ -1,0 +1,66 @@
+# Re-baseline under the quality/criteria_coverage split (MYS-586, final)
+
+**Date:** 2026-07-21 · **Judge:** gemini-2.5-flash-lite (pinned), quality prompt
+WITHOUT book-specific criteria (ablation-B config); compliance scored
+separately as `criteria_coverage` · **System under test:**
+gemini-3.1-flash-lite · **Runs:** CI dispatches 29793963847 / 29793981815,
+18 cases each, same config, two-run noise protocol.
+
+## Results
+
+| Dataset | Run 1 | Run 2 | Pooled | pairΔ | criteria_coverage |
+|---|---:|---:|---:|---:|---:|
+| storyland_eval | 4.357 | 4.317 | **4.34** | 0.040 | n/a (no criteria) |
+| books_v1 | 3.897 | 3.911 | **3.90** | 0.014 | **2.4 / 2.3** |
+
+The judge-history arc on books_v1: 2.88 ±0.40 (compliance-blended) → 2.94
+±0.16 (reference reframed) → **3.90 ±0.014** (compliance split out). The
+level landed inside the ablation's predicted range (labels averaged 3.7–3.9
+on the older generations), and the run-to-run noise collapsed by ~30×:
+**the compliance mechanism was not only depressing the level — it was the
+dominant noise source.** Similarity-to-a-reference is brittle; merits
+scoring is stable.
+
+`criteria_coverage` now says its own thing in its own column: current
+generations satisfy few of the dataset's book-specific criteria (~2.3–2.4).
+That is a real, visible compliance statement — previously it was silently
+averaged into "quality."
+
+## Per-shape (books_v1) — revises the MYS-560 support
+
+| Shape | Run 1 | Run 2 |
+|---|---:|---:|
+| with_preferences | 4.03 | 4.10 |
+| without_preferences | 3.76 | 3.72 |
+
+Under the compliance-blended judge the preference-free (prod-shape) cells ran
+~1.2 lower (2.68/2.12 vs 3.37/3.60). Under the split judge the gap is
+**~0.3**. Most of the "prod shape scores a point lower and twice as noisy"
+signal was the compliance mechanism, not a quality gap. A ~0.3 deficit on
+n=5/run remains worth watching, but MYS-560 should quote this number, not the
+pre-split one.
+
+## Gates
+
+Tight derivation (this pair's maxΔ): storyland ≥ 4.26, books ≥ 3.88. A
+single pair's Δ is an optimistic noise estimate, so interim conservative
+constants, flagged as judgment: **storyland ≥ 4.00** (historical maxΔ 0.17),
+**books_v1 ≥ 3.55** (borrowing 0.17 as a cross-dataset proxy — the old books
+maxΔ 0.40 was similarity noise that no longer exists; no post-split history
+of its own yet). Re-derive both after ~4 weekly same-config pairs accumulate.
+Both gates remain catastrophe detectors — pass means "no catastrophe."
+
+## mechanism:
+
+- Dimension mix (books, run1→run2): br 3.5→3.7, pa 4.0→4.2, co 3.9→3.9,
+  ac 4.0→3.9, ga 4.2→4.1, en 3.9→3.9 — level shift is broad-based vs the
+  pre-split runs (every dimension up 0.7–1.2), which is the expected
+  signature of removing a global penalty, not of one dimension moving.
+- Token profile: 16.6k–17.4k/case books, 16.9k–19.7k storyland — consistent
+  with prior runs; no truncation signature. criteria_coverage adds one small
+  judge call per books case (~1–2k tokens).
+- Trust status: the quality judge for books_v1 now runs the exact config that
+  agreed with the second-model reading at +0.07 bias / 0.45 MAD on the 30
+  labeled itineraries. books_v1 quality deltas are now as believable as
+  storyland's — same caveat as always that the anchor is a second model's
+  reading, with human anchors accumulating via the weekly spot-checks.

--- a/evaluation/tools/llm_scorer.py
+++ b/evaluation/tools/llm_scorer.py
@@ -176,6 +176,14 @@ def _build_scoring_prompt(
         reference_section = ""
 
     def _criterion_block(key: str, number: int, label: str) -> str:
+        # Calibration ablation (MYS-586): injecting per-book requirements here
+        # is the DOMINANT similarity mechanism — the judge grades compliance
+        # with expected specifics, not quality (books_v1 divergence −0.95 with
+        # them, +0.07 without, vs a second model's read). The itinerary runner
+        # therefore no longer passes quality_criteria to the quality judge;
+        # compliance is scored separately (score_criteria_coverage). The
+        # injection remains for callers that WANT a compliance-inflected judge
+        # (local-atmosphere asserts radius adherence through it, by design).
         block = f"**{number}. {label} (1-5)**\n{SCORING_CRITERIA[key]}"
         if quality_criteria and quality_criteria.get(key):
             block += f"\n\nBook-specific requirement: {quality_criteria[key]}"
@@ -376,6 +384,133 @@ Respond with ONLY a valid JSON object (no markdown, no explanation) with these e
         )
         logger.error(
             "llm_scoring_failed",
+            error=str(e),
+            error_type=type(e).__name__,
+            book_title=book_title,
+        )
+        raise
+
+
+class CriteriaCoverage(BaseModel):
+    """Structured output for the book-specific criteria-coverage score."""
+
+    criteria_coverage: int = Field(
+        ..., ge=1, le=5,
+        description="How fully the itinerary satisfies the book-specific criteria",
+    )
+
+
+COVERAGE_RUBRIC = (
+    "Score 1-5 where:\n"
+    "5 = Every listed criterion clearly satisfied\n"
+    "4 = Most criteria satisfied, minor gaps\n"
+    "3 = Roughly half the criteria satisfied\n"
+    "2 = Few criteria satisfied\n"
+    "1 = The listed criteria are essentially unmet"
+)
+
+
+def _build_coverage_prompt(
+    book_title: str,
+    author: str,
+    quality_criteria: Dict[str, str],
+    itinerary: Dict[str, Any],
+) -> str:
+    """Build the compliance prompt: coverage of the dataset's book-specific
+    criteria, deliberately separated from the quality judge (MYS-586: one
+    number carrying quality AND compliance meant a reader couldn't tell which
+    half moved)."""
+    criteria_lines = "\n".join(
+        f"- ({key}) {text}" for key, text in quality_criteria.items()
+    )
+    itinerary_json = json.dumps(itinerary, indent=2)
+    return f"""How fully does this travel itinerary for "{book_title}" by {author} satisfy the following book-specific criteria?
+
+This is a COMPLIANCE check against the listed criteria only — do not judge overall quality, style, or anything not listed.
+
+**CRITERIA**:
+{criteria_lines}
+
+{COVERAGE_RUBRIC}
+
+**GENERATED ITINERARY**:
+{itinerary_json}
+
+---
+
+Respond with ONLY a valid JSON object (no markdown, no explanation):
+{{
+  "criteria_coverage": <integer 1-5>
+}}
+"""
+
+
+@observe(name="llm_score_criteria_coverage", as_type="generation")
+async def score_criteria_coverage(
+    api_key: str,
+    book_title: str,
+    author: str,
+    quality_criteria: Dict[str, str],
+    itinerary: Dict[str, Any],
+    model_name: str = "gemini-2.5-flash-lite",
+) -> int:
+    """Score coverage of book-specific criteria (1-5), separate from quality.
+
+    Raises on any failure — the caller records a visible null rather than a
+    silent absence (same discipline as a judge omitting a demanded dimension).
+    """
+    prompt = _build_coverage_prompt(book_title, author, quality_criteria, itinerary)
+
+    get_client().update_current_generation(
+        model=model_name,
+        input={"book_title": book_title, "criteria_keys": list(quality_criteria.keys())},
+        metadata={"scoring_method": "llm_criteria_coverage"},
+    )
+
+    try:
+        client = genai.Client(api_key=api_key)
+        response = client.models.generate_content(
+            model=model_name,
+            contents=prompt,
+            config=types.GenerateContentConfig(temperature=0.0),
+        )
+
+        response_text = response.text.strip()
+        if response_text.startswith("```json"):
+            response_text = response_text[7:]
+        if response_text.startswith("```"):
+            response_text = response_text[3:]
+        if response_text.endswith("```"):
+            response_text = response_text[:-3]
+        response_text = response_text.strip()
+
+        coverage = CriteriaCoverage.model_validate_json(response_text)
+
+        usage = response.usage_metadata
+        get_client().update_current_generation(
+            output={"criteria_coverage": coverage.criteria_coverage},
+            usage_details={
+                "input": usage.prompt_token_count or 0,
+                "output": usage.candidates_token_count or 0,
+                "total": usage.total_token_count or 0,
+            } if usage else None,
+            level="DEFAULT",
+            status_message="Coverage scoring completed",
+        )
+        logger.info(
+            "criteria_coverage_complete",
+            book_title=book_title,
+            criteria_coverage=coverage.criteria_coverage,
+        )
+        return coverage.criteria_coverage
+
+    except Exception as e:
+        get_client().update_current_generation(
+            level="ERROR",
+            status_message=f"Coverage scoring failed: {str(e)}",
+        )
+        logger.error(
+            "criteria_coverage_failed",
             error=str(e),
             error_type=type(e).__name__,
             book_title=book_title,

--- a/evaluation/tools/run_scheduled_eval.py
+++ b/evaluation/tools/run_scheduled_eval.py
@@ -37,7 +37,7 @@ from google.genai import types
 import uuid
 
 # LLM-as-judge scorer (Issue #96)
-from evaluation.tools.llm_scorer import score_itinerary
+from evaluation.tools.llm_scorer import score_itinerary, score_criteria_coverage
 
 try:
     from langfuse import Langfuse
@@ -865,6 +865,10 @@ Find cities, landmarks, and author-related sites, then group them into practical
                 # Get user preferences from session state
                 preferences = session.state.get("user:preferences", {})
 
+                # quality_criteria deliberately NOT passed to the quality
+                # judge (MYS-586 ablation: the injection made books_v1 grade
+                # compliance-with-specifics, not quality — divergence −0.95
+                # with it, +0.07 without). Compliance is its own score below.
                 scores = await score_itinerary(
                     api_key=config.google_api_key,
                     book_title=exact_title,
@@ -872,7 +876,6 @@ Find cities, landmarks, and author-related sites, then group them into practical
                     input_text=book_title,
                     itinerary=itinerary_data,
                     preferences=preferences,
-                    quality_criteria=quality_criteria,
                     expected_output=expected_output,
                     model_name="gemini-2.5-flash-lite",
                 )
@@ -924,6 +927,34 @@ Find cities, landmarks, and author-related sites, then group them into practical
                 # Present only when scored (no-preference cases average 5 dims).
                 if scores.preference_adherence is not None:
                     scores_data["preference_adherence"] = scores.preference_adherence
+
+                # Compliance with book-specific criteria: a SEPARATE score,
+                # never blended into the quality average — one number carrying
+                # quality and compliance meant a reader couldn't tell which
+                # half moved. Failure records a visible null, not an absence.
+                if quality_criteria:
+                    try:
+                        coverage = await score_criteria_coverage(
+                            api_key=config.google_api_key,
+                            book_title=exact_title,
+                            author=exact_author,
+                            quality_criteria=quality_criteria,
+                            itinerary=itinerary_data,
+                            model_name="gemini-2.5-flash-lite",
+                        )
+                        scores_data["criteria_coverage"] = coverage
+                        root_span.score_trace(
+                            name="criteria_coverage",
+                            value=coverage,
+                            comment="Compliance with book-specific criteria (1-5) — separate from quality",
+                        )
+                    except Exception as coverage_error:
+                        scores_data["criteria_coverage"] = None
+                        logger.warning(
+                            "criteria_coverage_failed",
+                            error=str(coverage_error),
+                            book_title=exact_title,
+                        )
 
                 logger.info(
                     "eval_scoring_complete",

--- a/evaluation/trend_report.md
+++ b/evaluation/trend_report.md
@@ -1,13 +1,13 @@
 # StoryLand AI - Evaluation Trends
 
-**Report Generated:** 2026-07-21 01:17:33
+**Report Generated:** 2026-07-21 01:52:42
 **Period:** Last 30 days
 **Total Evaluation Runs:** 1
 
 ## Overview
 
 - **Total Test Cases Evaluated:** 18
-- **Latest Evaluation:** 2026-07-21T01:17:32.923787
+- **Latest Evaluation:** 2026-07-21T01:52:42.502940
 
 ## Recent Evaluations
 

--- a/tests/unit/test_llm_scorer.py
+++ b/tests/unit/test_llm_scorer.py
@@ -391,3 +391,59 @@ class TestBuildScoringPromptWithExpectedOutput:
             expected_output=None,
         )
         assert "REFERENCE EXAMPLE" not in prompt
+
+
+class TestCriteriaCoverageSplit:
+    """MYS-586: compliance is scored separately from quality."""
+
+    def _criteria(self):
+        return {
+            "book_relevance": "Must include the Limestone start and Freeport",
+            "geographical_accuracy": "Route must follow US-1 south",
+        }
+
+    def test_coverage_prompt_lists_criteria_and_compliance_framing(self):
+        from evaluation.tools.llm_scorer import _build_coverage_prompt
+
+        prompt = _build_coverage_prompt(
+            "The Long Walk", "Stephen King", self._criteria(), {"cities": []}
+        )
+        assert "COMPLIANCE check" in prompt
+        assert "Limestone start" in prompt
+        assert "US-1 south" in prompt
+        assert "do not judge overall quality" in prompt
+        assert "criteria_coverage" in prompt
+
+    def test_coverage_model_bounds(self):
+        from evaluation.tools.llm_scorer import CriteriaCoverage
+
+        assert CriteriaCoverage(criteria_coverage=5).criteria_coverage == 5
+        with pytest.raises(ValidationError):
+            CriteriaCoverage(criteria_coverage=6)
+        with pytest.raises(ValidationError):
+            CriteriaCoverage(criteria_coverage=0)
+
+    def test_quality_prompt_without_qc_has_no_requirement_blocks(self):
+        # The itinerary runner no longer passes quality_criteria to the
+        # quality judge — this is what the ablation-B configuration looks
+        # like, and what run_scheduled_eval now produces.
+        prompt = _build_scoring_prompt(
+            book_title="The Long Walk",
+            author="Stephen King",
+            input_text="The Long Walk",
+            itinerary={"cities": []},
+            quality_criteria=None,
+        )
+        assert "Book-specific requirement" not in prompt
+
+    def test_quality_prompt_with_qc_still_injects_for_la_runner(self):
+        # local-atmosphere asserts radius adherence through the injection,
+        # by design — the capability must survive the itinerary-runner split.
+        prompt = _build_scoring_prompt(
+            book_title="The Long Walk",
+            author="Stephen King",
+            input_text="The Long Walk",
+            itinerary={"cities": []},
+            quality_criteria=self._criteria(),
+        )
+        assert "Book-specific requirement" in prompt


### PR DESCRIPTION
## The split (Olga's recommended option 3)

books_v1's book-specific `quality_criteria` no longer feed the quality judge — they're scored separately as **`criteria_coverage`** (1–5, compliance only, visible null on failure, never blended into the quality average). One number carrying two meanings meant a reader couldn't tell which half moved. The local-atmosphere runner keeps its deliberate injection (radius adherence rides on it) — capability preserved, guarded by tests on both sides.

## Re-baseline under the split judge (2 runs, 29793963847 / 29793981815)

| Dataset | Pooled | pairΔ | criteria_coverage |
|---|---:|---:|---:|
| storyland_eval | 4.34 | 0.040 | n/a |
| books_v1 | **3.90** | **0.014** | **2.4 / 2.3** |

books_v1 judge-config arc: 2.88 ±0.40 → 2.94 ±0.16 → 3.90 ±0.014. **The compliance mechanism was the dominant noise source**, not just a level depressor — and the level landed inside the ablation's predicted range. The judge now runs the exact config that matched the second-model reading (+0.07 / 0.45 on the 30 labeled itineraries): books_v1 quality deltas are now as believable as storyland's.

**Revises MYS-560's supporting number:** the with/without-preferences gap shrinks from ~1.2 (compliance-blended) to **~0.3** under the split judge — most of the prod-shape deficit was the mechanism. Still a real ~0.3 on n=5/run, but the quote should be the post-split number.

Interim conservative gates (flagged as judgment, re-derive after ~4 weekly pairs): **storyland ≥ 4.00, books_v1 ≥ 3.55**. Both remain catastrophe detectors.

Also: `evaluation/README.md` gains the **Gate status & caveats** section (both gates loose by construction; judge-trust ≠ gate-trust; geography dimension not evidence-grade; 2026-07 labels are model labels; weekly spot-checks accumulate human anchors).

Full report: `evaluation/calibration/rebaseline_split_2026-07.md` (mechanism section included).

## Tests

879 unit + 10 integration passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)