### PR TITLE
docs(ci): catalog storyland-ai workflows + rename mis-named eval workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -5,18 +5,23 @@ lives in `storyland-team-os/conventions/engineering-standards.md`; this file is 
 repo-local companion to it. This is the most workflow-heavy repo in the fleet — **12
 workflow files** plus GitHub-managed **Dependabot Updates**.
 
+> **Public-repo constraint:** storyland-ai is **public**, and a public repo cannot `uses:` a
+> reusable workflow that lives in the **private** `storyland-infrastructure`. So this repo's
+> deploy and gitleaks are **inlined copies** that must be kept in sync manually with the infra
+> originals — noted per row below.
+
 | Workflow | File | Triggers | Purpose | Verdict |
 |---|---|---|---|---|
 | **Unit Tests** | `codex.yml` | push/PR `main`+`develop`, dispatch, call | `make test-ci` — unit tests + coverage ratchet. Core PR gate. | **Keep** |
 | **Integration Tests** | `integration-tests.yml` | push/PR `main`+`develop`, dispatch, call | Integration suite against **mocked / VCR cassettes** — no live API spend. Runs on every push/PR. | **Keep** |
 | **Integration Tests (Live API)** | `integration-live-tests.yml` | dispatch (requires `reason`) | The **live-API** counterpart — spends real quota/cost. Manual-only by design; run to validate real API behavior before a release. Intentionally distinct from the mocked suite above. | **Keep** |
-| **CI/CD Pipeline** | `ci-cd.yml` | push `main`, dispatch (`skip-tests`) | Build/publish pipeline on `main`. | **Keep** |
-| **Gitleaks** | `gitleaks.yml` | push/PR `main` | Secret scan (calls the reusable full-history scan; MYS-629/MYS-440). | **Keep** |
+| **CI/CD Pipeline** | `ci-cd.yml` | push `main`, dispatch (`skip-tests`) | **Test orchestration only** — fans out to `codex.yml` (unit) + `integration-tests.yml`. Contains **no build/publish/deploy job**; a `main` push does not produce or publish an artifact. | **Keep** |
+| **Gitleaks** | `gitleaks.yml` | push/PR `main` | Full-history secret scan. **Inline** (mirrors `infra/reusable-gitleaks.yml` step-for-step; cannot `uses:` the private reusable — public-repo constraint). Re-point to the reusable version if infra ever goes public. | **Keep** |
 | **pip-audit** | `pip-audit.yml` | push/PR `main`+`develop` | Python dependency vulnerability gate. | **Keep** |
-| **Deploy AI (prod)** | `deploy-ai-prod.yml` | dispatch | G5-gated production release. Per-service **caller** for the reusable SSH-deploy workflow in `storyland-infrastructure` (`deploy-service.yml`). Supports build-and-deploy or `image_tag` redeploy (rollback lever). | **Keep** |
+| **Deploy AI (prod)** | `deploy-ai-prod.yml` | dispatch | G5-gated production release. **Self-contained / inlined** — mirrors `infra/deploy-service.yml` step-for-step (stage gate, build, SSH deploy) because it cannot call the private reusable. **Keep-in-sync** with the infra original. Supports build-and-deploy or `image_tag` redeploy. | **Keep** |
 | **Claude Code** | `claude.yml` | issue_comment, PR review (+comment), issues opened/assigned | The `@claude` agent. Fires only when mentioned — **`skipped` runs on unrelated comments are normal**, not failures. | **Keep** |
-| **PR body sections** | `pr-body-sections.yml` | PR opened/edited/reopened/synchronize | Enforces the four PR template headings (`## Why / ## What / ## Docs / ## Verification`, MYS-617). **Required check.** | **Keep** |
-| **Evaluation (manual dispatch)** | `scheduled-eval.yml` | dispatch (runner/datasets/max_cases) | Runs an eval runner (itinerary / local_atmosphere / expansion / place_to_book) against Langfuse datasets. **Manual-only — has no cron.** Renamed 2026-07-25 (was "Scheduled Evaluation", which implied a schedule it never had). Filename kept as-is to avoid breaking references. | **Keep** |
+| **PR body sections** | `pr-body-sections.yml` | PR opened/edited/reopened/synchronize | Enforces the four PR template headings (`## Why / ## What / ## Docs / ## Verification`, MYS-617). **Required check** (Dependabot / `Revert …` PRs skip). | **Keep** |
+| **Evaluation (manual dispatch)** | `scheduled-eval.yml` | dispatch (runner/datasets/max_cases) | Runs an eval runner (itinerary / local_atmosphere / expansion / place_to_book) against Langfuse datasets. **Manual-only — has no cron.** Renamed 2026-07-25 (was "Scheduled Evaluation", which implied a schedule it never had). Filename kept as-is to avoid breaking references; `evaluation/README.md` updated to match. | **Keep** |
 | **Re-record VCR Cassettes** | `re-record-cassettes.yml` | dispatch | Manual utility to regenerate VCR cassettes (MYS-440 re-record split). No automatic trigger; run when live responses change. | **Keep** (manual tool) |
 | **Sync rotated env keys to box** | `sync-env-keys.yml` | dispatch | Manual utility to push rotated env keys to the prod box (MYS-440 key rotation). | **Keep** (manual tool) |
 | **Dependabot Updates** | *(GitHub-managed, `.github/dependabot.yml`)* | Dependabot schedule | Automated dependency-update PRs. Not a YAML in `.github/workflows/`. | **Keep** |
@@ -25,9 +30,12 @@ workflow files** plus GitHub-managed **Dependabot Updates**.
 - `main` **green**; security lane (Gitleaks, pip-audit, Dependabot) all passing.
 - Naming defect **fixed** in this PR: `scheduled-eval.yml` was titled "Scheduled Evaluation"
   but only ever ran on `workflow_dispatch` (no `schedule:`) — the name implied a cron that
-  did not exist. Manual-only is intended (cost); renamed to make the name honest.
+  did not exist. Manual-only is intended (cost); renamed to make the name honest, and the
+  Actions-tab reference in `evaluation/README.md` updated to the new name.
 
 ## Conventions
 - Two integration workflows are **intentionally split**: mocked/VCR on every push vs.
   live-API on manual dispatch. Do not "consolidate" them.
+- Deploy + gitleaks are **inlined** here (public-repo constraint) and must be kept in sync
+  with the infra originals — change both places.
 - Deploys are `workflow_dispatch`-only and G5-gated; there is no push-to-deploy.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,33 @@
+# GitHub Actions — storyland-ai
+
+Catalog of this repo's CI/CD workflows. Last audited **2026-07-25**. Org-wide CI policy
+lives in `storyland-team-os/conventions/engineering-standards.md`; this file is the
+repo-local companion to it. This is the most workflow-heavy repo in the fleet — **12
+workflow files** plus GitHub-managed **Dependabot Updates**.
+
+| Workflow | File | Triggers | Purpose | Verdict |
+|---|---|---|---|---|
+| **Unit Tests** | `codex.yml` | push/PR `main`+`develop`, dispatch, call | `make test-ci` — unit tests + coverage ratchet. Core PR gate. | **Keep** |
+| **Integration Tests** | `integration-tests.yml` | push/PR `main`+`develop`, dispatch, call | Integration suite against **mocked / VCR cassettes** — no live API spend. Runs on every push/PR. | **Keep** |
+| **Integration Tests (Live API)** | `integration-live-tests.yml` | dispatch (requires `reason`) | The **live-API** counterpart — spends real quota/cost. Manual-only by design; run to validate real API behavior before a release. Intentionally distinct from the mocked suite above. | **Keep** |
+| **CI/CD Pipeline** | `ci-cd.yml` | push `main`, dispatch (`skip-tests`) | Build/publish pipeline on `main`. | **Keep** |
+| **Gitleaks** | `gitleaks.yml` | push/PR `main` | Secret scan (calls the reusable full-history scan; MYS-629/MYS-440). | **Keep** |
+| **pip-audit** | `pip-audit.yml` | push/PR `main`+`develop` | Python dependency vulnerability gate. | **Keep** |
+| **Deploy AI (prod)** | `deploy-ai-prod.yml` | dispatch | G5-gated production release. Per-service **caller** for the reusable SSH-deploy workflow in `storyland-infrastructure` (`deploy-service.yml`). Supports build-and-deploy or `image_tag` redeploy (rollback lever). | **Keep** |
+| **Claude Code** | `claude.yml` | issue_comment, PR review (+comment), issues opened/assigned | The `@claude` agent. Fires only when mentioned — **`skipped` runs on unrelated comments are normal**, not failures. | **Keep** |
+| **PR body sections** | `pr-body-sections.yml` | PR opened/edited/reopened/synchronize | Enforces the four PR template headings (`## Why / ## What / ## Docs / ## Verification`, MYS-617). **Required check.** | **Keep** |
+| **Evaluation (manual dispatch)** | `scheduled-eval.yml` | dispatch (runner/datasets/max_cases) | Runs an eval runner (itinerary / local_atmosphere / expansion / place_to_book) against Langfuse datasets. **Manual-only — has no cron.** Renamed 2026-07-25 (was "Scheduled Evaluation", which implied a schedule it never had). Filename kept as-is to avoid breaking references. | **Keep** |
+| **Re-record VCR Cassettes** | `re-record-cassettes.yml` | dispatch | Manual utility to regenerate VCR cassettes (MYS-440 re-record split). No automatic trigger; run when live responses change. | **Keep** (manual tool) |
+| **Sync rotated env keys to box** | `sync-env-keys.yml` | dispatch | Manual utility to push rotated env keys to the prod box (MYS-440 key rotation). | **Keep** (manual tool) |
+| **Dependabot Updates** | *(GitHub-managed, `.github/dependabot.yml`)* | Dependabot schedule | Automated dependency-update PRs. Not a YAML in `.github/workflows/`. | **Keep** |
+
+## Health notes (2026-07-25)
+- `main` **green**; security lane (Gitleaks, pip-audit, Dependabot) all passing.
+- Naming defect **fixed** in this PR: `scheduled-eval.yml` was titled "Scheduled Evaluation"
+  but only ever ran on `workflow_dispatch` (no `schedule:`) — the name implied a cron that
+  did not exist. Manual-only is intended (cost); renamed to make the name honest.
+
+## Conventions
+- Two integration workflows are **intentionally split**: mocked/VCR on every push vs.
+  live-API on manual dispatch. Do not "consolidate" them.
+- Deploys are `workflow_dispatch`-only and G5-gated; there is no push-to-deploy.

--- a/.github/workflows/scheduled-eval.yml
+++ b/.github/workflows/scheduled-eval.yml
@@ -1,4 +1,7 @@
-name: Scheduled Evaluation
+# Manual-only despite the historical name: this workflow has NO `schedule:`/cron
+# trigger and runs solely on workflow_dispatch. Kept manual on purpose — each run
+# spends live API quota. Renamed 2026-07-25 so the name stops implying a cron.
+name: Evaluation (manual dispatch)
 
 on:
   workflow_dispatch: # Allow manual trigger

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -284,7 +284,7 @@ Evaluations run automatically via GitHub Actions:
 - **Workflow**: `.github/workflows/scheduled-eval.yml`
 - **Results**: Uploaded as workflow artifacts
 
-Manual trigger: Go to Actions tab → Scheduled Evaluation → Run workflow
+Manual trigger: Go to Actions tab → Evaluation (manual dispatch) → Run workflow
 
 ### Prompt Versioning
 


### PR DESCRIPTION
## Why

A fleet-wide GitHub Actions audit (2026-07-25) found (a) no per-repo documentation of what each workflow does, and (b) that `scheduled-eval.yml` is titled "Scheduled Evaluation" but has **no `schedule:`/cron** — it only runs on `workflow_dispatch`. The name implied an automatic cadence that never existed. Olga confirmed manual-only is intended (each run spends live API quota).

## What

Two changes:
1. New `.github/workflows/README.md` cataloging all 12 workflow files + Dependabot (trigger, purpose, keep/retire verdict). Notes the intentional mocked-vs-live integration split so it is not "consolidated" later.
2. `scheduled-eval.yml`: renamed `name:` to **"Evaluation (manual dispatch)"** with a header comment explaining it is cron-less by design. **`name:` only** — filename and job id unchanged to avoid breaking any references.

## Docs

The README *is* the doc; ground-truthed against each workflow file's `on:` block and header on `main`, and against `gh run` history. The rename is self-documenting via the new header comment, and the README health note records why. No cross-repo doc claim changes.

## Verification

Every table row checked against live YAML `on:` triggers and `gh workflow list -R o-ostrovskiy/storyland-ai`. The rename touches only the display `name:`; job id (`scheduled-eval`) and filename are unchanged, so no required-status-check reference breaks. Docs + a name string only — Unit/Integration Tests should stay green; will confirm before requesting merge.