### PR TITLE
ci(security): stop injecting live keys into the PR job + pip-audit gate + dependabot (MYS-440)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# MYS-440 scope 2: automated dependency update PRs. Both ecosystems weekly —
+# this repo's deps are hash-locked (requirements*.lock), so a Dependabot pip
+# PR still needs a relock before merge (see CLAUDE.md's dependency section);
+# its value here is the NOTIFICATION that a floor moved for a security fix.
+# Dependabot PRs are exempt from the PR-body-sections check by author.
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,16 +24,11 @@ jobs:
   integration-tests:
     name: Integration Tests
     if: ${{ !inputs.skip-tests }}
+    # MYS-440 AC-1: the VCR-replay workflow takes no secrets (it replays
+    # offline on the conftest dummy key) and needs only read access.
     permissions:
-      contents: write
-      pull-requests: write
-      issues: write
+      contents: read
     uses: ./.github/workflows/integration-tests.yml
-    secrets:
-      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-      LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
-      LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
-      LANGFUSE_HOST: ${{ secrets.LANGFUSE_HOST }}
 
 # NOTE: This pipeline is a compile/test check only — it does NOT deploy. The app
 # runs on a single Lightsail box (self-hosted, see storyland-infrastructure/deploy/);

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,29 +1,29 @@
 name: Integration Tests
 
+# MYS-440 AC-1: the VCR-replay job takes NO secrets. It replays cassettes
+# offline against the dummy key tests/integration/conftest.py already
+# provides, so a live GOOGLE_API_KEY here bought nothing — while a same-repo
+# branch PR could edit the Makefile/conftest to exfiltrate it. Live-key
+# integration lives ONLY in integration-live-tests.yml (manual), and the
+# re-record job below (manual) which genuinely needs the real API.
+# Do NOT convert anything here to pull_request_target — that would hand
+# secrets to fork PRs, which the current triggers correctly do not.
 on:
   push:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
   workflow_dispatch: # Allow manual trigger
-  workflow_call:
-    secrets:
-      GOOGLE_API_KEY:
-        required: true
-      LANGFUSE_SECRET_KEY:
-        required: false
-      LANGFUSE_PUBLIC_KEY:
-        required: false
-      LANGFUSE_HOST:
-        required: false
+  workflow_call: {}
 
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
+    # Least privilege (MYS-440): read-only. The old issues:/pull-requests:
+    # write existed for a boilerplate PR comment, removed with it — a job
+    # that runs PR-authored code should hold no write scopes.
     permissions:
       contents: read
-      pull-requests: write
-      issues: write
 
     steps:
       - name: Checkout repository
@@ -50,13 +50,14 @@ jobs:
           pip install --require-hashes -r requirements-dev.lock
           pip install -e . --no-deps
 
-      - name: Create .env file for tests
+      - name: Create .env file for tests (dummy key — VCR replay is offline)
+        # The explicit dummy matches tests/integration/conftest.py's
+        # setdefault, so the value in play is visible in the job log (AC-1's
+        # "prove it" clause). No LANGFUSE_* lines: absent keys cleanly
+        # disable the tracing plugin (core/types.py Optional fields).
         run: |
-          echo "GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }}" > .env
+          echo "GOOGLE_API_KEY=test-key-for-vcr-replay" > .env
           echo "USE_DATABASE=false" >> .env
-          echo "LANGFUSE_SECRET_KEY=${{ secrets.LANGFUSE_SECRET_KEY }}" >> .env
-          echo "LANGFUSE_PUBLIC_KEY=${{ secrets.LANGFUSE_PUBLIC_KEY }}" >> .env
-          echo "LANGFUSE_HOST=${{ secrets.LANGFUSE_HOST }}" >> .env
 
       - name: Run integration tests (VCR cassettes)
         run: |
@@ -71,22 +72,6 @@ jobs:
             .pytest_cache/
             tests/integration/cassettes/
           retention-days: 7
-
-      - name: Comment test results on PR
-        if: github.event_name == 'pull_request' && always()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const testStatus = '${{ job.status }}';
-            const emoji = testStatus === 'success' ? '✅' : '❌';
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `${emoji} **Integration Tests ${testStatus}**\n\nDefault integration run excludes live API tests (\`real_api\` marker).\nUse manual jobs/targets for live network verification.`
-            });
 
   # Optional: Re-record cassettes (manual trigger only, uses API quota)
   re-record-cassettes:

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -1,0 +1,38 @@
+name: pip-audit
+
+# MYS-440 scope 2: CVE gate on the PROD lock (what the image ships) — the
+# same gate storyland-services runs in its test workflow. Accepted or
+# unfixable CVEs are ignored inline WITH justification + a ticket, and the
+# ignore is removed the moment a fixed version exists and the lock moves
+# past it.
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  pip-audit:
+    name: pip-audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Audit shipped dependencies
+        run: |
+          pip install pip-audit==2.10.1
+          pip-audit --strict --require-hashes -r requirements.lock \
+            --ignore-vuln PYSEC-2026-2447
+            # diskcache 5.6.3 pickle deserialization (CVE-2025-69872 class):
+            # exploitable only with WRITE access to the cache directory on
+            # the box — an attacker with that access has already won. NO
+            # fixed release exists. Accepted risk, tracked on MYS-440/MYS-402
+            # (lockfile PR2); drop this ignore when a fixed version ships.


### PR DESCRIPTION
## Why

MYS-440's reopened residual — the part the ticket calls its only security payload. The `pull_request`-triggered integration job wrote the **live** `GOOGLE_API_KEY` + `LANGFUSE_*` into `.env` while holding `issues: write` / `pull-requests: write`. The suite it runs is offline VCR replay that already uses a dummy key, so the live key bought nothing — and a same-repo branch PR could edit the Makefile/conftest to exfiltrate it. This matters *more* after the MYS-623 rotation: without this change, the freshly-rotated Gemini key would be handed to PR-authored code on the very next PR.

## What

- **`integration-tests.yml`**: the VCR job takes **no secrets** — `.env` gets the explicit dummy (`test-key-for-vcr-replay`, matching conftest's setdefault, visible in the job log per AC-1's "prove it" clause) and no `LANGFUSE_*` lines (absent keys cleanly disable the tracing plugin). Permissions drop to `contents: read`; the boilerplate PR-comment step that justified the write scopes goes with them. `workflow_call` declares no secrets.
- **`ci-cd.yml`**: its call updated to match (no secrets passed, read-only permissions).
- **Live keys stay only in manual paths**: `integration-live-tests.yml` and the `workflow_dispatch`-gated re-record job. Nothing converted to `pull_request_target` (per the ticket — that would hand secrets to fork PRs).
- **`pip-audit.yml`**: CVE gate on `requirements.lock`, same shape as storyland-services'. One justified inline ignore: PYSEC-2026-2447 (diskcache pickle deserialization — needs write access to the cache dir, [no fixed release](https://security.snyk.io/vuln/SNYK-PYTHON-DISKCACHE-15268422)); tracked on MYS-440/MYS-402, removed when a fix ships.
- **`.github/dependabot.yml`**: pip + github-actions, weekly (hash-locked repo, so pip PRs still need a relock — the value is the security-floor notification).

## Docs

Inline comments in each workflow carry the rationale; MYS-440 is the board record. CLAUDE.md's dependency section already documents the relock flow Dependabot PRs must follow — no doc change needed beyond that (argued, not asserted: the only new reader-visible surface is CI behavior, documented where it lives).

## Verification

- AC-1: VCR suite passes locally on the dummy key alone (`10 passed, 4 deselected`); `grep` over the PR-triggered job block shows **zero** `secrets.` references; this PR's own run proves the job goes green without the secrets.
- AC-2 (audit half): `pip-audit --strict --require-hashes -r requirements.lock` run locally — clean with the single documented ignore. Scanner half already landed (gitleaks, ai#250).
- AC-3: live-key testing still available via the manual workflow + re-record job (untouched, dispatch-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)