### PR TITLE
fix(ai): guard against a stop rendering under a city its own address contradicts

### DIFF
--- a/core/extraction.py
+++ b/core/extraction.py
@@ -25,6 +25,49 @@ from models.place_key import resolve_country_name, slug
 
 logger = get_logger("storyland.core.extraction")
 
+# US state/territory names that can occupy the state-field position of a
+# "landmark, district, city, state, country" address (MYS-660 r8 / Codex
+# P1). Observed to collide with a same-trip CityPlan sharing the same
+# string -- "Washington" the STATE happening to equal "Washington" a
+# same-trip CityPlan (Washington, D.C.), so a Seattle-addressed stop (whose
+# true city, Seattle, is not on this trip at all) was actively RE-FILED
+# into Washington on state-name-only evidence, and could delete Washington
+# if it was that city's only stop. `_find_reconciliation_target`'s
+# all-segment scan (r3) was right to abandon fixed-position locality
+# guessing -- but checking every segment against the trip's CityPlans
+# without also asking "is this segment even a plausible LOCALITY" let an
+# administrative segment stand in for one.
+#
+# This list only restricts the DIFFERENT-city re-file signal (see its call
+# site) -- it never touches the own-city "still home" scan, which stays a
+# fail-safe, unrestricted, all-segment check per the module's existing
+# convention (a false negative there only skips a re-file that wasn't
+# needed; a false positive on the different-city path actively misfiles a
+# correct stop). US-only because every observed regression (Massachusetts,
+# New York, Washington) is a US state/territory in a "city, state, USA"
+# address; not a general gazetteer, and an unrecognised administrative name
+# elsewhere still falls through to "no signal" via city_indices_by_slug the
+# same as it always has -- this only makes an already-fail-open path fail
+# open for one more well-defined reason.
+_US_STATE_AND_TERRITORY_SLUGS: frozenset[str] = frozenset(
+    slug(name)
+    for name in (
+        "Alabama", "Alaska", "Arizona", "Arkansas", "California", "Colorado",
+        "Connecticut", "Delaware", "Florida", "Georgia", "Hawaii", "Idaho",
+        "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky", "Louisiana",
+        "Maine", "Maryland", "Massachusetts", "Michigan", "Minnesota",
+        "Mississippi", "Missouri", "Montana", "Nebraska", "Nevada",
+        "New Hampshire", "New Jersey", "New Mexico", "New York",
+        "North Carolina", "North Dakota", "Ohio", "Oklahoma", "Oregon",
+        "Pennsylvania", "Rhode Island", "South Carolina", "South Dakota",
+        "Tennessee", "Texas", "Utah", "Vermont", "Virginia", "Washington",
+        "West Virginia", "Wisconsin", "Wyoming",
+        "District of Columbia", "Washington D.C.", "Washington DC",
+        "Puerto Rico", "Guam", "American Samoa", "U.S. Virgin Islands",
+        "Northern Mariana Islands",
+    )
+)
+
 
 def validate_trip_itinerary(value: object) -> Optional[dict]:
     """Validate an itinerary payload against TripItinerary schema.
@@ -195,6 +238,14 @@ def _find_reconciliation_target(
     unambiguous different-city signal exists in the address (fail open --
     never guess, and never drop on an unresolved tail).
 
+    A segment recognised as a US state/territory name (see
+    `_US_STATE_AND_TERRITORY_SLUGS`) is excluded from THIS re-file signal
+    only -- MYS-660 r8 / Codex P1, a state name colliding with a same-trip
+    city's name (Washington the state vs. Washington, D.C. the CityPlan)
+    was misread as locality evidence and actively misfiled a stop whose
+    true city wasn't even on the trip. Own-city attestation below stays
+    unrestricted; only a RE-FILE needed the extra check.
+
     Scans every comma segment (see `_address_city_candidates`) rather than a
     fixed position. A segment only counts when it slug-matches a CityPlan
     name already on this trip -- an off-trip city name (e.g. a real place
@@ -303,6 +354,17 @@ def _find_reconciliation_target(
             # positive "still home" evidence, regardless of who else also
             # qualifies.
             own_attested = True
+            continue
+
+        if segment_slug in _US_STATE_AND_TERRITORY_SLUGS:
+            # MYS-660 r8 (Codex P1): this segment is administrative, not a
+            # locality -- it says which STATE the address is in, nothing
+            # about which CITY. It can still attest "still home" above (an
+            # own-city match there is unrestricted and fail-safe), but it
+            # must never be the sole evidence that RE-FILES a stop into a
+            # different same-trip city just because a state name happens
+            # to collide with that city's name (Washington the state vs.
+            # Washington, D.C. the CityPlan).
             continue
 
         distinct_others = set(qualified) - {own_index}
@@ -502,11 +564,31 @@ def _drop_suggestions_naming_removed_cities(
     almost always survives an itinerary. Both together match `expand()`'s
     real behavior exactly, never a stricter or looser test than the one
     that actually matters.
+
+    r8 (Codex P2, lower severity than the r7 P1 fixed alongside it): the
+    (a)/(b) test above is name-only, same as `expand()` itself -- neither
+    can do better, `action_prompt` is free text with no country field to
+    qualify against. That is an INHERENT limit, not a bug to fix here. What
+    r6/r7 got wrong is going silent about it: if a removed identity and a
+    surviving identity share a bare name but resolve to DIFFERENT countries
+    (a removed London, GB chip "surviving" only because a same-trip
+    London, CA also exists), condition (b) still keeps the chip -- correct,
+    since that's exactly what `expand()` will do too -- but `expand()`
+    will resolve it to the WRONG London with no signal anywhere that this
+    happened. Flag that specific shape loudly (still keep the chip; there
+    is nothing safer to do with no country in the prompt) rather than let
+    it look identical to the ordinary, unambiguous "still resolves" case.
     """
     if not removed_identities or not isinstance(suggestions, list):
         return suggestions
     removed_names = {name for name, _country in removed_identities}
     surviving_names = {name for name, _country in surviving_identities}
+    removed_countries_by_name: dict = {}
+    for name, country in removed_identities:
+        removed_countries_by_name.setdefault(name, set()).add(country)
+    surviving_countries_by_name: dict = {}
+    for name, country in surviving_identities:
+        surviving_countries_by_name.setdefault(name, set()).add(country)
     kept = []
     for chip in suggestions:
         if not isinstance(chip, dict):
@@ -514,17 +596,38 @@ def _drop_suggestions_naming_removed_cities(
             continue
         prompt = chip.get("action_prompt")
         prompt_lower = prompt.lower() if isinstance(prompt, str) else ""
-        if not prompt_lower or not any(name in prompt_lower for name in removed_names):
+        matched_removed = {name for name in removed_names if name in prompt_lower} if prompt_lower else set()
+        if not matched_removed:
             # Either city-agnostic (empty prompt, intentionally resolves via
             # expand()'s own cities[0] fallback) or doesn't name anything
             # this pass removed -- not this guard's concern either way.
             kept.append(chip)
             continue
-        if any(name in prompt_lower for name in surviving_names):
+        matched_surviving = {name for name in surviving_names if name in prompt_lower}
+        if matched_surviving:
             # Names a removed city by substring, but the prompt ALSO still
             # matches a surviving city's name -- expand() will resolve it
             # to that survivor, same as it always has. Not the orphaned-
             # fallback-to-cities[0] defect this guard exists to prevent.
+            for name in matched_removed & matched_surviving:
+                removed_countries = removed_countries_by_name.get(name, set())
+                surviving_countries = surviving_countries_by_name.get(name, set())
+                if any(
+                    rc is not None and sc is not None and rc != sc
+                    for rc in removed_countries
+                    for sc in surviving_countries
+                ):
+                    # r8: a genuine cross-country name collision -- the
+                    # surviving match expand() will actually use may not be
+                    # the city this chip meant. Can't resolve it (no
+                    # country in free text); flag it so it's visible.
+                    logger.warning(
+                        "suggestion_kept_despite_removed_city_name_collision",
+                        action_prompt=prompt,
+                        name=name,
+                        removed_countries=sorted(c or "unresolved" for c in removed_countries),
+                        surviving_countries=sorted(c or "unresolved" for c in surviving_countries),
+                    )
             kept.append(chip)
             continue
         logger.warning("suggestion_dropped_removed_city", action_prompt=prompt)

--- a/core/extraction.py
+++ b/core/extraction.py
@@ -202,22 +202,24 @@ def _find_reconciliation_target(
     match here, same as a segment that doesn't parse as a place at all; both
     are "no signal", not "signal of a mismatch".
 
-    Country-qualified (MYS-660 r3 / Codex P2, same lesson as MYS-548 --
-    identity matching must not be blind to a same-named disambiguator): when
-    more than one CityPlan on this itinerary shares a segment's matched name
-    slug -- INCLUDING when one of those same-named CityPlans is the stop's
-    own city -- the address's own trailing segment is checked as a country
-    name/code and used to narrow the candidates to the one(s) whose
-    `country` resolves to the same code. If the stop's own city survives
-    that narrowing, the segment is consistent with "already home", not a
-    mismatch signal, even if a same-named different-country city also
-    exists elsewhere on the itinerary. Only when the own city is narrowed
-    OUT and exactly one different candidate remains is that treated as a
-    positive different-city signal. An unresolvable country on either side
-    is tolerated, not treated as a mismatch (matching
-    `locality_matches_cities`'s convention) -- but if that tolerance still
-    leaves more than one candidate standing, there is no honest way to
-    choose, so that segment yields no match either.
+    Country-qualified for EVERY segment, not just ones with a same-named
+    collision (MYS-660 r5 / Codex P2, same lesson as MYS-548 -- identity
+    matching must not be blind to a same-named disambiguator): a real
+    regression had a stop addressed "..., Paris, Texas, USA" get re-filed to
+    a same-trip "Paris, France" CityPlan, because the OLD code only
+    country-checked a segment when more than one CityPlan on the trip shared
+    its slug -- a lone same-named CityPlan skipped the check entirely and
+    matched on name alone, ignoring that the address's own country
+    disagreed. There is only ONE matching path now: every segment's
+    slug-matched candidates (whether there's one or several) are narrowed by
+    the address's trailing country segment when one resolves; a candidate
+    whose own `country` resolves and actively disagrees with the address's
+    country is excluded, an unresolvable country on either side is
+    tolerated (kept in, matching this module's "no signal is not evidence
+    of a mismatch" convention). If narrowing empties the candidate set,
+    the segment yields no match at all -- not a mismatch signal, since a
+    same-named different-country city existing elsewhere doesn't mean this
+    address referred to it.
 
     Own-city evidence always wins, across the WHOLE address, not just its
     own segment (MYS-660 r4 / Codex P1): a real regression had a stop filed
@@ -226,12 +228,16 @@ def _find_reconciliation_target(
     segment ("New York") also happens to name a different same-trip
     CityPlan. Scanning segment-by-and-adding-to-`matched_indices`
     unconditionally let that later segment outvote the earlier "already
-    home" evidence and re-filed a correct stop into the wrong city -- the
-    third consecutive revision to drop/misfile a VALID stop. The fix: any
-    segment that attests the stop is still home (`own_attested`) is
-    recorded across the full scan, and wins over any different-city
+    home" evidence and re-filed a correct stop into the wrong city. The
+    fix: any segment that attests the stop is still home (`own_attested`)
+    is recorded across the full scan, and wins over any different-city
     match found elsewhere in the SAME address, regardless of which segment
     came first.
+
+    A single unified pass keeps both invariants: no segment's match is ever
+    accepted (own-city OR different-city) without surviving the same
+    country-qualification test, and own-city evidence anywhere still beats
+    every different-city match in the same address.
     """
     parts = _address_city_candidates(address)
     if parts is None:
@@ -252,19 +258,10 @@ def _find_reconciliation_target(
         if not all_indices:
             continue
 
-        if len(all_indices) == 1:
-            idx = all_indices[0]
-            if idx == own_index:
-                own_attested = True  # positive "still home" evidence
-                continue
-            matched_indices.add(idx)
-            continue
-
-        # The same city name is shared by more than one CityPlan on this
-        # itinerary (own city included, possibly). Narrow by country when
-        # the address gives one; an unresolvable country is tolerated
-        # (kept in), matching this module's "no signal is not evidence of a
-        # mismatch" convention.
+        # Country-qualify every candidate this segment's slug names -- one
+        # match or several, same rule either way (MYS-660 r5). An
+        # unresolvable country (either side) is tolerated, not treated as a
+        # mismatch, matching `locality_matches_cities`'s convention.
         if address_country_code is not None:
             qualified = [
                 idx
@@ -280,6 +277,12 @@ def _find_reconciliation_target(
         else:
             qualified = list(all_indices)
 
+        if not qualified:
+            # Every same-named candidate's own country actively disagrees
+            # with the address's country -- this segment names a place
+            # that isn't any CityPlan on this trip. No signal either way.
+            continue
+
         if own_index in qualified:
             # The stop's own city hasn't been ruled out as this address's
             # match -- could still plausibly be home, so this segment is
@@ -291,9 +294,10 @@ def _find_reconciliation_target(
         distinct_others = set(qualified) - {own_index}
         if len(distinct_others) == 1:
             matched_indices.add(next(iter(distinct_others)))
-        # else: zero or multiple qualified candidates besides the (already
-        # ruled-out) own city -- still ambiguous, this segment yields no
-        # match.
+        # else: zero (unreachable -- qualified is non-empty and own_index
+        # isn't in it) or multiple qualified candidates besides the
+        # (already ruled-out) own city -- still ambiguous, this segment
+        # yields no match.
 
     if own_attested:
         # Own-city evidence anywhere in the address beats a different-city

--- a/core/extraction.py
+++ b/core/extraction.py
@@ -244,9 +244,23 @@ def _find_reconciliation_target(
         return None
 
     address_country_code = resolve_country_name(parts[-1])
-    # A trailing segment that resolved as a country is the country field,
-    # not a locality candidate -- the city can be at any other position.
-    candidate_segments = parts[:-1] if address_country_code is not None else parts
+    # A trailing segment that resolved as a country is normally the country
+    # field, not a locality candidate -- the city can be at any other
+    # position. r7 (Codex P2, lowest severity, fail-open under-reach not a
+    # regression): a resolved trailing segment can ALSO be the city itself
+    # for a city-state address ("Marina Bay, Singapore", "Central, Hong
+    # Kong"), where the last comma segment names both the city and the
+    # country. Dropping it unconditionally lost the only segment that could
+    # ever have named that CityPlan, so a same-trip misfile there went
+    # unreconciled. Keep it as a candidate too when it ALSO slug-matches a
+    # CityPlan already on this itinerary -- it still resolves the country
+    # either way (`address_country_code` above), this only changes whether
+    # it's ALSO tried as a locality.
+    candidate_segments = (
+        parts
+        if address_country_code is None or slug(parts[-1]) in city_indices_by_slug
+        else parts[:-1]
+    )
 
     matched_indices: set = set()
     own_attested = False
@@ -424,12 +438,24 @@ def reconcile_stop_city_grouping(itinerary_dict: Optional[dict]) -> Optional[dic
 
 
 def _city_names(itinerary_dict: Optional[dict]) -> set:
-    """The (lowercased) names of every CityPlan currently on this itinerary.
+    """The (lowercased name, resolved-country-or-None) identity of every
+    CityPlan currently on this itinerary.
 
     MYS-660 r6: `_finalize` diffs this before/after `reconcile_stop_city_
     grouping` to learn which cities the guard just removed, rather than
     changing that function's return signature -- every existing caller
     (this module's own tests included) expects a single `dict` back.
+
+    MYS-660 r7 (Codex P2): country-qualified, same lesson as MYS-548 and
+    `_find_reconciliation_target`'s own country check -- a bare name-only
+    set can't tell two same-named CityPlans apart. Two same-trip cities
+    both named "London" (UK and Canada) collapsed to one `"london"` entry;
+    if the pass removed one of them, the before/after diff saw `"london"`
+    on both sides (the survivor covering for the one that was actually
+    dropped) and reported no removal at all. An unresolvable country is
+    tolerated as `None`, matching every other guard in this module's
+    fail-open convention -- it still distinguishes from a resolved country
+    that disagrees, it just can't rule anything out on its own.
     """
     if not itinerary_dict:
         return set()
@@ -437,7 +463,7 @@ def _city_names(itinerary_dict: Optional[dict]) -> set:
     if not isinstance(cities, list):
         return set()
     return {
-        city["name"].lower()
+        (city["name"].lower(), resolve_country_name(city.get("country")))
         for city in cities
         if isinstance(city, dict)
         and isinstance(city.get("name"), str)
@@ -445,8 +471,10 @@ def _city_names(itinerary_dict: Optional[dict]) -> set:
     }
 
 
-def _drop_suggestions_naming_removed_cities(suggestions: list, removed_names: set) -> list:
-    """MYS-660 r6: a suggestion chip whose `action_prompt` names a city
+def _drop_suggestions_naming_removed_cities(
+    suggestions: list, removed_identities: set, surviving_identities: set
+) -> list:
+    """MYS-660 r6/r7: a suggestion chip whose `action_prompt` names a city
     `reconcile_stop_city_grouping` just removed can no longer resolve to any
     persisted city. Left alone, `executor.expand()`'s target-city scan
     (`core/executor.py`, ``city_name.lower() in action_prompt_lower``) finds
@@ -458,13 +486,27 @@ def _drop_suggestions_naming_removed_cities(suggestions: list, removed_names: se
     was ever removed, so a chip's named city always existed; a city this
     pass drops (r1-r5's fix) can now orphan a suggestion that named it.
 
-    Uses the SAME case-insensitive substring check `expand()` itself makes,
-    so a chip survives this filter if and only if `expand()` would still
-    resolve it to a real, persisted city -- never a stricter or looser test
-    than the one that actually matters.
+    r7 (Codex P1): r6's filter used ONE substring test -- "does the prompt
+    contain a removed city's name" -- as the whole decision, which over-
+    drops. A removed name is often a substring of unrelated, still-valid
+    prompt text ("York" removed matches surviving "New York"; "Nice"
+    matches "nice restaurants"; "Bath" matches "bathhouse") -- r6's own doc
+    comment claimed this "survives iff `expand()` would still resolve it",
+    which was false: `expand()` never even LOOKS at removed names, it scans
+    the CURRENT cities list for a substring match. Mirroring that directly
+    is both simpler and correct: a chip is dropped only if (a) it names a
+    removed city AND (b) it does NOT ALSO still resolve to a surviving
+    city -- the exact two conditions `expand()`'s own resolution loop
+    implies. Condition (a) alone over-drops (case above); condition (b)
+    alone would never trigger on a plain rename/re-file since some city
+    almost always survives an itinerary. Both together match `expand()`'s
+    real behavior exactly, never a stricter or looser test than the one
+    that actually matters.
     """
-    if not removed_names or not isinstance(suggestions, list):
+    if not removed_identities or not isinstance(suggestions, list):
         return suggestions
+    removed_names = {name for name, _country in removed_identities}
+    surviving_names = {name for name, _country in surviving_identities}
     kept = []
     for chip in suggestions:
         if not isinstance(chip, dict):
@@ -472,10 +514,20 @@ def _drop_suggestions_naming_removed_cities(suggestions: list, removed_names: se
             continue
         prompt = chip.get("action_prompt")
         prompt_lower = prompt.lower() if isinstance(prompt, str) else ""
-        if prompt_lower and any(name in prompt_lower for name in removed_names):
-            logger.warning("suggestion_dropped_removed_city", action_prompt=prompt)
+        if not prompt_lower or not any(name in prompt_lower for name in removed_names):
+            # Either city-agnostic (empty prompt, intentionally resolves via
+            # expand()'s own cities[0] fallback) or doesn't name anything
+            # this pass removed -- not this guard's concern either way.
+            kept.append(chip)
             continue
-        kept.append(chip)
+        if any(name in prompt_lower for name in surviving_names):
+            # Names a removed city by substring, but the prompt ALSO still
+            # matches a surviving city's name -- expand() will resolve it
+            # to that survivor, same as it always has. Not the orphaned-
+            # fallback-to-cities[0] defect this guard exists to prevent.
+            kept.append(chip)
+            continue
+        logger.warning("suggestion_dropped_removed_city", action_prompt=prompt)
     return kept
 
 
@@ -498,14 +550,18 @@ def extract_itinerary_from_response(
 
     def _finalize(itinerary_dict, suggestions):
         itinerary_dict = downgrade_ungrounded_match_types(itinerary_dict, grounding_text)
-        names_before = _city_names(itinerary_dict)
+        identities_before = _city_names(itinerary_dict)
         itinerary_dict = reconcile_stop_city_grouping(itinerary_dict)
-        # MYS-660 r6: a city the guard above just removed can orphan a
+        # MYS-660 r6/r7: a city the guard above just removed can orphan a
         # suggestion chip that named it -- see _drop_suggestions_naming_
-        # removed_cities's own doc comment for why that matters.
-        removed_names = names_before - _city_names(itinerary_dict)
-        if removed_names:
-            suggestions = _drop_suggestions_naming_removed_cities(suggestions, removed_names)
+        # removed_cities's own doc comment for why that matters, and why it
+        # needs BOTH the removed and surviving identity sets (r7).
+        identities_after = _city_names(itinerary_dict)
+        removed_identities = identities_before - identities_after
+        if removed_identities:
+            suggestions = _drop_suggestions_naming_removed_cities(
+                suggestions, removed_identities, identities_after
+            )
         itinerary_dict = sanitize_itinerary_explanations(itinerary_dict)
         return itinerary_dict, suggestions
 

--- a/core/extraction.py
+++ b/core/extraction.py
@@ -218,6 +218,20 @@ def _find_reconciliation_target(
     `locality_matches_cities`'s convention) -- but if that tolerance still
     leaves more than one candidate standing, there is no honest way to
     choose, so that segment yields no match either.
+
+    Own-city evidence always wins, across the WHOLE address, not just its
+    own segment (MYS-660 r4 / Codex P1): a real regression had a stop filed
+    under Buffalo with address "..., Buffalo, New York, USA" -- one segment
+    ("Buffalo") positively confirms the stop is already home, but a LATER
+    segment ("New York") also happens to name a different same-trip
+    CityPlan. Scanning segment-by-and-adding-to-`matched_indices`
+    unconditionally let that later segment outvote the earlier "already
+    home" evidence and re-filed a correct stop into the wrong city -- the
+    third consecutive revision to drop/misfile a VALID stop. The fix: any
+    segment that attests the stop is still home (`own_attested`) is
+    recorded across the full scan, and wins over any different-city
+    match found elsewhere in the SAME address, regardless of which segment
+    came first.
     """
     parts = _address_city_candidates(address)
     if parts is None:
@@ -229,6 +243,7 @@ def _find_reconciliation_target(
     candidate_segments = parts[:-1] if address_country_code is not None else parts
 
     matched_indices: set = set()
+    own_attested = False
     for segment in candidate_segments:
         segment_slug = slug(segment)
         if not segment_slug:
@@ -240,7 +255,8 @@ def _find_reconciliation_target(
         if len(all_indices) == 1:
             idx = all_indices[0]
             if idx == own_index:
-                continue  # matches the stop's own city -- not a mismatch
+                own_attested = True  # positive "still home" evidence
+                continue
             matched_indices.add(idx)
             continue
 
@@ -267,7 +283,9 @@ def _find_reconciliation_target(
         if own_index in qualified:
             # The stop's own city hasn't been ruled out as this address's
             # match -- could still plausibly be home, so this segment is
-            # not a mismatch signal, regardless of who else also qualifies.
+            # positive "still home" evidence, regardless of who else also
+            # qualifies.
+            own_attested = True
             continue
 
         distinct_others = set(qualified) - {own_index}
@@ -277,6 +295,12 @@ def _find_reconciliation_target(
         # ruled-out) own city -- still ambiguous, this segment yields no
         # match.
 
+    if own_attested:
+        # Own-city evidence anywhere in the address beats a different-city
+        # match found in another segment of the SAME address (MYS-660 r4) --
+        # never re-file a stop the address also positively confirms is
+        # still home.
+        return None
     if len(matched_indices) == 1:
         return next(iter(matched_indices))
     # Zero, or more than one, distinct different-city match across every

--- a/core/extraction.py
+++ b/core/extraction.py
@@ -423,6 +423,62 @@ def reconcile_stop_city_grouping(itinerary_dict: Optional[dict]) -> Optional[dic
     return itinerary_dict
 
 
+def _city_names(itinerary_dict: Optional[dict]) -> set:
+    """The (lowercased) names of every CityPlan currently on this itinerary.
+
+    MYS-660 r6: `_finalize` diffs this before/after `reconcile_stop_city_
+    grouping` to learn which cities the guard just removed, rather than
+    changing that function's return signature -- every existing caller
+    (this module's own tests included) expects a single `dict` back.
+    """
+    if not itinerary_dict:
+        return set()
+    cities = itinerary_dict.get("cities")
+    if not isinstance(cities, list):
+        return set()
+    return {
+        city["name"].lower()
+        for city in cities
+        if isinstance(city, dict)
+        and isinstance(city.get("name"), str)
+        and city["name"].strip()
+    }
+
+
+def _drop_suggestions_naming_removed_cities(suggestions: list, removed_names: set) -> list:
+    """MYS-660 r6: a suggestion chip whose `action_prompt` names a city
+    `reconcile_stop_city_grouping` just removed can no longer resolve to any
+    persisted city. Left alone, `executor.expand()`'s target-city scan
+    (`core/executor.py`, ``city_name.lower() in action_prompt_lower``) finds
+    no match on any CURRENTLY-persisted city and silently falls back to
+    ``cities[0]`` -- the expansion's new places get appended, and PERSISTED,
+    under whatever city happens to be first. That is the exact "stop under
+    the wrong city" defect this ticket exists to kill, newly reachable
+    through this guard's own side effect: before this guard existed no city
+    was ever removed, so a chip's named city always existed; a city this
+    pass drops (r1-r5's fix) can now orphan a suggestion that named it.
+
+    Uses the SAME case-insensitive substring check `expand()` itself makes,
+    so a chip survives this filter if and only if `expand()` would still
+    resolve it to a real, persisted city -- never a stricter or looser test
+    than the one that actually matters.
+    """
+    if not removed_names or not isinstance(suggestions, list):
+        return suggestions
+    kept = []
+    for chip in suggestions:
+        if not isinstance(chip, dict):
+            kept.append(chip)
+            continue
+        prompt = chip.get("action_prompt")
+        prompt_lower = prompt.lower() if isinstance(prompt, str) else ""
+        if prompt_lower and any(name in prompt_lower for name in removed_names):
+            logger.warning("suggestion_dropped_removed_city", action_prompt=prompt)
+            continue
+        kept.append(chip)
+    return kept
+
+
 def extract_itinerary_from_response(
     final_response, state_accessor
 ) -> Optional[Tuple[dict, list]]:
@@ -442,7 +498,14 @@ def extract_itinerary_from_response(
 
     def _finalize(itinerary_dict, suggestions):
         itinerary_dict = downgrade_ungrounded_match_types(itinerary_dict, grounding_text)
+        names_before = _city_names(itinerary_dict)
         itinerary_dict = reconcile_stop_city_grouping(itinerary_dict)
+        # MYS-660 r6: a city the guard above just removed can orphan a
+        # suggestion chip that named it -- see _drop_suggestions_naming_
+        # removed_cities's own doc comment for why that matters.
+        removed_names = names_before - _city_names(itinerary_dict)
+        if removed_names:
+            suggestions = _drop_suggestions_naming_removed_cities(suggestions, removed_names)
         itinerary_dict = sanitize_itinerary_explanations(itinerary_dict)
         return itinerary_dict, suggestions
 

--- a/core/extraction.py
+++ b/core/extraction.py
@@ -155,31 +155,133 @@ def downgrade_ungrounded_match_types(
     return itinerary_dict
 
 
-# MYS-660: an address the composer wrote for a stop is free text ending in
-# "..., <city>, <country>" per the composer prompt's own convention (a
-# country segment is not guaranteed -- some addresses stop at the city, e.g.
-# "221B Baker Street, London"). Extracted here rather than assumed at a fixed
-# comma position, so both shapes parse.
-def _address_locality(address: object) -> Optional[str]:
-    """Best-effort city name from the tail of a free-text stop address.
+# MYS-660: a stop's own `address` is composer-written free text with no
+# guaranteed shape -- "<place>, <neighbourhood>, <city>, <country>" and
+# "<place>, <neighbourhood>, <city>, <state>, <country>" are BOTH observed,
+# so the city is not reliably at a fixed comma position (r1 guessed
+# "second-to-last when the last segment is a country", which read
+# "...Salem, Massachusetts, USA" as locality "Massachusetts" -- a state, not
+# a city -- and dropped a legitimate Salem stop; MYS-660 r3 / Codex P1).
+#
+# Rather than guess a position, every comma segment of the address is
+# checked against the CityPlans actually on THIS itinerary: an address never
+# invents a new city to file a stop under, so the only signal worth acting
+# on is "one of my segments names a CityPlan already on this trip". No
+# segment matching any known CityPlan is not evidence of a mismatch -- it's
+# simply not a signal (fail open, same convention this file's other
+# guardrails use).
+def _address_city_candidates(address: object) -> Optional[list]:
+    """Comma-separated, stripped segments of a free-text stop address.
 
-    Returns None (never a guess) when the address is missing, empty, or a
-    single fragment with no separable locality -- the caller's contract is
-    "skip when unsure", never "fail when unsure".
+    Returns None (never a guess) for a missing/empty address or one with a
+    single fragment -- there's no separable locality to check at all.
     """
     if not isinstance(address, str):
         return None
     parts = [p.strip() for p in address.split(",") if p.strip()]
     if len(parts) < 2:
         return None
-    if resolve_country_name(parts[-1]) is not None:
-        # Last segment IS a real country name/code -> locality is the one
-        # before it (the common, fully-qualified shape).
-        return parts[-2] if len(parts) >= 2 else None
-    # No recognisable country trailing the address -> assume the composer
-    # simply stopped at the city (the shorter shape the model docstring
-    # itself gives as an example).
-    return parts[-1]
+    return parts
+
+
+def _find_reconciliation_target(
+    address: object,
+    cities: list,
+    city_indices_by_slug: dict,
+    own_index: int,
+) -> Optional[int]:
+    """Does this stop's address positively name a DIFFERENT CityPlan already
+    on this itinerary? Returns that CityPlan's index, or None when no single
+    unambiguous different-city signal exists in the address (fail open --
+    never guess, and never drop on an unresolved tail).
+
+    Scans every comma segment (see `_address_city_candidates`) rather than a
+    fixed position. A segment only counts when it slug-matches a CityPlan
+    name already on this trip -- an off-trip city name (e.g. a real place
+    the address mentions that simply isn't part of this itinerary) yields no
+    match here, same as a segment that doesn't parse as a place at all; both
+    are "no signal", not "signal of a mismatch".
+
+    Country-qualified (MYS-660 r3 / Codex P2, same lesson as MYS-548 --
+    identity matching must not be blind to a same-named disambiguator): when
+    more than one CityPlan on this itinerary shares a segment's matched name
+    slug -- INCLUDING when one of those same-named CityPlans is the stop's
+    own city -- the address's own trailing segment is checked as a country
+    name/code and used to narrow the candidates to the one(s) whose
+    `country` resolves to the same code. If the stop's own city survives
+    that narrowing, the segment is consistent with "already home", not a
+    mismatch signal, even if a same-named different-country city also
+    exists elsewhere on the itinerary. Only when the own city is narrowed
+    OUT and exactly one different candidate remains is that treated as a
+    positive different-city signal. An unresolvable country on either side
+    is tolerated, not treated as a mismatch (matching
+    `locality_matches_cities`'s convention) -- but if that tolerance still
+    leaves more than one candidate standing, there is no honest way to
+    choose, so that segment yields no match either.
+    """
+    parts = _address_city_candidates(address)
+    if parts is None:
+        return None
+
+    address_country_code = resolve_country_name(parts[-1])
+    # A trailing segment that resolved as a country is the country field,
+    # not a locality candidate -- the city can be at any other position.
+    candidate_segments = parts[:-1] if address_country_code is not None else parts
+
+    matched_indices: set = set()
+    for segment in candidate_segments:
+        segment_slug = slug(segment)
+        if not segment_slug:
+            continue
+        all_indices = city_indices_by_slug.get(segment_slug, ())
+        if not all_indices:
+            continue
+
+        if len(all_indices) == 1:
+            idx = all_indices[0]
+            if idx == own_index:
+                continue  # matches the stop's own city -- not a mismatch
+            matched_indices.add(idx)
+            continue
+
+        # The same city name is shared by more than one CityPlan on this
+        # itinerary (own city included, possibly). Narrow by country when
+        # the address gives one; an unresolvable country is tolerated
+        # (kept in), matching this module's "no signal is not evidence of a
+        # mismatch" convention.
+        if address_country_code is not None:
+            qualified = [
+                idx
+                for idx in all_indices
+                if (
+                    resolved := resolve_country_name(
+                        cities[idx].get("country") if isinstance(cities[idx], dict) else None
+                    )
+                )
+                is None
+                or resolved == address_country_code
+            ]
+        else:
+            qualified = list(all_indices)
+
+        if own_index in qualified:
+            # The stop's own city hasn't been ruled out as this address's
+            # match -- could still plausibly be home, so this segment is
+            # not a mismatch signal, regardless of who else also qualifies.
+            continue
+
+        distinct_others = set(qualified) - {own_index}
+        if len(distinct_others) == 1:
+            matched_indices.add(next(iter(distinct_others)))
+        # else: zero or multiple qualified candidates besides the (already
+        # ruled-out) own city -- still ambiguous, this segment yields no
+        # match.
+
+    if len(matched_indices) == 1:
+        return next(iter(matched_indices))
+    # Zero, or more than one, distinct different-city match across every
+    # segment -- no single unambiguous signal. Fail open.
+    return None
 
 
 def reconcile_stop_city_grouping(itinerary_dict: Optional[dict]) -> Optional[dict]:
@@ -195,16 +297,19 @@ def reconcile_stop_city_grouping(itinerary_dict: Optional[dict]) -> Optional[dic
 
     Policy, per AC-2 (a wholesale envelope reject is explicitly the "last
     resort, not the default" -- not implemented here; see PR notes):
-      * A stop whose address locality slug-matches a DIFFERENT CityPlan
-        already on this same itinerary is RE-FILED there (the Colombia
-        case: the 3 mismatched stops move to the existing Cartagena entry).
-      * A stop whose address locality matches no CityPlan on this itinerary
-        is DROPPED (we have nowhere honest to put it).
-      * A stop with no discernible address locality (``None``, no address,
-        or a single-fragment address) is left where the composer put it --
-        "no signal" is not evidence of a mismatch, matching this file's
-        other guardrails' fail-open convention (see
-        ``downgrade_ungrounded_match_types``).
+      * A stop whose address positively, unambiguously names a DIFFERENT
+        CityPlan already on this same itinerary is RE-FILED there (the
+        Colombia case: the 3 mismatched stops move to the existing
+        Cartagena entry).
+      * A stop whose address names no CityPlan on this itinerary at all --
+        whether because it has no discernible locality, or because every
+        comma segment fails to match any CityPlan here, or because a match
+        is ambiguous (same-named cities, unresolvable country) -- is left
+        exactly where the composer put it. "No signal" is not evidence of a
+        mismatch (see ``_find_reconciliation_target``; this also closes the
+        MYS-660 r3 regression where a state/administrative segment like
+        "Massachusetts" used to be misread as the locality and a genuinely
+        correct Salem stop was dropped for not matching anything).
       * A CityPlan left with zero stops after this pass is dropped entirely
         (MYS-268: an empty city section is worse than no section).
 
@@ -220,16 +325,16 @@ def reconcile_stop_city_grouping(itinerary_dict: Optional[dict]) -> Optional[dic
     if not isinstance(cities, list) or not cities:
         return itinerary_dict
 
-    # First CityPlan on the itinerary matching each city-name slug -- a stop
-    # is only ever re-filed to a city ALREADY on this same trip, never a new
-    # one this pass invents.
-    city_index_by_slug: dict = {}
+    # EVERY CityPlan index sharing a given name slug (not just the first) --
+    # needed so a same-named different-country city can be disambiguated
+    # rather than silently shadowed by an earlier entry of the same name.
+    city_indices_by_slug: dict = {}
     for i, city in enumerate(cities):
         if not isinstance(city, dict):
             continue
         name_slug = slug(city.get("name")) if isinstance(city.get("name"), str) else ""
-        if name_slug and name_slug not in city_index_by_slug:
-            city_index_by_slug[name_slug] = i
+        if name_slug:
+            city_indices_by_slug.setdefault(name_slug, []).append(i)
 
     # A city that arrived with zero stops was never this pass's business --
     # only a city THIS PASS emptied (had >=1 stop before, none after) is
@@ -242,7 +347,6 @@ def reconcile_stop_city_grouping(itinerary_dict: Optional[dict]) -> Optional[dic
 
     refiled_into: dict = {i: [] for i in range(len(cities))}
     refiled_count = 0
-    dropped_count = 0
 
     for i, city in enumerate(cities):
         if not isinstance(city, dict):
@@ -250,50 +354,33 @@ def reconcile_stop_city_grouping(itinerary_dict: Optional[dict]) -> Optional[dic
         stops = city.get("stops")
         if not isinstance(stops, list):
             continue
-        own_slug = slug(city.get("name")) if isinstance(city.get("name"), str) else ""
         kept = []
         for stop in stops:
             if not isinstance(stop, dict):
                 kept.append(stop)
                 continue
-            locality = _address_locality(stop.get("address"))
-            if locality is None:
+            target = _find_reconciliation_target(
+                stop.get("address"), cities, city_indices_by_slug, own_index=i
+            )
+            if target is None:
                 kept.append(stop)
                 continue
-            locality_slug = slug(locality)
-            if not locality_slug or locality_slug == own_slug:
-                kept.append(stop)
-                continue
-            target = city_index_by_slug.get(locality_slug)
-            if target is not None and target != i:
-                refiled_into[target].append(stop)
-                refiled_count += 1
-                logger.warning(
-                    "stop_city_mismatch_refiled",
-                    stop=stop.get("name"),
-                    filed_under=city.get("name"),
-                    address_locality=locality,
-                )
-            else:
-                dropped_count += 1
-                logger.warning(
-                    "stop_city_mismatch_dropped",
-                    stop=stop.get("name"),
-                    filed_under=city.get("name"),
-                    address_locality=locality,
-                )
+            refiled_into[target].append(stop)
+            refiled_count += 1
+            logger.warning(
+                "stop_city_mismatch_refiled",
+                stop=stop.get("name"),
+                filed_under=city.get("name"),
+                refiled_to=cities[target].get("name") if isinstance(cities[target], dict) else None,
+            )
         city["stops"] = kept
 
     for i, extra in refiled_into.items():
         if extra:
             cities[i]["stops"] = list(cities[i].get("stops") or []) + extra
 
-    if refiled_count or dropped_count:
-        logger.info(
-            "itinerary_stop_city_reconciled",
-            refiled=refiled_count,
-            dropped=dropped_count,
-        )
+    if refiled_count:
+        logger.info("itinerary_stop_city_reconciled", refiled=refiled_count)
 
     # A city THIS PASS emptied carries nothing honest to show -- drop it
     # (MYS-268). A city that arrived with zero stops already was never

--- a/core/extraction.py
+++ b/core/extraction.py
@@ -21,6 +21,7 @@ from core.guardrails import (
 )
 from models.book import BookRecommendationsResult
 from models.itinerary import TripItinerary, ComposerEnvelope, ExpansionResult
+from models.place_key import resolve_country_name, slug
 
 logger = get_logger("storyland.core.extraction")
 
@@ -154,6 +155,159 @@ def downgrade_ungrounded_match_types(
     return itinerary_dict
 
 
+# MYS-660: an address the composer wrote for a stop is free text ending in
+# "..., <city>, <country>" per the composer prompt's own convention (a
+# country segment is not guaranteed -- some addresses stop at the city, e.g.
+# "221B Baker Street, London"). Extracted here rather than assumed at a fixed
+# comma position, so both shapes parse.
+def _address_locality(address: object) -> Optional[str]:
+    """Best-effort city name from the tail of a free-text stop address.
+
+    Returns None (never a guess) when the address is missing, empty, or a
+    single fragment with no separable locality -- the caller's contract is
+    "skip when unsure", never "fail when unsure".
+    """
+    if not isinstance(address, str):
+        return None
+    parts = [p.strip() for p in address.split(",") if p.strip()]
+    if len(parts) < 2:
+        return None
+    if resolve_country_name(parts[-1]) is not None:
+        # Last segment IS a real country name/code -> locality is the one
+        # before it (the common, fully-qualified shape).
+        return parts[-2] if len(parts) >= 2 else None
+    # No recognisable country trailing the address -> assume the composer
+    # simply stopped at the city (the shorter shape the model docstring
+    # itself gives as an example).
+    return parts[-1]
+
+
+def reconcile_stop_city_grouping(itinerary_dict: Optional[dict]) -> Optional[dict]:
+    """MYS-660: never render a stop under a city its own address contradicts.
+
+    The composer groups stops by city itself, as free-form text, with no
+    coordinates and nothing that cross-checks a stop's ``address`` against
+    the ``CityPlan`` it ends up filed under. Both fields are already on the
+    record we hold (zero new upstream calls, zero spend) -- confirmed live:
+    a real itinerary filed 3 Cartagena-addressed restaurants under
+    Aracataca, ~250km away, while Cartagena was ALSO its own city on the
+    same trip.
+
+    Policy, per AC-2 (a wholesale envelope reject is explicitly the "last
+    resort, not the default" -- not implemented here; see PR notes):
+      * A stop whose address locality slug-matches a DIFFERENT CityPlan
+        already on this same itinerary is RE-FILED there (the Colombia
+        case: the 3 mismatched stops move to the existing Cartagena entry).
+      * A stop whose address locality matches no CityPlan on this itinerary
+        is DROPPED (we have nowhere honest to put it).
+      * A stop with no discernible address locality (``None``, no address,
+        or a single-fragment address) is left where the composer put it --
+        "no signal" is not evidence of a mismatch, matching this file's
+        other guardrails' fail-open convention (see
+        ``downgrade_ungrounded_match_types``).
+      * A CityPlan left with zero stops after this pass is dropped entirely
+        (MYS-268: an empty city section is worse than no section).
+
+    Deterministic post-processing on whatever the composer emitted -- holds
+    regardless of MYS-563's composition non-determinism, which is a
+    *different* defect (a truncated/degenerate envelope) this validation
+    layer does not attempt to fix.
+    """
+    if not itinerary_dict:
+        return itinerary_dict
+
+    cities = itinerary_dict.get("cities")
+    if not isinstance(cities, list) or not cities:
+        return itinerary_dict
+
+    # First CityPlan on the itinerary matching each city-name slug -- a stop
+    # is only ever re-filed to a city ALREADY on this same trip, never a new
+    # one this pass invents.
+    city_index_by_slug: dict = {}
+    for i, city in enumerate(cities):
+        if not isinstance(city, dict):
+            continue
+        name_slug = slug(city.get("name")) if isinstance(city.get("name"), str) else ""
+        if name_slug and name_slug not in city_index_by_slug:
+            city_index_by_slug[name_slug] = i
+
+    # A city that arrived with zero stops was never this pass's business --
+    # only a city THIS PASS emptied (had >=1 stop before, none after) is
+    # "worse than no section" per MYS-268. Recorded before any mutation.
+    city_had_stops: dict = {}
+    for i, city in enumerate(cities):
+        if isinstance(city, dict):
+            existing = city.get("stops")
+            city_had_stops[i] = bool(isinstance(existing, list) and existing)
+
+    refiled_into: dict = {i: [] for i in range(len(cities))}
+    refiled_count = 0
+    dropped_count = 0
+
+    for i, city in enumerate(cities):
+        if not isinstance(city, dict):
+            continue
+        stops = city.get("stops")
+        if not isinstance(stops, list):
+            continue
+        own_slug = slug(city.get("name")) if isinstance(city.get("name"), str) else ""
+        kept = []
+        for stop in stops:
+            if not isinstance(stop, dict):
+                kept.append(stop)
+                continue
+            locality = _address_locality(stop.get("address"))
+            if locality is None:
+                kept.append(stop)
+                continue
+            locality_slug = slug(locality)
+            if not locality_slug or locality_slug == own_slug:
+                kept.append(stop)
+                continue
+            target = city_index_by_slug.get(locality_slug)
+            if target is not None and target != i:
+                refiled_into[target].append(stop)
+                refiled_count += 1
+                logger.warning(
+                    "stop_city_mismatch_refiled",
+                    stop=stop.get("name"),
+                    filed_under=city.get("name"),
+                    address_locality=locality,
+                )
+            else:
+                dropped_count += 1
+                logger.warning(
+                    "stop_city_mismatch_dropped",
+                    stop=stop.get("name"),
+                    filed_under=city.get("name"),
+                    address_locality=locality,
+                )
+        city["stops"] = kept
+
+    for i, extra in refiled_into.items():
+        if extra:
+            cities[i]["stops"] = list(cities[i].get("stops") or []) + extra
+
+    if refiled_count or dropped_count:
+        logger.info(
+            "itinerary_stop_city_reconciled",
+            refiled=refiled_count,
+            dropped=dropped_count,
+        )
+
+    # A city THIS PASS emptied carries nothing honest to show -- drop it
+    # (MYS-268). A city that arrived with zero stops already was never
+    # touched by this guard and is left exactly as the composer emitted it
+    # (e.g. a legitimate zero-stop city elsewhere in the pipeline's own
+    # fixtures) -- this pass only removes what it itself created.
+    itinerary_dict["cities"] = [
+        c
+        for i, c in enumerate(cities)
+        if not isinstance(c, dict) or c.get("stops") or not city_had_stops.get(i, True)
+    ]
+    return itinerary_dict
+
+
 def extract_itinerary_from_response(
     final_response, state_accessor
 ) -> Optional[Tuple[dict, list]]:
@@ -173,6 +327,7 @@ def extract_itinerary_from_response(
 
     def _finalize(itinerary_dict, suggestions):
         itinerary_dict = downgrade_ungrounded_match_types(itinerary_dict, grounding_text)
+        itinerary_dict = reconcile_stop_city_grouping(itinerary_dict)
         itinerary_dict = sanitize_itinerary_explanations(itinerary_dict)
         return itinerary_dict, suggestions
 

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -37,7 +37,7 @@ from core.extraction import (
     extract_book_recommendations_from_state,
     downgrade_ungrounded_match_types,
     reconcile_stop_city_grouping,
-    _address_locality,
+    _find_reconciliation_target,
     grounding_token_set,
     is_title_grounded,
 )
@@ -1096,7 +1096,15 @@ class TestReconcileStopCityGrouping:
             "La Vitrola",
         }
 
-    def test_mismatch_with_no_matching_city_is_dropped(self):
+    def test_mismatch_with_no_matching_city_fails_open(self):
+        # MYS-660 r3: Lyon is a real, resolvable place, but it is not a
+        # CityPlan anywhere on THIS itinerary -- only Paris is. r1 treated
+        # "locality resolved but matches no known city" as grounds to drop
+        # the stop; the Eng Lead's r3 fix-list retired that path precisely
+        # because a fixed-position locality guess can misfire (see the
+        # Salem/Massachusetts test below), so "no known-city match anywhere
+        # in the address" is now fail-open, not a drop -- acting only
+        # happens on a positive, unambiguous DIFFERENT-known-city signal.
         itin = {
             "summary_text": "t",
             "cities": [
@@ -1111,8 +1119,78 @@ class TestReconcileStopCityGrouping:
             ],
         }
         out = reconcile_stop_city_grouping(itin)
-        names = [s["name"] for s in out["cities"][0]["stops"]]
-        assert names == ["Eiffel Tower"]
+        names = {s["name"] for s in out["cities"][0]["stops"]}
+        assert names == {"Eiffel Tower", "Ghost Cafe"}
+
+    def test_state_qualified_address_does_not_misidentify_locality_as_state(self):
+        # The exact live regression (MYS-660 r3 / Codex P1): r1's fixed
+        # "second-to-last segment" heuristic read
+        # "...Salem, Massachusetts, USA" as locality "Massachusetts" (a
+        # state, not a city) -- "massachusetts" matched no CityPlan, so a
+        # perfectly valid Salem stop was dropped. Salem IS a CityPlan on
+        # this itinerary; the fix must re-file to it, not drop.
+        itin = {
+            "summary_text": "t",
+            "cities": [
+                self._city(
+                    "Boston",
+                    [
+                        self._stop(
+                            "Salem Witch Museum",
+                            "19 1/2 Washington Square N, Salem, Massachusetts, USA",
+                        ),
+                    ],
+                    country="USA",
+                ),
+                self._city(
+                    "Salem",
+                    [self._stop("Peabody Essex Museum", "East India Sq, Salem, Massachusetts, USA")],
+                    country="USA",
+                ),
+            ],
+        }
+        out = reconcile_stop_city_grouping(itin)
+        by_city = {c["name"]: {s["name"] for s in c["stops"]} for c in out["cities"]}
+        assert by_city == {
+            "Salem": {"Peabody Essex Museum", "Salem Witch Museum"},
+        } or ("Boston" not in by_city)
+        # Boston is left with zero stops after the re-file and is correctly
+        # dropped (MYS-268); Salem carries both.
+        assert by_city["Salem"] == {"Peabody Essex Museum", "Salem Witch Museum"}
+
+    def test_ambiguous_same_named_city_disambiguated_by_country(self):
+        # MYS-660 r3 / Codex P2: two CityPlans named "London" (combined-book
+        # itinerary) -- the address's own trailing country segment picks the
+        # right one, same lesson as MYS-548 (identity match must not be
+        # blind to a same-named disambiguator).
+        itin = {
+            "summary_text": "t",
+            "cities": [
+                self._city("Paris", [self._stop("Misfiled", "221B Baker Street, London, Canada")], country="France"),
+                self._city("London", [self._stop("Tower Bridge", "Tower Bridge Rd, London, UK")], country="United Kingdom"),
+                self._city("London", [self._stop("CN Tower area cafe", "1 Front St, London, Canada")], country="Canada"),
+            ],
+        }
+        out = reconcile_stop_city_grouping(itin)
+        by_country = {(c["name"], c["country"]): {s["name"] for s in c["stops"]} for c in out["cities"]}
+        assert by_country[("London", "Canada")] == {"CN Tower area cafe", "Misfiled"}
+        assert by_country[("London", "United Kingdom")] == {"Tower Bridge"}
+
+    def test_ambiguous_same_named_city_without_country_signal_fails_open(self):
+        # Same two same-named CityPlans, but the address has no trailing
+        # country segment to disambiguate with -- there is no honest way to
+        # pick one, so no action is taken (fail open, never guess).
+        itin = {
+            "summary_text": "t",
+            "cities": [
+                self._city("Paris", [self._stop("Misfiled", "Some Street, London")], country="France"),
+                self._city("London", [self._stop("Tower Bridge", "Tower Bridge Rd, London, UK")], country="United Kingdom"),
+                self._city("London", [self._stop("Local cafe", "1 Front St, London, Canada")], country="Canada"),
+            ],
+        }
+        out = reconcile_stop_city_grouping(itin)
+        by_country = {(c["name"], c["country"]): {s["name"] for s in c["stops"]} for c in out["cities"]}
+        assert by_country[("Paris", "France")] == {"Misfiled"}
 
     def test_fail_open_on_no_address_or_single_fragment(self):
         # No signal is not evidence of a mismatch -- left exactly where the
@@ -1202,15 +1280,27 @@ class TestReconcileStopCityGrouping:
             ],
         }
 
-        def is_internally_consistent(result):
-            for city in result["cities"]:
-                for stop in city["stops"]:
-                    locality = _address_locality(stop.get("address"))
-                    if locality is None:
-                        continue
-                    from models.place_key import slug
+        from models.place_key import slug
 
-                    if slug(locality) and slug(locality) != slug(city["name"]):
+        def is_internally_consistent(result):
+            # Post-reconciliation, re-running the same target-finder against
+            # the FINAL city list must find no further action for any stop
+            # -- a fixed point. If it did, this pass left a stop mismatched
+            # against its own address.
+            cities = result["cities"]
+            city_indices_by_slug = {}
+            for idx, city in enumerate(cities):
+                if not isinstance(city, dict):
+                    continue
+                name_slug = slug(city.get("name")) if isinstance(city.get("name"), str) else ""
+                if name_slug:
+                    city_indices_by_slug.setdefault(name_slug, []).append(idx)
+            for idx, city in enumerate(cities):
+                for stop in city["stops"]:
+                    target = _find_reconciliation_target(
+                        stop.get("address"), cities, city_indices_by_slug, own_index=idx
+                    )
+                    if target is not None:
                         return False
             return True
 
@@ -1262,20 +1352,71 @@ class TestReconcileStopCityGrouping:
         out = reconcile_stop_city_grouping(itin)
         assert [c["name"] for c in out["cities"]] == ["Cartagena"]
 
-    def test_address_locality_country_suffix_stripped(self):
-        assert (
-            _address_locality("Calle 25 #10B-15, Getsemani, Cartagena, Colombia")
-            == "Cartagena"
+    def test_reconciliation_target_matches_a_known_different_city(self):
+        cities = [
+            self._city("Aracataca", []),
+            self._city("Cartagena", []),
+        ]
+        city_indices_by_slug = {"aracataca": [0], "cartagena": [1]}
+        target = _find_reconciliation_target(
+            "Calle 25 #10B-15, Getsemani, Cartagena, Colombia",
+            cities,
+            city_indices_by_slug,
+            own_index=0,
         )
+        assert target == 1
 
-    def test_address_locality_no_country_uses_last_segment(self):
-        assert _address_locality("221B Baker Street, London") == "London"
+    def test_reconciliation_target_no_country_still_matches_last_segment(self):
+        cities = [self._city("Aracataca", []), self._city("London", [])]
+        city_indices_by_slug = {"aracataca": [0], "london": [1]}
+        target = _find_reconciliation_target(
+            "221B Baker Street, London", cities, city_indices_by_slug, own_index=0
+        )
+        assert target == 1
 
-    def test_address_locality_single_fragment_is_none(self):
-        assert _address_locality("Somewhere magical") is None
+    def test_reconciliation_target_single_fragment_or_missing_is_none(self):
+        cities = [self._city("Aracataca", [])]
+        city_indices_by_slug = {"aracataca": [0]}
+        assert (
+            _find_reconciliation_target("Somewhere magical", cities, city_indices_by_slug, own_index=0)
+            is None
+        )
+        assert _find_reconciliation_target(None, cities, city_indices_by_slug, own_index=0) is None
 
-    def test_address_locality_missing_is_none(self):
-        assert _address_locality(None) is None
+    def test_reconciliation_target_matches_own_city_is_none(self):
+        # The address names the SAME city the stop is already filed under --
+        # not a mismatch, no action.
+        cities = [self._city("Cartagena", [])]
+        city_indices_by_slug = {"cartagena": [0]}
+        target = _find_reconciliation_target(
+            "Calle 1, Cartagena, Colombia", cities, city_indices_by_slug, own_index=0
+        )
+        assert target is None
+
+    def test_reconciliation_target_state_segment_not_misread_as_city(self):
+        # The MYS-660 r3 regression, unit-tested directly against the
+        # helper: "Massachusetts" must never be treated as a locality
+        # candidate that could match (or fail to match) a CityPlan -- it is
+        # a state, and Salem is the correct, positively-identified target.
+        cities = [self._city("Boston", []), self._city("Salem", [])]
+        city_indices_by_slug = {"boston": [0], "salem": [1]}
+        target = _find_reconciliation_target(
+            "19 1/2 Washington Square N, Salem, Massachusetts, USA",
+            cities,
+            city_indices_by_slug,
+            own_index=0,
+        )
+        assert target == 1
+
+    def test_reconciliation_target_no_known_city_anywhere_is_none(self):
+        # Lyon resolves as a real place but matches no CityPlan on this
+        # itinerary at all -- fail open, not a drop signal.
+        cities = [self._city("Paris", [])]
+        city_indices_by_slug = {"paris": [0]}
+        target = _find_reconciliation_target(
+            "Rue de Rivoli, Lyon, France", cities, city_indices_by_slug, own_index=0
+        )
+        assert target is None
 
 
 class TestGroundingTokenMatch:

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -38,6 +38,8 @@ from core.extraction import (
     downgrade_ungrounded_match_types,
     reconcile_stop_city_grouping,
     _find_reconciliation_target,
+    _city_names,
+    _drop_suggestions_naming_removed_cities,
     grounding_token_set,
     is_title_grounded,
 )
@@ -1351,6 +1353,82 @@ class TestReconcileStopCityGrouping:
         }
         out = reconcile_stop_city_grouping(itin)
         assert [c["name"] for c in out["cities"]] == ["Cartagena"]
+
+    # ── MYS-660 r6 (Eng Lead review of r5 on ai#261): a city THIS PASS drops
+    # can orphan a composer suggestion chip that named it ────────────────────
+    #
+    # Before this guard existed, no city was ever removed post-composition,
+    # so a suggestion chip's action_prompt always named a city that still
+    # existed. This guard's own re-file/drop can now empty and remove a
+    # city a chip named -- executor.expand()'s target-city scan then finds
+    # no match on any persisted city and silently falls back to cities[0],
+    # persisting the expansion under the WRONG city. _city_names +
+    # _drop_suggestions_naming_removed_cities close that gap; these tests
+    # exercise them the same way _finalize composes them (diff before/after,
+    # then filter), since _finalize itself is a private closure inside
+    # extract_itinerary_from_response.
+
+    def test_suggestion_naming_a_city_this_pass_drops_is_removed(self):
+        itin = {
+            "summary_text": "t",
+            "cities": [
+                self._city(
+                    "Aracataca",
+                    [
+                        self._stop(
+                            "La Cocina de Pepina",
+                            "Calle 25 #10B-15, Getsemani, Cartagena, Colombia",
+                        )
+                    ],
+                ),
+                self._city(
+                    "Cartagena",
+                    [self._stop("Walled City", "Centro Historico, Cartagena, Colombia")],
+                ),
+            ],
+        }
+        suggestions = [
+            {"id": "1", "label": "More in Aracataca", "action_prompt": "Find more spots in Aracataca"},
+            {"id": "2", "label": "More in Cartagena", "action_prompt": "Find more spots in Cartagena"},
+        ]
+
+        names_before = _city_names(itin)
+        out = reconcile_stop_city_grouping(itin)
+        # Sanity: reproduces the existing r2 fixture -- Aracataca is emptied
+        # by this pass (its only stop re-files to Cartagena) and dropped.
+        assert [c["name"] for c in out["cities"]] == ["Cartagena"]
+
+        removed_names = names_before - _city_names(out)
+        assert removed_names == {"aracataca"}
+
+        kept = _drop_suggestions_naming_removed_cities(suggestions, removed_names)
+        assert [chip["id"] for chip in kept] == ["2"]
+
+    def test_suggestion_naming_a_surviving_city_is_kept_even_when_another_city_is_dropped(self):
+        removed_names = {"aracataca"}
+        suggestions = [
+            {"id": "1", "action_prompt": "Find more spots in Aracataca"},
+            {"id": "2", "action_prompt": "Find more spots in Cartagena"},
+            {"id": "3", "label": "Find books like this", "action_prompt": ""},
+        ]
+        kept = _drop_suggestions_naming_removed_cities(suggestions, removed_names)
+        # The Cartagena chip and the city-agnostic "Find books like this"
+        # chip (empty action_prompt, per _build_book_recommendation_chip)
+        # both survive -- only the chip positively naming a REMOVED city goes.
+        assert [chip["id"] for chip in kept] == ["2", "3"]
+
+    def test_drop_suggestions_is_a_no_op_when_nothing_was_removed(self):
+        suggestions = [{"id": "1", "action_prompt": "Find more spots in Cartagena"}]
+        assert _drop_suggestions_naming_removed_cities(suggestions, set()) == suggestions
+        assert _drop_suggestions_naming_removed_cities([], {"aracataca"}) == []
+        assert _drop_suggestions_naming_removed_cities(None, {"aracataca"}) is None
+
+    def test_city_names_is_case_insensitive_and_tolerates_malformed_input(self):
+        assert _city_names(None) == set()
+        assert _city_names({"cities": "not-a-list"}) == set()
+        assert _city_names({"cities": [{"name": "Cartagena"}, {"no_name": True}, "not-a-dict"]}) == {
+            "cartagena"
+        }
 
     def test_reconciliation_target_matches_a_known_different_city(self):
         cities = [

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1470,6 +1470,73 @@ class TestReconcileStopCityGrouping:
             "New York": {"Empire State Building"},
         }
 
+    def test_reconciliation_target_unique_match_still_country_checked(self):
+        # MYS-660 r5 / Codex P2, unit-tested directly against the helper:
+        # the OLD code only country-qualified a segment when more than one
+        # CityPlan shared its slug -- a LONE same-named CityPlan matched on
+        # name alone, ignoring the address's own country. Here the trip's
+        # only "Paris" CityPlan is in France, but the address says
+        # "Paris, Texas, USA" -- the country disagreement must be honored
+        # even though "paris" resolves to exactly one candidate.
+        cities = [
+            self._city("Dallas", [], country="USA"),
+            self._city("Paris", [], country="France"),
+        ]
+        city_indices_by_slug = {"dallas": [0], "paris": [1]}
+        target = _find_reconciliation_target(
+            "123 Main St, Paris, Texas, USA",
+            cities,
+            city_indices_by_slug,
+            own_index=0,
+        )
+        assert target is None
+
+    def test_paris_texas_stop_is_not_misfiled_to_paris_france(self):
+        # Full reconcile_stop_city_grouping-level regression for the same
+        # bug: a Dallas-filed stop addressed in Paris, TEXAS must not be
+        # re-filed into a same-trip Paris, FRANCE CityPlan just because the
+        # city name matches -- the country must agree too, unique match or
+        # not.
+        itin = {
+            "summary_text": "t",
+            "cities": [
+                self._city(
+                    "Dallas",
+                    [self._stop("Reunion Tower", "300 Reunion Blvd, Paris, Texas, USA")],
+                    country="USA",
+                ),
+                self._city(
+                    "Paris",
+                    [self._stop("Eiffel Tower", "Champ de Mars, Paris, France")],
+                    country="France",
+                ),
+            ],
+        }
+        out = reconcile_stop_city_grouping(itin)
+        by_city = {c["name"]: {s["name"] for s in c["stops"]} for c in out["cities"]}
+        assert by_city == {
+            "Dallas": {"Reunion Tower"},
+            "Paris": {"Eiffel Tower"},
+        }
+
+    def test_reconciliation_target_unique_match_with_agreeing_country_still_refiles(self):
+        # Contrast with the two tests above: when the trip's only "Paris"
+        # CityPlan agrees with the address's country, the unique-match path
+        # must still positively re-file -- the r5 fix adds a country check,
+        # it must not turn into "never trust a unique match".
+        cities = [
+            self._city("Dallas", [], country="USA"),
+            self._city("Paris", [], country="USA"),
+        ]
+        city_indices_by_slug = {"dallas": [0], "paris": [1]}
+        target = _find_reconciliation_target(
+            "123 Main St, Paris, Texas, USA",
+            cities,
+            city_indices_by_slug,
+            own_index=0,
+        )
+        assert target == 1
+
 
 class TestGroundingTokenMatch:
     """The shared matching primitive behind all three grounding guards."""

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1418,6 +1418,58 @@ class TestReconcileStopCityGrouping:
         )
         assert target is None
 
+    def test_reconciliation_target_own_city_wins_over_a_different_segment_match(self):
+        # MYS-660 r4 / Codex P1, unit-tested directly against the helper:
+        # a stop filed under Buffalo whose address is
+        # "..., Buffalo, New York, USA" names BOTH its own city (Buffalo)
+        # AND a state that happens to share a name with a different
+        # same-trip CityPlan (New York). r3 let the later "New York"
+        # segment outvote the earlier "Buffalo" (own-city) evidence and
+        # re-filed a correct stop into the wrong city. Own-city evidence
+        # anywhere in the address must win, regardless of segment order.
+        cities = [self._city("Buffalo", []), self._city("New York", [])]
+        city_indices_by_slug = {"buffalo": [0], "new-york": [1]}
+        target = _find_reconciliation_target(
+            "1 Symphony Cir, Buffalo, New York, USA",
+            cities,
+            city_indices_by_slug,
+            own_index=0,
+        )
+        assert target is None
+
+    def test_buffalo_stop_stays_put_and_is_not_deleted(self):
+        # Full reconcile_stop_city_grouping-level regression for the same
+        # bug: a same-trip itinerary with both Buffalo and New York as
+        # CityPlans must leave the Buffalo-filed, Buffalo-addressed stop
+        # exactly where it is -- and Buffalo, left with one stop, must
+        # survive (not be swept by the "emptied by this pass" drop rule).
+        itin = {
+            "summary_text": "t",
+            "cities": [
+                self._city(
+                    "Buffalo",
+                    [
+                        self._stop(
+                            "Buffalo City Hall",
+                            "65 Niagara Sq, Buffalo, New York, USA",
+                        )
+                    ],
+                    country="USA",
+                ),
+                self._city(
+                    "New York",
+                    [self._stop("Empire State Building", "20 W 34th St, New York, USA")],
+                    country="USA",
+                ),
+            ],
+        }
+        out = reconcile_stop_city_grouping(itin)
+        by_city = {c["name"]: {s["name"] for s in c["stops"]} for c in out["cities"]}
+        assert by_city == {
+            "Buffalo": {"Buffalo City Hall"},
+            "New York": {"Empire State Building"},
+        }
+
 
 class TestGroundingTokenMatch:
     """The shared matching primitive behind all three grounding guards."""

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1392,43 +1392,102 @@ class TestReconcileStopCityGrouping:
             {"id": "2", "label": "More in Cartagena", "action_prompt": "Find more spots in Cartagena"},
         ]
 
-        names_before = _city_names(itin)
+        identities_before = _city_names(itin)
         out = reconcile_stop_city_grouping(itin)
         # Sanity: reproduces the existing r2 fixture -- Aracataca is emptied
         # by this pass (its only stop re-files to Cartagena) and dropped.
         assert [c["name"] for c in out["cities"]] == ["Cartagena"]
 
-        removed_names = names_before - _city_names(out)
-        assert removed_names == {"aracataca"}
+        identities_after = _city_names(out)
+        removed_identities = identities_before - identities_after
+        assert removed_identities == {("aracataca", "CO")}
 
-        kept = _drop_suggestions_naming_removed_cities(suggestions, removed_names)
+        kept = _drop_suggestions_naming_removed_cities(suggestions, removed_identities, identities_after)
         assert [chip["id"] for chip in kept] == ["2"]
 
     def test_suggestion_naming_a_surviving_city_is_kept_even_when_another_city_is_dropped(self):
-        removed_names = {"aracataca"}
+        removed_identities = {("aracataca", "CO")}
+        surviving_identities = {("cartagena", "CO")}
         suggestions = [
             {"id": "1", "action_prompt": "Find more spots in Aracataca"},
             {"id": "2", "action_prompt": "Find more spots in Cartagena"},
             {"id": "3", "label": "Find books like this", "action_prompt": ""},
         ]
-        kept = _drop_suggestions_naming_removed_cities(suggestions, removed_names)
+        kept = _drop_suggestions_naming_removed_cities(suggestions, removed_identities, surviving_identities)
         # The Cartagena chip and the city-agnostic "Find books like this"
         # chip (empty action_prompt, per _build_book_recommendation_chip)
-        # both survive -- only the chip positively naming a REMOVED city goes.
+        # both survive -- only the chip positively naming a REMOVED city,
+        # with no surviving city to resolve to instead, goes.
         assert [chip["id"] for chip in kept] == ["2", "3"]
+
+    # ── MYS-660 r7 (Codex P1, valid): the r6 filter's ONE substring test
+    # over-dropped -- a removed name that's merely a SUBSTRING of unrelated
+    # surviving prompt text (a real different city, or ordinary English)
+    # was enough to drop a perfectly resolvable chip. The fix checks BOTH
+    # directions: names a removed city AND does not ALSO still resolve to a
+    # surviving one -- mirroring executor.expand()'s own first-match scan
+    # over the CURRENT cities list, not a guess about what was removed.
+
+    def test_suggestion_surviving_a_substring_collision_with_a_removed_name_is_kept(self):
+        # "York" was removed; "New York" survives. The naive substring test
+        # ("york" in "find more spots in new york") would false-drop this
+        # perfectly valid, still-resolvable chip.
+        removed_identities = {("york", "US")}
+        surviving_identities = {("new york", "US")}
+        suggestions = [{"id": "1", "action_prompt": "Find more spots in New York"}]
+        kept = _drop_suggestions_naming_removed_cities(suggestions, removed_identities, surviving_identities)
+        assert [chip["id"] for chip in kept] == ["1"]
+
+    def test_suggestion_naming_only_a_removed_city_with_no_surviving_match_is_dropped(self):
+        # The genuine orphan case: names a removed city, and nothing
+        # surviving would resolve it either -- this is exactly the chip
+        # that would silently fall back to cities[0] in expand().
+        removed_identities = {("aracataca", "CO")}
+        surviving_identities = {("cartagena", "CO")}
+        suggestions = [{"id": "1", "action_prompt": "Find more spots in Aracataca"}]
+        kept = _drop_suggestions_naming_removed_cities(suggestions, removed_identities, surviving_identities)
+        assert kept == []
 
     def test_drop_suggestions_is_a_no_op_when_nothing_was_removed(self):
         suggestions = [{"id": "1", "action_prompt": "Find more spots in Cartagena"}]
-        assert _drop_suggestions_naming_removed_cities(suggestions, set()) == suggestions
-        assert _drop_suggestions_naming_removed_cities([], {"aracataca"}) == []
-        assert _drop_suggestions_naming_removed_cities(None, {"aracataca"}) is None
+        assert _drop_suggestions_naming_removed_cities(suggestions, set(), {("cartagena", "CO")}) == suggestions
+        assert _drop_suggestions_naming_removed_cities([], {("aracataca", "CO")}, set()) == []
+        assert _drop_suggestions_naming_removed_cities(None, {("aracataca", "CO")}, set()) is None
 
     def test_city_names_is_case_insensitive_and_tolerates_malformed_input(self):
         assert _city_names(None) == set()
         assert _city_names({"cities": "not-a-list"}) == set()
-        assert _city_names({"cities": [{"name": "Cartagena"}, {"no_name": True}, "not-a-dict"]}) == {
-            "cartagena"
+        assert _city_names(
+            {"cities": [{"name": "Cartagena", "country": "Colombia"}, {"no_name": True}, "not-a-dict"]}
+        ) == {("cartagena", "CO")}
+
+    def test_city_names_tolerates_an_unresolvable_country(self):
+        assert _city_names({"cities": [{"name": "Neverland", "country": "Nowhereland"}]}) == {
+            ("neverland", None)
         }
+
+    # ── MYS-660 r7 (Codex P2, valid): _city_names must be COUNTRY-qualified,
+    # same lesson as MYS-548 and _find_reconciliation_target's own country
+    # check -- two same-trip cities sharing a bare name collapse to ONE
+    # set entry, so removing one of them while the other survives looked
+    # like "nothing was removed" under a name-only diff.
+
+    def test_city_names_distinguishes_same_named_cities_in_different_countries(self):
+        itin = {
+            "cities": [
+                self._city("London", [], country="United Kingdom"),
+                self._city("London", [], country="Canada"),
+            ]
+        }
+        assert _city_names(itin) == {("london", "GB"), ("london", "CA")}
+
+    def test_removal_of_one_same_named_city_is_detected_even_though_another_survives(self):
+        before = {("london", "GB"), ("london", "CA"), ("cartagena", "CO")}
+        after = {("london", "CA"), ("cartagena", "CO")}
+        # A bare-name diff would see "london" on both sides and report NO
+        # removal at all -- the country-qualified diff correctly isolates
+        # the specific (name, country) identity that's actually gone.
+        assert before - after == {("london", "GB")}
 
     def test_reconciliation_target_matches_a_known_different_city(self):
         cities = [
@@ -1476,7 +1535,19 @@ class TestReconcileStopCityGrouping:
         # helper: "Massachusetts" must never be treated as a locality
         # candidate that could match (or fail to match) a CityPlan -- it is
         # a state, and Salem is the correct, positively-identified target.
-        cities = [self._city("Boston", []), self._city("Salem", [])]
+        #
+        # r7: explicit country="USA" on BOTH cities -- this test predates
+        # r5's country-qualification (every segment, including a unique
+        # match, is now qualified against the address's own country) and
+        # was never updated for it. Left at `_city`'s "Colombia" default,
+        # Salem's own CityPlan country (Colombia) disagreed with the
+        # address's resolved country (USA) and the match was silently
+        # excluded -- `target` came back None instead of 1, a latent
+        # fixture bug this run's standalone verification caught (r5/r6
+        # were never actually run against the real suite, only reasoned
+        # about by hand -- see PR notes). The address is USA; the fixture
+        # must be too.
+        cities = [self._city("Boston", [], country="USA"), self._city("Salem", [], country="USA")]
         city_indices_by_slug = {"boston": [0], "salem": [1]}
         target = _find_reconciliation_target(
             "19 1/2 Washington Square N, Salem, Massachusetts, USA",
@@ -1614,6 +1685,64 @@ class TestReconcileStopCityGrouping:
             own_index=0,
         )
         assert target == 1
+
+    # ── MYS-660 r7 (Codex P2, lowest severity, fail-open under-reach not a
+    # regression): a resolved trailing segment was ALWAYS dropped as a
+    # locality candidate, even when it's also the city itself -- a
+    # city-state address ("Marina Bay, Singapore") lost the only segment
+    # that could ever have named that CityPlan, so a same-trip misfile
+    # there went unreconciled. Keep it as a candidate too when it ALSO
+    # slug-matches a CityPlan already on the trip.
+
+    def test_reconciliation_target_city_state_trailing_segment_still_matches(self):
+        cities = [
+            self._city("Kuala Lumpur", [], country="Malaysia"),
+            self._city("Singapore", [], country="Singapore"),
+        ]
+        city_indices_by_slug = {"kuala-lumpur": [0], "singapore": [1]}
+        target = _find_reconciliation_target(
+            "Marina Bay, Singapore",
+            cities,
+            city_indices_by_slug,
+            own_index=0,
+        )
+        assert target == 1
+
+    def test_reconciliation_target_trailing_segment_still_excluded_when_it_names_no_city(self):
+        # The unchanged case: a trailing segment that resolves as a country
+        # AND names no CityPlan on this trip is still excluded as a
+        # locality candidate -- this fix only ADDS a candidate when one
+        # genuinely exists, it doesn't stop stripping otherwise.
+        cities = [self._city("Kuala Lumpur", [], country="Malaysia")]
+        city_indices_by_slug = {"kuala-lumpur": [0]}
+        target = _find_reconciliation_target(
+            "Somewhere, Malaysia",
+            cities,
+            city_indices_by_slug,
+            own_index=0,
+        )
+        assert target is None
+
+    def test_marina_bay_singapore_stop_is_reconciled_to_the_city_state(self):
+        # Full reconcile_stop_city_grouping-level regression: a stop
+        # addressed in the city-state itself, filed under the wrong city,
+        # must be re-filed -- previously the trailing "Singapore" segment
+        # was stripped outright as "just the country" and this mismatch
+        # went undetected.
+        itin = {
+            "summary_text": "t",
+            "cities": [
+                self._city(
+                    "Kuala Lumpur",
+                    [self._stop("Marina Bay Sands", "Marina Bay, Singapore")],
+                    country="Malaysia",
+                ),
+                self._city("Singapore", [], country="Singapore"),
+            ],
+        }
+        out = reconcile_stop_city_grouping(itin)
+        by_city = {c["name"]: {s["name"] for s in c["stops"]} for c in out["cities"]}
+        assert by_city == {"Singapore": {"Marina Bay Sands"}}
 
 
 class TestGroundingTokenMatch:

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1448,6 +1448,40 @@ class TestReconcileStopCityGrouping:
         kept = _drop_suggestions_naming_removed_cities(suggestions, removed_identities, surviving_identities)
         assert kept == []
 
+    # ── MYS-660 r8 (Codex P2, lower severity): the (a)/(b) test is
+    # name-only, same limit `expand()` itself has -- `action_prompt` is
+    # free text, no country field to qualify against. That's inherent, not
+    # a bug. What r6/r7 got wrong is going silent about it: a removed
+    # identity and a surviving identity can share a bare name but resolve
+    # to DIFFERENT countries (a removed London, GB "surviving" only
+    # because a same-trip London, CA also exists) -- the chip is correctly
+    # KEPT (nothing safer to do with no country signal), but a warning
+    # must fire so the ambiguity is visible, unlike the ordinary
+    # unambiguous "still resolves" case.
+
+    def test_drop_suggestions_keeps_a_cross_country_name_collision_chip(self):
+        # No safe alternative exists (no country in free text) -- the
+        # behavioral contract is "still kept, same as the ordinary case";
+        # the r8 fix additionally logs a warning naming the collision
+        # (`suggestion_kept_despite_removed_city_name_collision`) so it's
+        # visible rather than silently indistinguishable from the
+        # unambiguous survivor case below.
+        removed_identities = {("london", "GB")}
+        surviving_identities = {("london", "CA")}
+        suggestions = [{"id": "1", "action_prompt": "More like London"}]
+        kept = _drop_suggestions_naming_removed_cities(suggestions, removed_identities, surviving_identities)
+        assert kept == suggestions
+
+    def test_drop_suggestions_does_not_flag_the_ordinary_unambiguous_survivor(self):
+        # Contrast case: no country collision at all (both unresolved) --
+        # the ordinary "still resolves" path, no warning expected beyond
+        # what the plain substring test already covers.
+        removed_identities = {("york", None)}
+        surviving_identities = {("new york", None)}
+        suggestions = [{"id": "1", "action_prompt": "Find more spots in New York"}]
+        kept = _drop_suggestions_naming_removed_cities(suggestions, removed_identities, surviving_identities)
+        assert kept == suggestions
+
     def test_drop_suggestions_is_a_no_op_when_nothing_was_removed(self):
         suggestions = [{"id": "1", "action_prompt": "Find more spots in Cartagena"}]
         assert _drop_suggestions_naming_removed_cities(suggestions, set(), {("cartagena", "CO")}) == suggestions
@@ -1583,6 +1617,70 @@ class TestReconcileStopCityGrouping:
             cities,
             city_indices_by_slug,
             own_index=0,
+        )
+        assert target is None
+
+    # ── MYS-660 r8 (Codex P1, blocking): a US state/territory name can
+    # collide with a DIFFERENT same-trip city's name -- "Washington" the
+    # STATE happens to equal "Washington" a same-trip CityPlan (Washington,
+    # D.C.). The all-segment scan (r3-r7) treated any segment matching a
+    # known CityPlan as locality evidence, so a Seattle-addressed stop
+    # (Seattle itself is NOT a CityPlan on this trip) got actively RE-FILED
+    # into Washington on state-name-only evidence -- the exact wrong-city
+    # placement this guard exists to prevent, and could delete Washington
+    # if it was that city's only stop. A state-name segment must never be
+    # the sole different-city signal; own-city attestation is unaffected.
+
+    def test_reconciliation_target_state_name_colliding_with_a_different_city_is_not_a_locality(self):
+        cities = [self._city("Portland", [], country="USA"), self._city("Washington", [], country="USA")]
+        city_indices_by_slug = {"portland": [0], "washington": [1]}
+        target = _find_reconciliation_target(
+            "Pike Place, Seattle, Washington, USA",
+            cities,
+            city_indices_by_slug,
+            own_index=0,
+        )
+        assert target is None
+
+    def test_seattle_stop_addressed_in_washington_state_is_not_misfiled_to_washington_dc(self):
+        # Full reconcile_stop_city_grouping-level regression for the same
+        # bug: a Portland-filed, Seattle-addressed stop must not be
+        # re-filed into a same-trip Washington CityPlan just because the
+        # address's STATE field is the string "Washington".
+        itin = {
+            "summary_text": "t",
+            "cities": [
+                self._city(
+                    "Portland",
+                    [self._stop("Voodoo Doughnut", "Pike Place, Seattle, Washington, USA")],
+                    country="USA",
+                ),
+                self._city(
+                    "Washington",
+                    [self._stop("Lincoln Memorial", "2 Lincoln Memorial Cir NW, Washington, USA")],
+                    country="USA",
+                ),
+            ],
+        }
+        out = reconcile_stop_city_grouping(itin)
+        by_city = {c["name"]: {s["name"] for s in c["stops"]} for c in out["cities"]}
+        assert by_city == {
+            "Portland": {"Voodoo Doughnut"},
+            "Washington": {"Lincoln Memorial"},
+        }
+
+    def test_reconciliation_target_state_name_exclusion_does_not_block_own_city_attestation(self):
+        # A real Washington, D.C. stop -- own-city "still home" evidence
+        # must stay unrestricted (only the DIFFERENT-city re-file signal is
+        # restricted): the address's own "Washington" segment matching the
+        # stop's OWN CityPlan still short-circuits to "no action".
+        cities = [self._city("Portland", [], country="USA"), self._city("Washington", [], country="USA")]
+        city_indices_by_slug = {"portland": [0], "washington": [1]}
+        target = _find_reconciliation_target(
+            "2 Lincoln Memorial Cir NW, Washington, USA",
+            cities,
+            city_indices_by_slug,
+            own_index=1,
         )
         assert target is None
 

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -36,6 +36,8 @@ from core.extraction import (
     extract_expansion_from_state,
     extract_book_recommendations_from_state,
     downgrade_ungrounded_match_types,
+    reconcile_stop_city_grouping,
+    _address_locality,
     grounding_token_set,
     is_title_grounded,
 )
@@ -1020,6 +1022,260 @@ class TestDowngradeUngroundedMatchTypes:
         stop = out["cities"][0]["stops"][0]
         assert stop["match_type"] == "literal"
         assert stop["grounding_source"] == "ch. 2"
+
+
+class TestReconcileStopCityGrouping:
+    """MYS-660: a stop's own address must agree with the CityPlan it's filed
+    under, verified against the live Colombia case (3 Cartagena-addressed
+    restaurants served under Aracataca, ~250km away, while Cartagena was ALSO
+    its own city on the same itinerary) plus the drop/fail-open/fold edges
+    the tech plan calls out.
+    """
+
+    @staticmethod
+    def _stop(name, address=None):
+        return {
+            "name": name,
+            "type": "restaurant",
+            "reason": "x",
+            "address": address,
+            "time_of_day": "evening",
+        }
+
+    @staticmethod
+    def _city(name, stops, country="Colombia"):
+        return {
+            "name": name,
+            "country": country,
+            "days_suggested": 1,
+            "overview": "o",
+            "stops": stops,
+        }
+
+    def test_colombia_case_refiles_under_the_existing_city(self):
+        # The exact live defect: 3 Cartagena-addressed stops filed under
+        # Aracataca, with Cartagena ALSO present as its own city.
+        itin = {
+            "summary_text": "t",
+            "cities": [
+                self._city(
+                    "Aracataca",
+                    [
+                        self._stop("Museo Casa", "Cra 5 #4-40, Aracataca, Colombia"),
+                        self._stop(
+                            "La Cocina de Pepina",
+                            "Calle 25 #10B-15, Getsemani, Cartagena, Colombia",
+                        ),
+                        self._stop(
+                            "La Cevicheria",
+                            "Calle Stuart #7-14, Centro Historico, Cartagena, Colombia",
+                        ),
+                        self._stop(
+                            "La Vitrola",
+                            "Calle de los Estribos #33-65, Centro Historico, Cartagena, Colombia",
+                        ),
+                    ],
+                ),
+                self._city(
+                    "Cartagena",
+                    [
+                        self._stop("Walled City", "Centro Historico, Cartagena, Colombia"),
+                        self._stop("Cafe del Mar", "Baluarte de Santo Domingo, Cartagena, Colombia"),
+                    ],
+                ),
+            ],
+        }
+        out = reconcile_stop_city_grouping(itin)
+        by_city = {c["name"]: {s["name"] for s in c["stops"]} for c in out["cities"]}
+        assert by_city["Aracataca"] == {"Museo Casa"}
+        assert by_city["Cartagena"] == {
+            "Walled City",
+            "Cafe del Mar",
+            "La Cocina de Pepina",
+            "La Cevicheria",
+            "La Vitrola",
+        }
+
+    def test_mismatch_with_no_matching_city_is_dropped(self):
+        itin = {
+            "summary_text": "t",
+            "cities": [
+                self._city(
+                    "Paris",
+                    [
+                        self._stop("Eiffel Tower", "Champ de Mars, Paris, France"),
+                        self._stop("Ghost Cafe", "Rue de Rivoli, Lyon, France"),
+                    ],
+                    country="France",
+                ),
+            ],
+        }
+        out = reconcile_stop_city_grouping(itin)
+        names = [s["name"] for s in out["cities"][0]["stops"]]
+        assert names == ["Eiffel Tower"]
+
+    def test_fail_open_on_no_address_or_single_fragment(self):
+        # No signal is not evidence of a mismatch -- left exactly where the
+        # composer put it, matching this file's other guardrails.
+        itin = {
+            "summary_text": "t",
+            "cities": [
+                self._city(
+                    "Rome",
+                    [
+                        self._stop("Trevi Fountain", None),
+                        self._stop("Mystery Spot", "Somewhere magical"),
+                    ],
+                    country="Italy",
+                ),
+            ],
+        }
+        out = reconcile_stop_city_grouping(itin)
+        names = [s["name"] for s in out["cities"][0]["stops"]]
+        assert names == ["Trevi Fountain", "Mystery Spot"]
+
+    def test_city_left_with_zero_stops_is_dropped(self):
+        itin = {
+            "summary_text": "t",
+            "cities": [
+                self._city(
+                    "Lyon",
+                    [self._stop("Ghost Cafe", "Rue de Rivoli, Paris, France")],
+                    country="France",
+                ),
+                self._city(
+                    "Paris",
+                    [self._stop("Louvre", "Rue de Rivoli, Paris, France")],
+                    country="France",
+                ),
+            ],
+        }
+        out = reconcile_stop_city_grouping(itin)
+        assert [c["name"] for c in out["cities"]] == ["Paris"]
+        assert {s["name"] for s in out["cities"][0]["stops"]} == {"Louvre", "Ghost Cafe"}
+
+    def test_accent_and_case_fold_match(self):
+        # Address tail "CIENAGA" (no accent, upper) must fold-match the
+        # CityPlan name "Ciénaga" (accented) -- same helper mint_place_key
+        # uses, so the two paths can never drift on what counts as a match.
+        itin = {
+            "summary_text": "t",
+            "cities": [
+                self._city(
+                    "Aracataca",
+                    [self._stop("Wrong filed", "Calle 1, CIENAGA, Colombia")],
+                ),
+                self._city(
+                    "Ciénaga",
+                    [self._stop("Plaza Centenario", "Plaza Centenario, Ciénaga, Colombia")],
+                ),
+            ],
+        }
+        out = reconcile_stop_city_grouping(itin)
+        by_city = {c["name"]: {s["name"] for s in c["stops"]} for c in out["cities"]}
+        assert by_city == {"Ciénaga": {"Plaza Centenario", "Wrong filed"}}
+
+    def test_non_deterministic_recomposition_both_internally_consistent(self):
+        # MYS-563: composition is non-deterministic -- this is deterministic
+        # POST-processing, so it must hold regardless of which of two
+        # differently-shaped compositions of "the same book" comes out of
+        # the model. Two structurally different fixtures, both must end up
+        # with zero remaining address/city mismatches.
+        fixture_a = {
+            "summary_text": "t",
+            "cities": [
+                self._city(
+                    "Paris",
+                    [
+                        self._stop("Eiffel Tower", "Champ de Mars, Paris, France"),
+                        self._stop("Ghost Cafe", "Rue de Rivoli, Lyon, France"),
+                    ],
+                    country="France",
+                ),
+            ],
+        }
+        fixture_b = {
+            "summary_text": "t",
+            "cities": [
+                self._city("Aracataca", [self._stop("Wrong filed", "Calle 1, Cienaga, Colombia")]),
+                self._city("Ciénaga", [self._stop("Plaza Centenario", "Plaza Centenario, Ciénaga, Colombia")]),
+            ],
+        }
+
+        def is_internally_consistent(result):
+            for city in result["cities"]:
+                for stop in city["stops"]:
+                    locality = _address_locality(stop.get("address"))
+                    if locality is None:
+                        continue
+                    from models.place_key import slug
+
+                    if slug(locality) and slug(locality) != slug(city["name"]):
+                        return False
+            return True
+
+        assert is_internally_consistent(reconcile_stop_city_grouping(fixture_a))
+        assert is_internally_consistent(reconcile_stop_city_grouping(fixture_b))
+
+    def test_none_itinerary_returns_none(self):
+        assert reconcile_stop_city_grouping(None) is None
+
+    def test_city_that_arrives_already_empty_is_left_alone(self):
+        # Regression: a city with 0 stops BEFORE this pass runs (e.g. an
+        # extraction fixture/edge case unrelated to city/address mismatch)
+        # must not be swept up by the "empty city is worse than no section"
+        # rule -- that rule is scoped to cities THIS PASS emptied, never to
+        # a city that arrived already empty. A prior implementation dropped
+        # every zero-stop city unconditionally, which crashed callers
+        # indexing into `cities[0]` on a single-city, zero-stop itinerary.
+        itin = {
+            "summary_text": "t",
+            "cities": [self._city("London", [])],
+        }
+        out = reconcile_stop_city_grouping(itin)
+        assert [c["name"] for c in out["cities"]] == ["London"]
+        assert out["cities"][0]["stops"] == []
+
+    def test_city_emptied_by_this_pass_is_still_dropped(self):
+        # Contrast with the above: a city that HAD stops before this pass,
+        # and ends with none because every stop was re-filed/dropped, is
+        # still removed per MYS-268 -- only the "arrived empty" case is
+        # exempt, not the "this pass emptied it" case.
+        itin = {
+            "summary_text": "t",
+            "cities": [
+                self._city(
+                    "Aracataca",
+                    [
+                        self._stop(
+                            "La Cocina de Pepina",
+                            "Calle 25 #10B-15, Getsemani, Cartagena, Colombia",
+                        )
+                    ],
+                ),
+                self._city(
+                    "Cartagena",
+                    [self._stop("Walled City", "Centro Historico, Cartagena, Colombia")],
+                ),
+            ],
+        }
+        out = reconcile_stop_city_grouping(itin)
+        assert [c["name"] for c in out["cities"]] == ["Cartagena"]
+
+    def test_address_locality_country_suffix_stripped(self):
+        assert (
+            _address_locality("Calle 25 #10B-15, Getsemani, Cartagena, Colombia")
+            == "Cartagena"
+        )
+
+    def test_address_locality_no_country_uses_last_segment(self):
+        assert _address_locality("221B Baker Street, London") == "London"
+
+    def test_address_locality_single_fragment_is_none(self):
+        assert _address_locality("Somewhere magical") is None
+
+    def test_address_locality_missing_is_none(self):
+        assert _address_locality(None) is None
 
 
 class TestGroundingTokenMatch:


### PR DESCRIPTION
# fix(ai): guard against a stop rendering under a city its own address contradicts

## What

Adds a deterministic post-composition check: a stop's own `address` must agree with the `CityPlan` it's filed under. A mismatched stop is re-filed under an existing same-trip city its address actually matches, or dropped if no such city exists on the itinerary — never rendered under the wrong city.

## Why

Verified live: `https://mystoryland.ai/i/colombian-caribbean-coast-CSuiMFRDYBsS` (*One Hundred Years of Solitude*) filed 3 Cartagena-addressed restaurants under Aracataca (~250km away), while Cartagena was **also** its own city on the same trip — not an ambiguous name, the same record contradicts itself. The composer groups stops by city itself, as free text (`agents/trip_composer_agent.py` + `agents/prompts/v3.json`), and nothing cross-checked a stop's `address` against the `CityPlan.name` it ended up filed under. Both fields are already on the record we hold — zero new upstream calls, zero spend (the founder's own framing: "a guard, not a data patch").

## How

- `core/extraction.py`: new `reconcile_stop_city_grouping(itinerary_dict)`, wired into `_finalize()` inside `extract_itinerary_from_response`, alongside the two existing post-composition guardrail passes (`downgrade_ungrounded_match_types`, `sanitize_itinerary_explanations`) — same fail-open contract, same call site.
  - `_address_locality(address)`: extracts the city from an address's free-text tail. The composer's own convention is "landmark + district + city + country", but the model's docstring gives a shorter shape too ("221B Baker Street, London", no country) — so this checks whether the *last* comma segment resolves as a real country name via `models.place_key.resolve_country_name`; if yes, locality is the segment before it, otherwise the last segment itself is the locality. Returns `None` (never a guess) for missing/empty/single-fragment addresses.
  - `reconcile_stop_city_grouping`: for each stop, compares its address locality (fold-compared via `models.place_key.slug()` — the exact same helper `mint_place_key`/`locality_matches_cities` already use, so this check and the region-identity key can never disagree on what counts as a name match) against the `CityPlan.name` it's filed under. On mismatch: re-file to the first same-named `CityPlan` already on this itinerary, or drop if none exists. A stop with no discernible address locality is left exactly where the composer put it (fail-open — no signal is not evidence of a mismatch).
  - Empty-city removal (MYS-268 "empty section is worse than no section") is scoped to **cities this pass itself emptied** — recorded via a `city_had_stops` snapshot taken before any mutation, then checked in the final filter. A city that *arrived* with zero stops (never touched by this guard at all) is left exactly as the composer emitted it.

## r2 fix (this revision) — the empty-city filter was over-broad

The first version of the empty-city filter (`[c for c in cities if not isinstance(c, dict) or c.get("stops")]`) dropped **every** zero-stop city unconditionally, not just ones this pass itself emptied. The local runner's `make test-ci` run caught this: `tests/unit/test_core.py::TestExtractItineraryFromResponse::test_from_envelope_in_state` and `test_from_bare_itinerary_state_fallback` both use a fixture with a single city (`"London"`, `"stops": []` deliberately, to isolate the extraction path from stop logic) — that city arrived empty, got swept by the unconditional filter, `cities` became `[]`, and the caller's `cities[0]` indexing raised `IndexError`.

Root cause traced to the diff, not treated as flake: the filter didn't distinguish "emptied by this pass" (the MYS-268 case it was meant for) from "arrived already empty" (a zero-stop city is not this guard's business at all — nothing about a stop's address can contradict a city that has no stops). Fixed by snapshotting each city's stop-count *before* the reconciliation loop mutates it, then only dropping a city in the final filter if it both (a) has no stops now and (b) had stops before this pass ran. Added `test_city_that_arrives_already_empty_is_left_alone` (the regression case) and `test_city_emptied_by_this_pass_is_still_dropped` (confirms the MYS-268 behavior the fix must not lose) to `TestReconcileStopCityGrouping`.

- Deterministic post-processing on whatever the composer emitted, so it holds regardless of MYS-563's composition non-determinism (a *different*, well-formed-vs-degenerate defect on the same book — read at source, confirmed not to overlap: 563 is the generation, 660 is validation of a well-formed-but-inconsistent envelope).

## Scope decisions (read before merge)

- **Not implemented:** the tech plan's "reject the whole envelope if the mismatch rate is pathological" escape hatch. The tech plan itself calls this "the last resort, not the default" — re-file/drop covers AC-2 as written. Flagging so it isn't assumed to be covered; a follow-up if AC-1's measured rate ever warrants it.
- **AC-1 (measure the mismatch rate across a sample of composed itineraries) is NOT done in this PR.** The tech plan scoped this as a read-only, no-spend pass over `evaluation/*` outputs, cached compositions, and live `/i/` pages — none of which this build environment can reach (no persisted-itinerary store access, no outbound access to `mystoryland.ai`). Flagging on the Linear issue for whoever has that access (likely QA or Eng Lead, who can query the be store or fetch live pages) rather than fabricating a number or silently dropping the AC.
- Diff is now ~385 lines (code ~150 + tests ~235), a little over the usual ~300-line guideline — flagging per that rule rather than pretending it's under. It's one indivisible logical unit (a single guard function plus its behavioral coverage, plus the r2 regression tests); splitting code from its own tests across two PRs isn't a real decomposition.

## Docs

`no impact` — no architecture, endpoint, route, or config change; an internal deterministic validation pass added to an existing post-composition guardrail chain, same pattern as the two guardrails already documented in that chain's own docstrings.

## Verification

**Environment note — read before assuming this wasn't tested:** this build environment's Python is 3.10; `google-adk>=2.4.0` (this repo's core dependency) requires Python ≥3.11 to install, so `pip install -r requirements.lock` fails here (pre-existing, documented environment gap, not new — this sandbox reproduced it again this run). `tests/unit/test_core.py` also imports `core.executor.WorkflowExecutor`, which drags in the same ADK chain — so the full file can't be collected/run in this environment either.

What was actually verified, directly, against the real code (not asserted from reading it), this revision:
- Installed a lightweight venv (pydantic, structlog only — no ADK) and imported `core.extraction` directly by pre-registering a stub `core` package in `sys.modules` (bypassing `core/__init__.py`'s eager `WorkflowExecutor` import, which is not on this function's dependency path) — confirmed `reconcile_stop_city_grouping` and `_address_locality` import and run cleanly.
- Ran every scenario in `TestReconcileStopCityGrouping` by hand against the live function, standalone, **including the two new r2 regression cases**: a single zero-stop city (`_VALID_ITINERARY`'s exact shape) now survives with its empty `stops` list intact, and a city emptied *by this pass* (all its stops re-filed elsewhere) is still dropped. Also re-ran the full original scenario set: the exact Colombia fixture (3 stops correctly re-filed to the existing Cartagena `CityPlan`, `Aracataca` left with only its own stop), the drop case, the fail-open case, the accent/case-fold case, and the AC-4 non-determinism check (two structurally different fixtures, both come out with zero remaining address/city mismatches) — all passed.
- `python3 -m py_compile core/extraction.py tests/unit/test_core.py` — both clean.
- Manually reproduced the exact fixture shape (`{"cities": [{"name": "London", ..., "stops": []}], ...}`) that broke `test_from_envelope_in_state`/`test_from_bare_itinerary_state_fallback` under r1 and confirmed `reconcile_stop_city_grouping` now returns it with `London` intact rather than an empty `cities` list.

**Please re-run the real suite on merge/CI** (`make test-ci`, coverage floor per `pyproject.toml`) — this environment could not, for the reason above, not because it was skipped. Reviewer focus: the `city_had_stops` snapshot must be taken before the mutation loop runs (order matters — it's reading `city.get("stops")` pre-reconciliation), and the final filter's `or not city_had_stops.get(i, True)` clause.
