### PR TITLE
fix(ai): make SessionStateAccessor read-only, persist book_metadata via append_event

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -439,12 +439,20 @@ class WorkflowExecutor:
 
             yield MetadataReady(metadata=book_metadata.model_dump())
 
-            # Store in session state
+            # Persist book metadata via append_event: in-place mutation of
+            # session.state does not survive get_session() (MYS-172) -- the
+            # accessor's setters were silent no-ops here.
             session = await self._session_service.get_session(
                 app_name=APP_NAME, user_id=user_id, session_id=job_id
             )
-            state = SessionStateAccessor(session.state)
-            state.book_metadata = book_metadata.model_dump()
+            metadata_event = Event(
+                invocation_id="system",
+                author="system",
+                actions=EventActions(
+                    state_delta={SessionStateKeys.BOOK_METADATA: book_metadata.model_dump()}
+                ),
+            )
+            await self._session_service.append_event(session, metadata_event)
 
             # Phase 2: Discovery
             yield ProgressEvent(
@@ -843,8 +851,16 @@ class WorkflowExecutor:
             session = await self._session_service.get_session(
                 app_name=APP_NAME, user_id=user_id, session_id=job_id
             )
-            state = SessionStateAccessor(session.state)
-            state.book_metadata = book_metadata.model_dump()
+            # Persist via append_event: in-place mutation of session.state
+            # does not survive get_session() (MYS-172).
+            metadata_event = Event(
+                invocation_id="system",
+                author="system",
+                actions=EventActions(
+                    state_delta={SessionStateKeys.BOOK_METADATA: book_metadata.model_dump()}
+                ),
+            )
+            await self._session_service.append_event(session, metadata_event)
 
             yield ProgressEvent(
                 phase=Phase.COMPOSITION,

--- a/core/session_state.py
+++ b/core/session_state.py
@@ -41,12 +41,21 @@ class SessionStateKeys:
 
 
 class SessionStateAccessor:
-    """Typed wrapper around session.state dict.
+    """Typed, READ-ONLY wrapper around session.state dict.
 
     Usage:
         state = SessionStateAccessor(session.state)
         metadata = state.book_metadata  # typed access, no magic strings
-        state.selected_regions = [...]  # typed write
+
+    MYS-172: this accessor is deliberately read-only. ADK's ``session.state``
+    does not persist an in-place mutation (``state[key] = value``) across a
+    ``get_session()`` call -- only ``session_service.append_event(session,
+    Event(actions=EventActions(state_delta={...})))`` does. A setter here
+    would look like a typed write and silently be a no-op against persisted
+    state, which is exactly the bug this ticket fixes (two call sites in
+    ``core/executor.py`` did precisely that). Write session state directly
+    via ``append_event`` at the call site, next to the ``session`` object
+    the write needs -- do not re-add a setter to this class.
     """
 
     def __init__(self, state: dict):
@@ -55,10 +64,6 @@ class SessionStateAccessor:
     @property
     def book_metadata(self) -> Optional[dict]:
         return self._state.get(SessionStateKeys.BOOK_METADATA)
-
-    @book_metadata.setter
-    def book_metadata(self, value: dict) -> None:
-        self._state[SessionStateKeys.BOOK_METADATA] = value
 
     @property
     def region_analysis(self) -> Optional[dict]:
@@ -78,17 +83,9 @@ class SessionStateAccessor:
     def selected_regions(self) -> List[dict]:
         return self._state.get(SessionStateKeys.SELECTED_REGIONS, [])
 
-    @selected_regions.setter
-    def selected_regions(self, value: List[dict]) -> None:
-        self._state[SessionStateKeys.SELECTED_REGIONS] = value
-
     @property
     def final_itinerary(self) -> Optional[object]:
         return self._state.get(SessionStateKeys.FINAL_ITINERARY)
-
-    def clear_final_itinerary(self) -> None:
-        """Remove a stale itinerary before a compose retry."""
-        self._state.pop(SessionStateKeys.FINAL_ITINERARY, None)
 
     @property
     def user_preferences(self) -> Optional[dict]:
@@ -97,10 +94,6 @@ class SessionStateAccessor:
     @property
     def failed(self) -> bool:
         return bool(self._state.get(SessionStateKeys.JOB_FAILED))
-
-    @failed.setter
-    def failed(self, value: bool) -> None:
-        self._state[SessionStateKeys.JOB_FAILED] = value
 
     @property
     def book_title(self) -> str:

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -220,12 +220,6 @@ class TestSessionStateAccessor:
         assert accessor.book_title == "1984"
         assert accessor.author == "George Orwell"
 
-    def test_write_book_metadata(self):
-        state = {}
-        accessor = SessionStateAccessor(state)
-        accessor.book_metadata = {"book_title": "1984"}
-        assert state["book_metadata"]["book_title"] == "1984"
-
     def test_read_regions(self):
         state = {
             "region_analysis": {
@@ -237,12 +231,6 @@ class TestSessionStateAccessor:
         assert len(accessor.regions) == 2
         assert accessor.analysis_note == "test note"
 
-    def test_write_selected_regions(self):
-        state = {}
-        accessor = SessionStateAccessor(state)
-        accessor.selected_regions = [{"region_id": 1}]
-        assert state["selected_regions"] == [{"region_id": 1}]
-
     def test_read_final_itinerary(self):
         itinerary = {"cities": [], "summary_text": "test"}
         state = {"final_itinerary": itinerary}
@@ -253,30 +241,34 @@ class TestSessionStateAccessor:
         accessor = SessionStateAccessor({})
         assert accessor.failed is False
 
-    def test_write_failed_flag(self):
-        state = {}
-        accessor = SessionStateAccessor(state)
-        accessor.failed = True
-        assert state["job_failed"] is True
-
-    def test_clear_failed_flag(self):
+    def test_failed_reads_true_when_set_on_the_underlying_dict(self):
         state = {"job_failed": True}
         accessor = SessionStateAccessor(state)
-        accessor.failed = False
-        assert accessor.failed is False
+        assert accessor.failed is True
 
-    def test_clear_final_itinerary(self):
-        state = {"final_itinerary": {"cities": [], "summary_text": "done"}}
-        accessor = SessionStateAccessor(state)
-        accessor.clear_final_itinerary()
-        assert accessor.final_itinerary is None
-        assert "final_itinerary" not in state
+    # MYS-172: the accessor is deliberately read-only -- writing through it
+    # used to be a silent no-op against persisted ADK session state (two
+    # `core/executor.py` call sites did exactly this). These regression
+    # tests pin that the setters/clear method are GONE, not merely unused,
+    # so a future re-add doesn't quietly reintroduce the trap.
+    def test_book_metadata_has_no_setter(self):
+        accessor = SessionStateAccessor({})
+        with pytest.raises(AttributeError):
+            accessor.book_metadata = {"book_title": "1984"}
 
-    def test_clear_final_itinerary_when_absent_is_safe(self):
-        state = {}
-        accessor = SessionStateAccessor(state)
-        accessor.clear_final_itinerary()  # must not raise
-        assert accessor.final_itinerary is None
+    def test_selected_regions_has_no_setter(self):
+        accessor = SessionStateAccessor({})
+        with pytest.raises(AttributeError):
+            accessor.selected_regions = [{"region_id": 1}]
+
+    def test_failed_has_no_setter(self):
+        accessor = SessionStateAccessor({})
+        with pytest.raises(AttributeError):
+            accessor.failed = True
+
+    def test_clear_final_itinerary_method_is_gone(self):
+        accessor = SessionStateAccessor({"final_itinerary": {"cities": []}})
+        assert not hasattr(accessor, "clear_final_itinerary")
 
 
 # =============================================================================

--- a/tests/unit/test_session_state_persistence.py
+++ b/tests/unit/test_session_state_persistence.py
@@ -1,0 +1,110 @@
+"""MYS-172: state.book_metadata = ... was a silent no-op against ADK's
+persisted session state -- in-place mutation of `session.state` does not
+survive a fresh `get_session()` call; only `session_service.append_event()`
+does. `core/executor.py`'s `discover()` and `local_atmosphere()` both wrote
+metadata the old way. These tests drive the REAL code paths (not a mock of
+SessionStateAccessor) and re-fetch state via a NEW `get_session()` call --
+per the Eng Lead's tech plan, a test that reads back from the same in-memory
+object the code just wrote to would pass today, defect and all, because the
+bug is specifically about what a SECOND, independent read sees.
+
+Each test fails the underlying agent workflow deliberately (by monkeypatching
+the workflow factory to raise) immediately AFTER the metadata write and
+BEFORE any real Gemini/Runner call -- so this never needs live model access,
+while still exercising the exact write this ticket fixes.
+"""
+
+import pytest
+
+from core.events import JobStarted
+from core.types import ExecutorConfig
+from services.session_service import create_session_service
+
+
+class TestBookMetadataPersistsAcrossGetSession:
+    async def test_discover_book_metadata_survives_a_fresh_get_session(
+        self, monkeypatch
+    ):
+        import core.executor as ex
+
+        def _boom(*args, **kwargs):
+            raise AssertionError(
+                "discovery workflow invoked -- metadata write must happen "
+                "before this, and this test must not need a real Gemini call"
+            )
+
+        monkeypatch.setattr(ex, "create_book_to_place_discovery_workflow", _boom)
+        monkeypatch.setattr(ex, "Runner", _boom)
+
+        session_service = create_session_service(use_database=False)
+        config = ExecutorConfig(
+            model_name="gemini-2.0-flash", google_api_key="test-key"
+        )
+        executor = ex.WorkflowExecutor(
+            config=config,
+            session_service=session_service,
+            model=object(),  # never reached; the workflow factory raises first
+        )
+
+        job_id = None
+        async for event in executor.discover(
+            book_title="1984", author="George Orwell"
+        ):
+            if isinstance(event, JobStarted):
+                job_id = event.job_id
+        assert job_id is not None, "discover() never emitted JobStarted"
+
+        # The regression check: a SECOND, independent get_session() call,
+        # not a read of the same object discover() already holds.
+        refetched = await session_service.get_session(
+            app_name=ex.APP_NAME, user_id="default", session_id=job_id
+        )
+        assert refetched.state["book_metadata"]["book_title"] == "1984"
+        assert refetched.state["book_metadata"]["author"] == "George Orwell"
+        # The exact truthiness api/routes.py::_derive_job_status checks to
+        # report JobStatus.DISCOVERING instead of SEARCHING.
+        assert bool(refetched.state.get("book_metadata"))
+
+    async def test_local_atmosphere_book_metadata_survives_a_fresh_get_session(
+        self, monkeypatch
+    ):
+        import core.executor as ex
+
+        def _boom(*args, **kwargs):
+            raise AssertionError(
+                "local-atmosphere workflow invoked -- metadata write must "
+                "happen before this, and this test must not need a real "
+                "Gemini call"
+            )
+
+        monkeypatch.setattr(ex, "create_local_atmosphere_workflow", _boom)
+        monkeypatch.setattr(ex, "Runner", _boom)
+
+        session_service = create_session_service(use_database=False)
+        config = ExecutorConfig(
+            model_name="gemini-2.0-flash", google_api_key="test-key"
+        )
+        executor = ex.WorkflowExecutor(
+            config=config,
+            session_service=session_service,
+            model=object(),
+        )
+
+        job_id = None
+        async for event in executor.local_atmosphere(
+            book_title="1984",
+            author="George Orwell",
+            location_label="New York, NY",
+            lat=40.7128,
+            lng=-74.0060,
+        ):
+            if isinstance(event, JobStarted):
+                job_id = event.job_id
+        assert job_id is not None, "local_atmosphere() never emitted JobStarted"
+
+        refetched = await session_service.get_session(
+            app_name=ex.APP_NAME, user_id="default", session_id=job_id
+        )
+        assert refetched.state["book_metadata"]["book_title"] == "1984"
+        assert refetched.state["book_metadata"]["author"] == "George Orwell"
+        assert bool(refetched.state.get("book_metadata"))


### PR DESCRIPTION
# fix(ai): make SessionStateAccessor read-only, persist book_metadata via append_event

## What

`SessionStateAccessor` exposed setters (`book_metadata`, `selected_regions`, `failed`) and a `clear_final_itinerary()` method that mutated `session.state` in place. ADK's session state does not persist an in-place mutation across a `get_session()` call — only `session_service.append_event(session, Event(actions=EventActions(state_delta={...})))` does. `core/executor.py`'s `discover()` and `local_atmosphere()` both called `state.book_metadata = ...`, which was a silent no-op against persisted state. This PR deletes the setters/method (making the accessor read-only) and fixes both call sites to persist via `append_event`.

## Why

ADR #11 documents the in-place-mutation trap and is the same class of bug as the `/status` FAILED-after-retry incident that motivated it. The dead write is harmless today only by accident — `book_title`/`author` reads fall back to the `BOOK_TITLE`/`AUTHOR` seed keys set at session creation, so nothing currently reads a *stale* value. But [MYS-168](https://linear.app/mystoryland/issue/MYS-168) (`USE_DATABASE=true` → `DatabaseSessionService`) cannot see an in-place dict write by construction — this is a precondition of that flip, not an optional cleanup. It also directly affects `/status`: `api/routes.py::_derive_job_status` and `get_status` both read `book_metadata` from persisted state, so a job that should report `JobStatus.DISCOVERING` was reporting `SEARCHING` for the entire discovery phase.

## How

- `core/session_state.py`: deleted the `book_metadata` setter, `selected_regions` setter, `failed` setter, and `clear_final_itinerary()`. Grepped the whole repo (code + tests) for callers outside `session_state.py`'s own test file: only `book_metadata`'s setter was ever actually invoked, at the two now-fixed `core/executor.py` call sites — the other three (`selected_regions` setter, `failed` setter, `clear_final_itinerary`) were dead code, presumably superseded by the `append_event`-based call sites that already exist elsewhere in `executor.py` for those same keys (`compose()`'s retry-clear block already sets `SELECTED_REGIONS`/`FINAL_ITINERARY`/`JOB_FAILED` correctly via `append_event`; `_mark_session_failed` already sets `JOB_FAILED` correctly the same way). Deleting them is the fix, not just documentation of intent: as long as a setter exists, the next writer reaches for `state.x = y` because it reads like it works. Updated the class docstring to state the read-only contract and point future writers at the `append_event` pattern instead.
- `core/executor.py`: `discover()` (metadata write before Phase 2) and `local_atmosphere()` (metadata write before the composition workflow) now build `Event(invocation_id="system", author="system", actions=EventActions(state_delta={SessionStateKeys.BOOK_METADATA: book_metadata.model_dump()}))` and `await self._session_service.append_event(session, metadata_event)` — the identical pattern already used a few lines away in the same file for `compose()`'s retry-clear block and `_mark_session_failed`.

## Scope decisions

- **`clear_final_itinerary`'s doc-comment mentioned a compose-retry use case, but it was never actually called anywhere** (confirmed by repo-wide grep) — the real retry-clear path already sets `FINAL_ITINERARY: None` via `append_event` in `compose()`'s existing guard block. Removing the dead method doesn't change behavior on that path.
- Not touched: any read-only property, `compose()`, `expand()`, `recommend_books()` — none of them use the deleted setters; their existing `state_delta`/`append_event` call sites were already correct and are the pattern this PR extends to the two remaining bad call sites.

## Docs

`no impact` — no architecture, endpoint, route, or config change; an internal API tightening (accessor becomes read-only) plus fixing two call sites to use the persistence mechanism the rest of the file already uses. `core/session_state.py`'s own docstring is the doc for this contract and was updated in this diff.

## Verification

**Environment note:** this build environment's Python is 3.10; `google-adk>=2.4.0` requires Python ≥3.11 to install, so the real test suite (which imports `google.adk`/`google.genai` transitively via `core/__init__.py` and `core/executor.py`) cannot be collected or run here — pre-existing, documented gap (see storyland-team-os memory "storyland-ai-deps-cant-install-in-sandbox"), not new to this PR.

What was verified directly, without ADK:
- `core/session_state.py` has zero ADK/google dependencies, so it was imported directly (via a stub `core` package in `sys.modules`, bypassing `core/__init__.py`'s eager `WorkflowExecutor` import) and every accessor behavior was run by hand: all existing reads unchanged, all three setters and `clear_final_itinerary` now raise `AttributeError`/are absent (`hasattr` false) — matching the four new regression tests added to `tests/unit/test_core.py`.
- `python3 -m py_compile` clean on all four changed/added files.
- Repo-wide grep confirming no caller of the three dead setters/method exists outside `session_state.py`'s own (now-updated) tests.
- Read `core/executor.py`'s existing correct `append_event`/`EventActions` call sites (the `compose()` retry-clear block, `_mark_session_failed`) and modeled both fixed call sites on the identical pattern — same `Event(invocation_id="system", author="system", ...)` shape, same `state_delta` dict shape, same immediate `await self._session_service.append_event(session, event)` call.
- Confirmed by reading the surrounding code that the `session`/`state` local variables I removed (the `SessionStateAccessor(session.state)` assignment that only existed to call the now-deleted setter) were not read again later in either `discover()`'s or `local_atmosphere()`'s body — `discover()` re-fetches a fresh `session`/`run_state` after `pump_events()` under a different variable name; `local_atmosphere()` reuses the same `session` variable later (`active_session = refreshed if refreshed is not None else session`), which I preserved by keeping the variable name and only replacing the setter call, not the `get_session()` line itself.
- **Could not literally execute** `tests/unit/test_session_state_persistence.py` (new) here — it drives `WorkflowExecutor.discover()`/`.local_atmosphere()` against a real `services.session_service.create_session_service(use_database=False)` (ADK's `InMemorySessionService`), monkeypatching the workflow-factory functions to raise immediately after the metadata write (so no live Gemini call is needed, modeled on the existing `TestExecutorCacheHit.test_cache_hit_skips_discovery_chain` pattern in `tests/unit/test_cache.py`), then re-fetches session state via a **second, independent** `get_session()` call and asserts `book_metadata` survived. This is the exact assertion shape the Eng Lead's tech plan calls for — a test reading back from the same in-memory object the code just wrote to would pass even with the bug, because the defect only shows up on an independent re-fetch.

**Please run the real suite on merge/CI** (`make test-ci`, coverage floor per `pyproject.toml`) — this environment could not, for the reason above, not because it was skipped. Reviewer focus: `tests/unit/test_session_state_persistence.py`'s two tests are new and the ones this PR's actual bug-fix claim rests on; the `test_core.py` accessor changes are lower-risk (pure-Python, already hand-verified above).
