### PR TITLE
chore: gitignore every .env variant (MYS-623)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,16 @@
 # ========================================
 # Environment & Secrets
 # ========================================
-.env
-.env.local
-.env.*.local
+# Prefix-match EVERY .env variant. MYS-623 (2026-07-21): a local backup named
+# `.env.bak-2026-07-20` was swept into a commit on this PUBLIC repo by
+# `git add -A`, exposing a live GOOGLE_API_KEY and LANGFUSE_SECRET_KEY. It
+# matched none of the patterns below it -- not `.env` (exact), not
+# `.env.local` (exact), not `.env.*.local` (needs the .local suffix), and not
+# `*.bak` (needs a .bak SUFFIX; that file ended in `-2026-07-20`). Enumerating
+# suffixes cannot work, because the next backup will be named something else.
+# Match the prefix. Already-tracked files are unaffected by gitignore, so a
+# committed .env*.example stays tracked.
+.env*
 *.pem
 *.key
 service-account*.json


### PR DESCRIPTION
## Why

[MYS-623](https://linear.app/mystoryland/issue/MYS-623): on 2026-07-21 a local backup file `.env.bak-2026-07-20` was swept into a commit on this **public** repo by `git add -A`, exposing a live `GOOGLE_API_KEY` and `LANGFUSE_SECRET_KEY`. Rotation is the containment; this is the recurrence guard.

Split out of #243 so it can land **now**. #243 also edits `.github/workflows/deploy-ai-prod.yml`, and that file cannot be merged or branch-updated by this App (`workflows` scope) while its branch is behind — so the guard was stuck behind an unrelated permission boundary. The guard is the security-relevant half; it should not wait.

## What

One line in the Environment & Secrets section: `.env*` replacing the three narrower patterns.

🔴 **Why the existing patterns didn't catch it — this is the interesting part.** The section already looked like it covered env files. It didn't cover the one that leaked:

| pattern | why `.env.bak-2026-07-20` escaped |
|---|---|
| `.env` | exact name only |
| `.env.local` | exact name only |
| `.env.*.local` | requires a `.local` suffix |
| `*.bak` | requires a `.bak` **suffix**; this ended in `-2026-07-20` |

Four patterns aimed at exactly this class, and the file threaded all of them. **Enumerating suffixes cannot work, because the next backup will be named something nobody predicted.** `.env*` matches by prefix instead, which is the property that actually holds.

Already-tracked files are unaffected by `.gitignore`, so any committed `.env*.example` stays tracked — no existing file is dropped.

## Docs

The rationale is inline in `.gitignore` at the point of use, including the escape table above, so the next person who considers "tidying" `.env*` back into named patterns sees why that would reopen the hole. No runbook claim changes. Cross-repo: the same prefix guard belongs in the sibling repos — filed separately rather than smuggled in here.

## Verification

Diff is one file, one hunk plus its comment — verified by opening the PR diff before merge. Real proof after merge: `git check-ignore -v .env.bak-2026-07-20` in a fresh clone should report the `.env*` rule, and `git status` with such a file present should show nothing. That is a one-command check, not an inference from the pattern.

🤖 Opened by the Engineering Lead, 2026-07-21