### PR TITLE
fix(ci): split manual re-record job out of the reusable integration-tests workflow (MYS-440 follow-up)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,7 +5,8 @@ name: Integration Tests
 # provides, so a live GOOGLE_API_KEY here bought nothing — while a same-repo
 # branch PR could edit the Makefile/conftest to exfiltrate it. Live-key
 # integration lives ONLY in integration-live-tests.yml (manual), and the
-# re-record job below (manual) which genuinely needs the real API.
+# manual re-record workflow (re-record-cassettes.yml) which genuinely
+# needs the real API.
 # Do NOT convert anything here to pull_request_target — that would hand
 # secrets to fork PRs, which the current triggers correctly do not.
 on:
@@ -73,80 +74,8 @@ jobs:
             tests/integration/cassettes/
           retention-days: 7
 
-  # Optional: Re-record cassettes (manual trigger only, uses API quota)
-  re-record-cassettes:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
-    permissions:
-      contents: write
-      pull-requests: write
+# The manual re-record job lives in re-record-cassettes.yml. It cannot live
+# here: workflow_call validates the permissions of EVERY job in the called
+# file — even if-skipped ones — so its write scopes broke ci-cd.yml's
+# read-only call at startup.
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: '3.12'
-          cache: 'pip'
-
-      - name: Create virtual environment
-        run: |
-          python -m venv .venv
-          echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          # Hash-locked install (same tree the unit workflow tests) — a live
-          # resolve here once drifted httpx/vcrpy and broke cassette replay
-          # with behavior the locked env can't reproduce. Editable pkg last,
-          # --no-deps, so the resolver can't re-touch the pinned tree.
-          pip install --require-hashes -r requirements-dev.lock
-          pip install -e . --no-deps
-
-      - name: Create .env file for tests
-        run: |
-          echo "GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }}" > .env
-          echo "USE_DATABASE=false" >> .env
-          echo "LANGFUSE_SECRET_KEY=${{ secrets.LANGFUSE_SECRET_KEY }}" >> .env
-          echo "LANGFUSE_PUBLIC_KEY=${{ secrets.LANGFUSE_PUBLIC_KEY }}" >> .env
-          echo "LANGFUSE_HOST=${{ secrets.LANGFUSE_HOST }}" >> .env
-
-      - name: Delete old cassettes
-        run: |
-          rm -rf tests/integration/cassettes/*
-
-      - name: Re-record VCR cassettes
-        run: |
-          make test-integration-vcr-record
-
-      - name: Upload new cassettes
-        uses: actions/upload-artifact@v7
-        with:
-          name: vcr-cassettes
-          path: tests/integration/cassettes/
-          retention-days: 30
-
-      - name: Create PR with updated cassettes
-        if: success()
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-
-          # Check if there are changes
-          if [[ -n $(git status -s tests/integration/cassettes/) ]]; then
-            git add tests/integration/cassettes/
-            git commit -m "chore: Re-record VCR cassettes for integration tests"
-
-            # Create a new branch
-            BRANCH_NAME="update-vcr-cassettes-$(date +%Y%m%d-%H%M%S)"
-            git checkout -b "$BRANCH_NAME"
-            git push origin "$BRANCH_NAME"
-
-            # Create PR using gh CLI
-            echo "New cassettes recorded. Please create a PR manually or use gh CLI."
-          else
-            echo "No changes to cassettes."
-          fi

--- a/.github/workflows/re-record-cassettes.yml
+++ b/.github/workflows/re-record-cassettes.yml
@@ -1,0 +1,86 @@
+name: Re-record VCR Cassettes
+
+# Manual-only: re-records cassettes against the real API (uses quota) and
+# needs live secrets + write scopes. Split out of integration-tests.yml
+# (MYS-440 follow-up): a workflow_call target is permission-validated on
+# EVERY job it contains — even `if`-skipped ones — so this job's write
+# scopes made ci-cd.yml's read-only call fail at startup.
+on:
+  workflow_dispatch:
+
+jobs:
+  re-record-cassettes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Create virtual environment
+        run: |
+          python -m venv .venv
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # Hash-locked install (same tree the unit workflow tests) — a live
+          # resolve here once drifted httpx/vcrpy and broke cassette replay
+          # with behavior the locked env can't reproduce. Editable pkg last,
+          # --no-deps, so the resolver can't re-touch the pinned tree.
+          pip install --require-hashes -r requirements-dev.lock
+          pip install -e . --no-deps
+
+      - name: Create .env file for tests
+        run: |
+          echo "GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }}" > .env
+          echo "USE_DATABASE=false" >> .env
+          echo "LANGFUSE_SECRET_KEY=${{ secrets.LANGFUSE_SECRET_KEY }}" >> .env
+          echo "LANGFUSE_PUBLIC_KEY=${{ secrets.LANGFUSE_PUBLIC_KEY }}" >> .env
+          echo "LANGFUSE_HOST=${{ secrets.LANGFUSE_HOST }}" >> .env
+
+      - name: Delete old cassettes
+        run: |
+          rm -rf tests/integration/cassettes/*
+
+      - name: Re-record VCR cassettes
+        run: |
+          make test-integration-vcr-record
+
+      - name: Upload new cassettes
+        uses: actions/upload-artifact@v7
+        with:
+          name: vcr-cassettes
+          path: tests/integration/cassettes/
+          retention-days: 30
+
+      - name: Create PR with updated cassettes
+        if: success()
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+          # Check if there are changes
+          if [[ -n $(git status -s tests/integration/cassettes/) ]]; then
+            git add tests/integration/cassettes/
+            git commit -m "chore: Re-record VCR cassettes for integration tests"
+
+            # Create a new branch
+            BRANCH_NAME="update-vcr-cassettes-$(date +%Y%m%d-%H%M%S)"
+            git checkout -b "$BRANCH_NAME"
+            git push origin "$BRANCH_NAME"
+
+            # Create PR using gh CLI
+            echo "New cassettes recorded. Please create a PR manually or use gh CLI."
+          else
+            echo "No changes to cassettes."
+          fi


### PR DESCRIPTION
## Why

Every `CI/CD Pipeline` run on main since #251 merged (8 consecutive runs, first failure 2026-07-22 01:55 UTC, e.g. [run 29906232896](https://github.com/o-ostrovskiy/storyland-ai/actions/runs/29906232896)) fails at **startup** with:

> The nested job 're-record-cassettes' is requesting 'contents: write, pull-requests: write', but is only allowed 'contents: read, pull-requests: none'.

#251 (MYS-440) correctly tightened `ci-cd.yml`'s call of the reusable `integration-tests.yml` to `contents: read` — but GitHub permission-validates **every job in a called workflow file, including jobs an `if:` condition would skip**. The manual `re-record-cassettes` job living in the same file still declares write scopes, so the whole workflow is rejected before any job runs. (The checkout@v7 bump in the latest failing run is unrelated.)

## What

- New `.github/workflows/re-record-cassettes.yml`: the manual re-record job moved verbatim (same scopes, same secrets, same steps), now `workflow_dispatch`-only — the `if: github.event_name == 'workflow_dispatch'` gate is no longer needed and was dropped.
- `.github/workflows/integration-tests.yml`: re-record job removed; the file now contains only the read-only, no-secrets VCR-replay job, which is exactly what MYS-440's least-privilege call expects. Header comment updated; a comment at the removal site explains why the job cannot return.
- No permission or secret changes to either job — this is a file split, not a scope change.

## Docs

A reader would expect this covered where the CI security posture is written down: `integration-tests.yml`'s own header comments (updated in this PR to point at the new file) and `docs/ARCHITECTURE.md`'s hash-locked-deps / CI notes, which reference `integration-tests.yml` only for its install strategy — still accurate, so no doc-file changes. `README.md` does not enumerate workflow files beyond deploy/eval.

## Verification

- `make test`: 879 passed. `make test-integration`: 10 passed, 4 deselected.
- All three touched/calling workflow files parse as valid YAML.
- The startup error names `re-record-cassettes`'s write scopes as the only violation; after the split, every job remaining in `integration-tests.yml` requests `contents: read`, within the caller's grant. The push-triggered `CI/CD Pipeline` run on main after merge is the end-to-end proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)