### PR TITLE
test(integration): Langfuse tests use DEFAULT_MODEL_NAME — gemini-2.0-flash-lite retired

### DIFF
--- a/tests/integration/cassettes/TestLangfuseWithRealWorkflow.test_book_metadata_workflow_with_langfuse.yaml
+++ b/tests/integration/cassettes/TestLangfuseWithRealWorkflow.test_book_metadata_workflow_with_langfuse.yaml
@@ -8,36 +8,35 @@ interactions:
       Content-Type:
       - application/json
       user-agent:
-      - google-genai-sdk/1.60.0 gl-python/3.12.6 google-adk/1.23.0 gl-python/3.12.6
+      - google-genai-sdk/2.11.0 gl-python/3.12.6 google-adk/2.5.0 gl-python/3.12.6
       x-goog-api-client:
-      - google-genai-sdk/1.60.0 gl-python/3.12.6 google-adk/1.23.0 gl-python/3.12.6
+      - google-genai-sdk/2.11.0 gl-python/3.12.6 google-adk/2.5.0 gl-python/3.12.6
     method: post
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-lite:generateContent
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite:generateContent
   response:
     body:
       string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
-        [\n          {\n            \"text\": \"```json\\n{\\n  \\\"title\\\": \\\"1984\\\",\\n
-        \ \\\"author\\\": \\\"George Orwell\\\",\\n  \\\"publication_year\\\": 1949,\\n
-        \ \\\"genre\\\": \\\"Dystopian Fiction\\\",\\n  \\\"isbn\\\": \\\"978-0451524935\\\"\\n}\\n```\"\n
+        [\n          {\n            \"text\": \"**Title:** 1984\\n**Author:** George
+        Orwell\\n**Original Publication Year:** 1949\\n**Genre:** Dystopian, Social
+        Science Fiction\\n**Agent ID:** book_metadata_pipeline\",\n            \"thoughtSignature\":
+        \"EjQKMgERTTIP6gM2ayjNneA2Qz6xjndwPPWVLP8UnERAoO/TUWkFDw4IcJbitcEsOr5oGaCh\"\n
         \         }\n        ],\n        \"role\": \"model\"\n      },\n      \"finishReason\":
-        \"STOP\",\n      \"avgLogprobs\": -0.052161566198688662\n    }\n  ],\n  \"usageMetadata\":
-        {\n    \"promptTokenCount\": 39,\n    \"candidatesTokenCount\": 73,\n    \"totalTokenCount\":
-        112,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
-        \       \"tokenCount\": 39\n      }\n    ],\n    \"candidatesTokensDetails\":
-        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 73\n
-        \     }\n    ]\n  },\n  \"modelVersion\": \"gemini-2.0-flash-lite\",\n  \"responseId\":
-        \"NPS9aba3LpSZ_uMPzcuS8QQ\"\n}\n"
+        \"STOP\",\n      \"index\": 0\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\":
+        41,\n    \"candidatesTokenCount\": 46,\n    \"totalTokenCount\": 87,\n    \"promptTokensDetails\":
+        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 41\n
+        \     }\n    ],\n    \"serviceTier\": \"standard\"\n  },\n  \"modelVersion\":
+        \"gemini-3.1-flash-lite\",\n  \"responseId\": \"EzBgaoz6GIfXjMcP8IST0Qo\"\n}\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Sat, 21 Mar 2026 01:28:21 GMT
+      - Wed, 22 Jul 2026 02:50:59 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=833
+      - gfet4t7; dur=501
       Transfer-Encoding:
       - chunked
       Vary:
@@ -53,7 +52,7 @@ interactions:
       X-XSS-Protection:
       - '0'
       content-length:
-      - '829'
+      - '819'
     status:
       code: 200
       message: OK

--- a/tests/integration/test_langfuse_integration.py
+++ b/tests/integration/test_langfuse_integration.py
@@ -16,6 +16,7 @@ from google.adk.runners import Runner
 from google.adk.agents import LlmAgent, SequentialAgent
 from google.genai import types
 
+from common.config import DEFAULT_MODEL_NAME
 from plugins.langfuse_plugin import LangfusePlugin
 from services.session_service import create_session_service
 
@@ -52,7 +53,7 @@ class TestLangfusePluginIntegration:
         """Create a simple LLM agent for testing."""
         return LlmAgent(
             name="test_agent",
-            model="gemini-2.0-flash-lite",
+            model=DEFAULT_MODEL_NAME,
             instruction="You are a helpful assistant. Respond briefly to user questions.",
         )
 
@@ -210,7 +211,7 @@ class TestLangfuseWithRealWorkflow:
         # not the specific agent under test.
         pipeline = LlmAgent(
             name="book_metadata_pipeline",
-            model="gemini-2.0-flash-lite",
+            model=DEFAULT_MODEL_NAME,
             instruction="You are a helpful assistant. Respond briefly.",
         )
 
@@ -279,13 +280,13 @@ class TestLangfuseWithRealWorkflow:
         # Create nested agents
         agent1 = LlmAgent(
             name="agent1",
-            model="gemini-2.0-flash-lite",
+            model=DEFAULT_MODEL_NAME,
             instruction="Say 'Agent 1 complete' and nothing else.",
         )
 
         agent2 = LlmAgent(
             name="agent2",
-            model="gemini-2.0-flash-lite",
+            model=DEFAULT_MODEL_NAME,
             instruction="Say 'Agent 2 complete' and nothing else.",
         )
 


### PR DESCRIPTION
## Why
Google retired `gemini-2.0-flash-lite` (the API now returns 404 NOT_FOUND for it), so the two `real_api` Langfuse integration tests fail on any machine with valid credentials — first seen as noise in the PR #257 verification run. The failures presented alongside stale-credential 401s (the MYS-440 rotation), which masked the model pin as the second root cause.

## What
- `tests/integration/test_langfuse_integration.py`: the four hardcoded `model="gemini-2.0-flash-lite"` literals become `model=DEFAULT_MODEL_NAME` (imported from `common.config`), so these tests track the shipped model and can never pin a retired one again.
- Re-recorded the one VCR cassette (`TestLangfuseWithRealWorkflow.test_book_metadata_workflow_with_langfuse`) against the current model — the old cassette's requests no longer match. Scrub filters applied as configured; grepped the new cassette for `AIza`/`sk-lf-`/`pk-lf-` patterns: clean.

## Docs
No doc impact, argued: no README or evaluation doc names gemini-2.0-flash-lite for these tests; the model-selection story lives in common/config.py (DEFAULT_MODEL_NAME) and .env.example, both already on gemini-3.1-flash-lite since #228.

## Verification
- `pytest tests/integration/test_langfuse_integration.py`: 6 passed (was 3 failed on main with valid local creds).
- `pytest tests/unit`: 879 passed.
- Cassette secret scan: 0 matches for key patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)