### PR TITLE
ci(deploy): stage gate migrates against Postgres, not SQLite (MYS-611, infra #43 twin)

### DIFF
--- a/.github/workflows/deploy-ai-prod.yml
+++ b/.github/workflows/deploy-ai-prod.yml
@@ -239,11 +239,18 @@ jobs:
                 backend: {condition: service_healthy}
           YML
           STAGE=(docker compose -p stage -f /tmp/docker-compose.stage.yml)
-          # Timeout re-derived for the pg-backed stack (MYS-611): worst-case
-          # serial chain = db healthy (~15s) → backend boot + alembic on
-          # empty pg (80s ceiling) → frontend (~25s), ai's 80s ceiling in
-          # parallel ≈ 120-175s worst case. 240 keeps ~40% headroom.
-          if "${STAGE[@]}" up -d --wait --wait-timeout 240; then
+          # Timeout derivation (MYS-611 review-corrected — the first version
+          # understated two ceilings). Time-to-verdict ceiling per service is
+          # start_period + retries x interval:
+          #   db       10 + 6x5  = 40s
+          #   ai       30 + 5x10 = 80s   (parallel with db)
+          #   backend  30 + 5x10 = 80s   (after max(db, ai))
+          #   frontend 15 + 5x10 = 65s   (after backend)
+          # Critical path = max(40, 80) + 80 + 65 = 225s. 300 gives ~75s
+          # (~25%) headroom; the gate exits the moment the stack is healthy,
+          # so the ceiling costs nothing on the happy path. If you tune any
+          # start_period/retries/interval above, RE-DO this sum.
+          if "${STAGE[@]}" up -d --wait --wait-timeout 300; then
             echo "Stage PASS: full stack healthy from the images about to ship."
             "${STAGE[@]}" ps
           else

--- a/.github/workflows/deploy-ai-prod.yml
+++ b/.github/workflows/deploy-ai-prod.yml
@@ -167,6 +167,21 @@ jobs:
           # a non-empty dummy so the fail-closed gateway check (MYS-446)
           # passes AND stays enforced.
           services:
+            # MYS-611: same engine+major as prod (postgres:16-alpine) so the
+            # backend's alembic migrations validate against the PROD dialect,
+            # not SQLite. Fresh volume every run — no prod data.
+            db:
+              image: postgres:16-alpine
+              environment:
+                - POSTGRES_USER=storyland
+                - POSTGRES_PASSWORD=stage-dummy
+                - POSTGRES_DB=storyland
+              healthcheck:
+                test: ["CMD-SHELL", "pg_isready -U storyland -d storyland"]
+                interval: 5s
+                timeout: 5s
+                retries: 6
+                start_period: 10s
             storyland-ai:
               image: ghcr.io/o-ostrovskiy/storyland-ai:prod
               environment:
@@ -194,11 +209,10 @@ jobs:
                 start_period: 30s
             backend:
               image: ghcr.io/o-ostrovskiy/storyland-backend:prod
-              volumes: ["/app/data"]
               environment:
                 - PORT=8090
                 - UPSTREAM_URL=http://storyland-ai:8080
-                - DATABASE_URL=sqlite+aiosqlite:////app/data/storyland.db
+                - DATABASE_URL=postgresql+asyncpg://storyland:stage-dummy@db:5432/storyland
                 - JWT_SECRET=stage-dummy
                 - CORS_ORIGINS=http://localhost:18080
                 - INTERNAL_API_SECRET=stage-dummy
@@ -211,6 +225,7 @@ jobs:
                 start_period: 30s
               depends_on:
                 storyland-ai: {condition: service_healthy}
+                db: {condition: service_healthy}
             frontend:
               image: ghcr.io/o-ostrovskiy/storyland-frontend:prod
               environment: ["BACKEND_URL=http://backend:8090"]
@@ -224,6 +239,10 @@ jobs:
                 backend: {condition: service_healthy}
           YML
           STAGE=(docker compose -p stage -f /tmp/docker-compose.stage.yml)
+          # Timeout re-derived for the pg-backed stack (MYS-611): worst-case
+          # serial chain = db healthy (~15s) → backend boot + alembic on
+          # empty pg (80s ceiling) → frontend (~25s), ai's 80s ceiling in
+          # parallel ≈ 120-175s worst case. 240 keeps ~40% headroom.
           if "${STAGE[@]}" up -d --wait --wait-timeout 240; then
             echo "Stage PASS: full stack healthy from the images about to ship."
             "${STAGE[@]}" ps


### PR DESCRIPTION
Twin of storyland-infrastructure#43 (keep-in-sync rule), closing [MYS-611](https://linear.app/mystoryland/issue/MYS-611): the stage gate's alembic run now executes against `postgres:16-alpine` — the same engine+major as prod — via `postgresql+asyncpg`, instead of SQLite. Fresh volume per run, zero prod data, `pg_isready`-gated in the `depends_on` chain.

**Timeout re-derived.** Per-service time-to-verdict ceiling = `start_period + retries × interval`: db `10+6×5` = **40s** (parallel with ai), ai `30+5×10` = **80s**, backend **80s** (after `max(db, ai)`), frontend `15+5×10` = **65s**. Critical path = `max(40, 80) + 80 + 65` = **225s**; `--wait-timeout` raised **240 → 300** for ~25% headroom, free on the happy path. This twin carries the full working rather than a bare ceiling — the point of recording the arithmetic is that the next person can check it.

## Docs

Workflow header + stage-step comments updated in the same diff. The runbook-level statement of what the gate covers lives in infra's `deploy/README.md` (updated in #43), since that is where a reader forms the "are migrations validated?" inference for the whole deploy path.

## Verification

YAML parses, embedded stage compose extracted and parsed standalone, step script passes `bash -n`. Live proof rides the first forward ai CI deploy.

---
*Description corrected by the Engineering Lead post-merge, 2026-07-21. The original body carried the **first, wrong** timeout derivation ("~120–175 s worst case against the unchanged 240 s ceiling") — the arithmetic this PR was held over at r1. Fixed in `bee948a`'s in-file comment but not here, leaving the merge record asserting numbers already established as false.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)