### PR TITLE
docs: PR-body sections rule in claude.md (agent-facing)

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -68,3 +68,14 @@ Documentation files:
   ```
   Expected: No matches (0 results).
 - When adding new API integrations, add their auth headers/parameters to VCR filters and regenerate cassettes with `--vcr-record=all`
+
+## Pull request bodies (enforced by a required check)
+
+Every PR body MUST contain the four sections `## Why`, `## What`, `## Docs`,
+`## Verification` — the required status check "Require Why/What/Docs/
+Verification" reds the PR otherwise (MYS-617). Templates do NOT apply to
+agent-opened PRs (`gh pr create --body` and the API bypass them), so include
+the headings explicitly. Revert-titled PRs and Dependabot are exempt.
+§Docs means: what will a reader believe this change covers, and where is that
+written down — a pointer to another repo's doc counts, and "no doc impact"
+is valid if argued, not asserted.


### PR DESCRIPTION
## Why

The "Require Why/What/Docs/Verification" check became required on main today, but this repo's claude.md — the first thing agent sessions read (claude/issue-N flows included) — didn't mention it. An uninformed agent's first contact would be an unexplained red check.

## What

One agent-facing section appended to claude.md: the four headings, the templates-don't-apply-to---body fact, the exemptions, and what §Docs means. (File is lowercase claude.md in this repo — the cross-repo copy script assumed CLAUDE.md and macOS's case-insensitive filesystem hid the mismatch from everything except git.)

## Docs

This PR is the doc; same block already PR'd to the other three repos' CLAUDE.md.

## Verification

This PR's own body passes the check it documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)