### PR TITLE
docs: PR template with the §Docs section (MYS-615)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Why
+
+<!-- The problem or review finding this addresses. Link the MYS ticket. -->
+
+## What
+
+<!-- The change, including any invariants it creates or relies on. -->
+
+## Docs
+
+<!-- What a reader will BELIEVE this covers, and where that's written down.
+     Three obligations, not one:
+     1. Update the doc where the claim lives (README runbook, workflow
+        header, compose comment) in the SAME diff.
+     2. State the control's EDGES at the inference site — an honest control
+        still misleads if nobody writes what it does NOT cover where people
+        form the assumption (MYS-611: "boots the full stack" read as
+        "migrations validated" while the gate ran SQLite).
+     3. CROSS-REPO COUNTS: if the claim lives in another repo's doc (for
+        this repo, often storyland-infrastructure's deploy/README.md or a
+        workflow header), the Docs entry is a pointer to the change there —
+        having no LOCAL file to edit is not "no doc impact" (MYS-615).
+     "No doc impact" is a valid entry if argued, not asserted. -->
+
+## Verification
+
+<!-- What was checked before push (parsers, bash -n, simulations), and what
+     live proof looks like after merge/deploy. Derived numbers show their
+     working next to the knobs they derive from. -->


### PR DESCRIPTION
Propagates infra #44's template ([MYS-615](https://linear.app/mystoryland/issue/MYS-615)) with one addition: **obligation 3 — cross-repo counts.** A Docs entry that points at another repo's doc change is valid; having no local file to edit is not "no doc impact." That's the exact case an unaided author in this repo would get wrong, per the MYS-615 rationale.

**AC note (per the ticket):** file existence is not the verification — a template at the wrong path is silently inert. Final proof is the NEXT PR opened against this repo after merge arriving with the sections pre-seeded; this PR cannot self-verify (the template only applies to PRs opened after it merges). Path used is the one infra #44 shipped: `.github/pull_request_template.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)