### PR TITLE
chore(deploy): normalize loopback healthchecks to 127.0.0.1 + gitignore .env* (clean reopen of #242)

### DIFF
--- a/.github/workflows/deploy-ai-prod.yml
+++ b/.github/workflows/deploy-ai-prod.yml
@@ -202,7 +202,7 @@ jobs:
                 - REQUIRE_GATEWAY_SECRET=true
                 - LOG_LEVEL=INFO
               healthcheck:
-                test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/api/v1/health')"]
+                test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/api/v1/health')"]
                 interval: 10s
                 timeout: 10s
                 retries: 5
@@ -218,7 +218,7 @@ jobs:
                 - INTERNAL_API_SECRET=stage-dummy
                 - LOG_LEVEL=INFO
               healthcheck:
-                test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8090/api/v1/health')"]
+                test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8090/api/v1/health')"]
                 interval: 10s
                 timeout: 10s
                 retries: 5

--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,7 @@ site/
 *.tar.gz
 *.rar
 AGENTS.md
+
+# Any .env variant, incl. backups (.env.bak-*): a live-secret file in the
+# worktree is one careless git-add from a public-repo leak (2026-07-21).
+.env*


### PR DESCRIPTION
## Why

Reopens #242's change cleanly. #242 was closed because `git add -A` swept an untracked local `.env` backup into the commit — on this public repo. Takedown (branch delete + PR close) is done but does **not** purge GitHub's PR refs; the leaked `GOOGLE_API_KEY` and `LANGFUSE_SECRET_KEY` are being rotated, which is the real containment.

## What

- The original two-token healthcheck normalization (stage heredoc: `localhost` → `127.0.0.1`), staged **explicitly by path** this time.
- `.gitignore` gains `.env*` — closing the class: no .env variant in this worktree can ever be committed again, however careless the add.

## Docs

The gitignore comment records the incident and the rule inline. Cross-repo: infra #49 is the twin for the normalization; the incident postmortem lives in the session record and the runner trap-list (reviewer's).

## Verification

YAML parses; `git diff --cached --name-only` confirmed exactly two files staged before commit; `git check-ignore` will confirm any future `.env.bak-*` is uncommittable. Stage gate exercises the healthcheck change on the next forward ai CI deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)