### PR TITLE
fix(ci): sync GOOGLE_BOOKS_API_KEY too (same-key convention)

### DIFF
--- a/.github/workflows/sync-env-keys.yml
+++ b/.github/workflows/sync-env-keys.yml
@@ -52,7 +52,12 @@ jobs:
               -H "x-goog-api-key: $GK" -d '{"contents":[{"parts":[{"text":"hi"}]}]}' \
               "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite-preview:generateContent")
           L=$(curl -s -o /dev/null -w "%{http_code}" -u "$LPK:$LSK" https://us.cloud.langfuse.com/api/public/projects)
-          echo "generateContent: $G · langfuse: $L"
+          # Books: informational only, never gates — the Books API has ambient
+          # 503 flakiness (fallback exists for it), and until the key's project
+          # has Books API enabled this prints 403 SERVICE_DISABLED. The value
+          # is still synced either way; this line makes the state visible.
+          B=$(curl -s -o /dev/null -w "%{http_code}" "https://www.googleapis.com/books/v1/volumes?q=intitle:test&maxResults=1&key=$GK")
+          echo "generateContent: $G · langfuse: $L · books(informational): $B"
           [ "$G" = "200" ] || { echo "::error::GOOGLE_API_KEY in GitHub secrets is INVALID (generateContent $G) — fix the secret, box untouched"; exit 1; }
           [ "$L" = "200" ] || { echo "::error::LANGFUSE key pair in GitHub secrets is INVALID (auth $L) — fix the secrets, box untouched"; exit 1; }
 
@@ -110,7 +115,11 @@ jobs:
             IFS= read -r GK; IFS= read -r LSK; IFS= read -r LPK
             cd ~/storyland/storyland-infrastructure/deploy
             cp .env.prod .env.prod.pre-sync && chmod 600 .env.prod.pre-sync
-            sed -i "s|^GOOGLE_API_KEY=.*|GOOGLE_API_KEY=$GK|; s|^LANGFUSE_SECRET_KEY=.*|LANGFUSE_SECRET_KEY=$LSK|; s|^LANGFUSE_PUBLIC_KEY=.*|LANGFUSE_PUBLIC_KEY=$LPK|" .env.prod
+            # GOOGLE_BOOKS_API_KEY gets the SAME value — the box convention is
+            # one Google key for both Gemini and Books (verified 2026-07-21:
+            # the two vars held an identical value). Rotating only one var
+            # orphans the other on a dead key.
+            sed -i "s|^GOOGLE_API_KEY=.*|GOOGLE_API_KEY=$GK|; s|^GOOGLE_BOOKS_API_KEY=.*|GOOGLE_BOOKS_API_KEY=$GK|; s|^LANGFUSE_SECRET_KEY=.*|LANGFUSE_SECRET_KEY=$LSK|; s|^LANGFUSE_PUBLIC_KEY=.*|LANGFUSE_PUBLIC_KEY=$LPK|" .env.prod
             docker compose -f docker-compose.prod.yml --env-file .env.prod --env-file .env.release up -d --no-deps --wait storyland-ai
             docker compose -f docker-compose.prod.yml ps storyland-ai --format "{{.Name}} {{.Status}}"
           '


### PR DESCRIPTION
## Why

Caught by Olga's question mid-incident: `.env.prod` uses one Google key for both `GOOGLE_API_KEY` and `GOOGLE_BOOKS_API_KEY` (verified identical), but the sync workflow rotated only the first — leaving Books keyed calls on the deleted key (hard 400, vs the ambient 503 the Jul-18 fallback was built for).

## What

The remote `sed` now writes the same new value into both Google vars, with the convention documented at the site. Pre-flight gains an **informational** Books line (never gates — Books has documented ambient 503 flakiness, and prints 403 SERVICE_DISABLED until the key's project enables the Books API; the sync is correct to proceed regardless).

## Docs

Convention (one key, both vars) now stated where the rotation implements it. The Books-API-enable step is Olga's console click (project of the AI Studio key → enable Books API) — noted in the incident thread; candidate for the infra README's next pass.

## Verification

YAML parses. Next dispatched run: pre-flight prints all three codes; post-run, a keyed Books call from the box distinguishes 200/503-ambient (good) from 400 (would mean the sed missed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)