### PR TITLE
fix(ci): key the Dependabot exemption on PR author, not actor (MYS-617)

### DIFF
--- a/.github/workflows/pr-body-sections.yml
+++ b/.github/workflows/pr-body-sections.yml
@@ -16,7 +16,14 @@ name: PR body sections
 # the check via job-level `if:`. Rollback = revert here (no feature flags),
 # and GitHub's Revert button generates a body with no headings — a required
 # check that gates the rollback lever is worse than the gap it closes; same
-# shape for Dependabot security updates. Job-level `if:` is the safe form:
+# shape for Dependabot security updates. The Dependabot exemption keys on
+# the PR AUTHOR (`github.event.pull_request.user.login`), not
+# `github.actor`: the actor is whoever caused the triggering event, so a
+# maintainer running `gh pr update-branch` on a Dependabot PR (mandatory —
+# branch protection enforces up-to-date branches) fires `synchronize` with
+# the maintainer as actor, and an actor-keyed exemption would run the check
+# for real against Dependabot's body and red it (bit PRs #253–#256,
+# 2026-07-22). Job-level `if:` is the safe form:
 # the workflow still triggers and reports the job as SKIPPED, which
 # satisfies a required status check — unlike a path-filtered workflow that
 # never reports and wedges the PR at "Expected" (the reason behind the
@@ -50,7 +57,7 @@ jobs:
     name: Require Why/What/Docs/Verification
     # Exemptions — see header. Skipped satisfies a required check.
     if: >-
-      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
       !startsWith(github.event.pull_request.title, 'Revert ')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Why

The Dependabot exemption in the required PR-body-sections check keyed on `github.actor`, which is the actor of the **triggering event**, not the PR author. Branch protection enforces up-to-date branches, so a maintainer must run `gh pr update-branch` on Dependabot PRs — and that `synchronize` event carries the maintainer as actor. The exemption stopped applying, the check ran for real against Dependabot's sectionless body, and PRs #253–#256 went red on 2026-07-22 (worked around by hand-appending the four sections to those bodies).

## What

- `.github/workflows/pr-body-sections.yml`: the job-level `if:` now keys on `github.event.pull_request.user.login != 'dependabot[bot]'` — the PR author, stable across every `pull_request` event regardless of who triggered it. The Revert-title exemption is unchanged.
- Workflow header: the EXEMPTIONS paragraph now explains the author-vs-actor distinction and records the #253–#256 incident.

## Docs

A reader will believe Dependabot PRs are exempt from this check **by author** — which is exactly what `.github/dependabot.yml` already says ("exempt from the PR-body-sections check by author"); this change makes that note true as written, so it needs no edit. The authoritative explanation lives in the workflow header comment, updated here. No README/ARCHITECTURE impact: the workflow's behavior toward human- and agent-opened PRs is unchanged.

## Verification

- `ruby -ryaml` parses the workflow cleanly.
- Unit tests: 879 passed. Integration: 11 passed, 3 failed in `test_langfuse_integration.py` — verified identical failures on `main` (local Langfuse credentials return 401; pre-existing environment issue, unrelated to this CI-YAML-only change).
- Logic check: `github.event.pull_request.user.login` is populated on all four trigger types (`opened`, `edited`, `reopened`, `synchronize`), so Dependabot PRs now skip the job (reported SKIPPED, which satisfies the required check) on every event, including maintainer-triggered `update-branch` synchronizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)