### PR TITLE
fix(deploy): frontend stage healthcheck targets 127.0.0.1 (infra #48 twin)

### DIFF
--- a/.github/workflows/deploy-ai-prod.yml
+++ b/.github/workflows/deploy-ai-prod.yml
@@ -230,7 +230,7 @@ jobs:
               image: ghcr.io/o-ostrovskiy/storyland-frontend:prod
               environment: ["BACKEND_URL=http://backend:8090"]
               healthcheck:
-                test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:80/"]
+                test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:80/"]
                 interval: 10s
                 timeout: 5s
                 retries: 5


### PR DESCRIPTION
## Why

Twin of storyland-infrastructure#48: the stage gate's first-ever execution caught the frontend healthcheck failing — busybox `wget` resolves `localhost` to `::1` with no IPv4 fallback, and the frontend nginx listens IPv4-only (the image's enable-IPv6 script is overwritten by envsubst before nginx starts). Reproduced and fix-verified inside the actual built image.

## What

One token in the stage heredoc: `localhost` → `127.0.0.1` in the frontend healthcheck. Backend/ai checks untouched (python urllib falls back to IPv4 — why only frontend failed).

## Docs

No claim changes; the heredoc's keep-in-sync note covers it. Cross-repo: canonical fix is infra #48 (prod compose + reusable workflow heredoc).

## Verification

Verified inside the image (`localhost` refused / `127.0.0.1` 200). The full dry-run re-execution rides infra #48's PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)