### PR TITLE
fix(ci): sync-keys pre-flight self-diagnoses; close-SSH gated on role assumption

### DIFF
--- a/.github/workflows/sync-env-keys.yml
+++ b/.github/workflows/sync-env-keys.yml
@@ -48,9 +48,13 @@ jobs:
           LPK: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
         run: |
           [ -n "$GK" ] && [ -n "$LSK" ] && [ -n "$LPK" ] || { echo "::error::a secret is empty"; exit 1; }
-          G=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H "Content-Type: application/json" \
+          GRESP=$(curl -s -w "\n%{http_code}" -X POST -H "Content-Type: application/json" \
               -H "x-goog-api-key: $GK" -d '{"contents":[{"parts":[{"text":"hi"}]}]}' \
               "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite-preview:generateContent")
+          G=$(printf '%s' "$GRESP" | tail -1)
+          # On failure, surface Google's own reason (no secret material in it)
+          # so a red run self-diagnoses: API-not-enabled vs restriction vs bad key.
+          [ "$G" = "200" ] || printf '%s' "$GRESP" | head -n -1 | head -c 600
           L=$(curl -s -o /dev/null -w "%{http_code}" -u "$LPK:$LSK" https://us.cloud.langfuse.com/api/public/projects)
           echo "generateContent: $G · langfuse: $L"
           [ "$G" = "200" ] || { echo "::error::GOOGLE_API_KEY in GitHub secrets is INVALID (generateContent $G) — fix the secret, box untouched"; exit 1; }
@@ -63,6 +67,7 @@ jobs:
           [ -n "$AWS_DEPLOY_ROLE_ARN" ] || { echo "::error::Repo variable AWS_DEPLOY_ROLE_ARN is not set"; exit 1; }
 
       - name: Assume deploy role (OIDC)
+        id: aws
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
@@ -116,7 +121,10 @@ jobs:
           '
 
       - name: Close SSH (at-rest state)
-        if: always()
+        # Only meaningful if AWS credentials were configured (i.e., we got at
+        # least as far as the role assumption) — otherwise the port was never
+        # opened and this step would just error with NoRegion noise.
+        if: always() && steps.aws.conclusion == 'success' 
         run: |
           aws lightsail close-instance-public-ports \
             --instance-name storyland \


### PR DESCRIPTION
## Why

Run 1 of the sync workflow worked as designed (bad `GOOGLE_API_KEY` secret caught pre-flight, box untouched) but exposed two rough edges: the 403 came with no reason (the body — which contains no secret material — distinguishes API-not-enabled vs key-restriction vs invalid), and the `always()` close-SSH step errored `NoRegion` despite the port never having been opened, because it ran before credentials existed.

## What

Pre-flight now prints Google's error body (≤600 chars) on non-200, so a red run names its own cause. Close-SSH gains `id`-based gating: runs only if the role assumption succeeded — exactly when a port could have been opened.

## Docs

Workflow header unchanged — safety properties identical; this is observability of failure, not behavior change.

## Verification

YAML parses. Next red pre-flight (if any) shows the reason inline; next green run is unchanged. Close-step gating is visible in the run's skipped/executed step list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)