### PR TITLE
test(ai): AI auth-boundary test gaps — cross-user session isolation, inflight-slot lifetime over a real stream + on disconnect, sweeper resolver-store wiring

### DIFF
--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -4,6 +4,7 @@ Unit tests for FastAPI SSE API layer.
 Tests API models, endpoint responses, and SSE streaming with mocked executor.
 """
 
+import asyncio
 import json
 
 import pytest
@@ -1438,9 +1439,19 @@ class TestPlaceToBookEndpoint:
 
 class TestInflightLimiterOverRealStream:
     @pytest.mark.asyncio
-    async def test_slot_is_released_after_a_completed_stream(
+    async def test_slot_is_held_during_the_stream_and_released_after(
         self, mock_app_state, mock_executor
     ):
+        """MYS-403 (Codex P2): the original version of this test fully
+        buffered the request (a plain ``client.post``) before inspecting
+        ``active`` -- so a regression that freed the slot as soon as the
+        endpoint FUNCTION returned, rather than when the SSE generator
+        actually finishes draining, would still have passed (it ends at 0
+        either way). This drives a genuine partial ASGI read: the mock
+        generator parks mid-stream (after its first event, before its
+        last) until the test explicitly releases it, so ``active`` is
+        inspected while the response is demonstrably still open.
+        """
         from api.app import create_app
         from api.ratelimit import InFlightLimiter
         from httpx import AsyncClient, ASGITransport
@@ -1448,10 +1459,16 @@ class TestInflightLimiterOverRealStream:
 
         mock_app_state.inflight_limiter = InFlightLimiter(max_in_flight=1)
 
+        hold = asyncio.Event()
+        first_event_sent = asyncio.Event()
+
         async def mock_discover(**kwargs):
             yield ProgressEvent(
                 phase=Phase.BOOK_SEARCH, step="Searching Google Books API"
             )
+            first_event_sent.set()
+            # Parked mid-stream until the test releases it below.
+            await hold.wait()
             yield WorkflowComplete(job_id="test-job")
 
         mock_executor.discover = mock_discover
@@ -1461,20 +1478,50 @@ class TestInflightLimiterOverRealStream:
         deps._app_state = mock_app_state
 
         client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
-        response = await client.post(
+
+        async def _drive_stream():
+            async with client.stream(
+                "POST",
+                "/api/v1/itinerary/discover",
+                json={"book_title": "1984", "author": "George Orwell"},
+            ) as response:
+                assert response.status_code == 200
+                async for _ in response.aiter_lines():
+                    if first_event_sent.is_set():
+                        break
+
+        stream_task = asyncio.create_task(_drive_stream())
+        await asyncio.wait_for(first_event_sent.wait(), timeout=5)
+        # Give the event loop a few ticks so the generator has genuinely
+        # parked on `hold.wait()` (not just scheduled to) before checking.
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+        assert mock_app_state.inflight_limiter.active == 1, (
+            "the slot must still be held WHILE the SSE generator is "
+            "mid-stream, not only before the endpoint function returns"
+        )
+        # At capacity 1, a concurrent request must be shed while the first
+        # is still open -- proves the slot is genuinely occupied, not just
+        # a counter that happens to read 1.
+        concurrent = await client.post(
             "/api/v1/itinerary/discover",
             json={"book_title": "1984", "author": "George Orwell"},
         )
-        assert response.status_code == 200
+        assert concurrent.status_code == 503
+
+        hold.set()
+        await asyncio.wait_for(stream_task, timeout=5)
+
         assert mock_app_state.inflight_limiter.active == 0, (
             "the slot must be free once the SSE generator has fully drained"
         )
         # And the freed slot is genuinely usable, not just zeroed by accident.
-        second = await client.post(
+        after = await client.post(
             "/api/v1/itinerary/discover",
             json={"book_title": "1984", "author": "George Orwell"},
         )
-        assert second.status_code == 200
+        assert after.status_code == 200
 
 
 # =============================================================================

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1412,3 +1412,132 @@ class TestPlaceToBookEndpoint:
     async def test_missing_place_rejected(self, test_client, reset_p2b_singleton):
         response = await test_client.post("/api/v1/place-to-book", json={})
         assert response.status_code == 422
+
+
+# =============================================================================
+# MYS-403 gap 3a: inflight-slot lifetime over a REAL ASGI stream
+# =============================================================================
+#
+# api/dependencies.py::limit_inflight was previously exercised only as a bare
+# async generator (tests/unit/test_ratelimit.py) -- never through a real
+# streaming response, so its own docstring's claim ("holds a slot for the
+# duration of the request ... releases it when the response completes") was
+# unverified. A leak here silently wedges capacity at MAX_INFLIGHT_REQUESTS
+# forever, shedding every subsequent request with 503 until a restart.
+#
+# The completed-stream half lives here (a genuine ASGI round-trip). The
+# mid-stream-disconnect half lives in test_ratelimit.py::
+# TestLimitInflightCancellation -- httpx's ASGITransport in this environment
+# does not propagate an early `async with client.stream(...)` exit as a real
+# server-side cancellation (confirmed empirically: it hangs for the full
+# generator lifetime instead), so that half is tested at the dependency-
+# generator level by cancelling the task holding the slot open, which is
+# exactly the mechanism Starlette uses to unwind a dependency generator on a
+# genuine client disconnect.
+
+
+class TestInflightLimiterOverRealStream:
+    @pytest.mark.asyncio
+    async def test_slot_is_released_after_a_completed_stream(
+        self, mock_app_state, mock_executor
+    ):
+        from api.app import create_app
+        from api.ratelimit import InFlightLimiter
+        from httpx import AsyncClient, ASGITransport
+        import api.dependencies as deps
+
+        mock_app_state.inflight_limiter = InFlightLimiter(max_in_flight=1)
+
+        async def mock_discover(**kwargs):
+            yield ProgressEvent(
+                phase=Phase.BOOK_SEARCH, step="Searching Google Books API"
+            )
+            yield WorkflowComplete(job_id="test-job")
+
+        mock_executor.discover = mock_discover
+
+        app = create_app()
+        app.router.lifespan_context = _null_lifespan
+        deps._app_state = mock_app_state
+
+        client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+        response = await client.post(
+            "/api/v1/itinerary/discover",
+            json={"book_title": "1984", "author": "George Orwell"},
+        )
+        assert response.status_code == 200
+        assert mock_app_state.inflight_limiter.active == 0, (
+            "the slot must be free once the SSE generator has fully drained"
+        )
+        # And the freed slot is genuinely usable, not just zeroed by accident.
+        second = await client.post(
+            "/api/v1/itinerary/discover",
+            json={"book_title": "1984", "author": "George Orwell"},
+        )
+        assert second.status_code == 200
+
+
+# =============================================================================
+# MYS-403 gap 3b: the lazily-created place->book resolver's session store
+# must be included in the session sweeper's provider once it exists, so the
+# sweeper doesn't leak it (api/app.py::lifespan's `_live_session_services`).
+# =============================================================================
+
+
+class TestSessionSweeperIncludesResolverStoreOnceCreated:
+    @pytest.mark.asyncio
+    async def test_resolver_store_joins_the_sweep_once_lazily_created(
+        self, monkeypatch
+    ):
+        from types import SimpleNamespace
+
+        import api.app as app_module
+        import api.dependencies as deps
+
+        fake_executor_session_service = object()
+        fake_state = SimpleNamespace(
+            executor=SimpleNamespace(session_service=fake_executor_session_service),
+            config=SimpleNamespace(
+                session_ttl_seconds=0,  # keeps SessionSweeper.start() a no-op
+                session_max_entries=0,
+                session_sweep_interval_seconds=3600,
+            ),
+        )
+
+        async def fake_initialize():
+            return fake_state
+
+        async def fake_shutdown():
+            return None
+
+        monkeypatch.setattr(app_module, "initialize", fake_initialize)
+        monkeypatch.setattr(app_module, "shutdown", fake_shutdown)
+        # deps._place_to_book_resolver starts unset -- the whole point of
+        # this test is to prove the provider PICKS IT UP once it exists,
+        # exactly as it does lazily on the app's first place-to-book request.
+        monkeypatch.setattr(deps, "_place_to_book_resolver", None)
+
+        app = app_module.FastAPI()
+        async with app_module.lifespan(app):
+            sweeper = app.state.session_sweeper
+
+            before = sweeper._resolve_services()
+            assert fake_executor_session_service in before
+            assert len(before) == 1, (
+                f"resolver has no store yet -- must not appear early: {before!r}"
+            )
+
+            fake_resolver_store = object()
+            monkeypatch.setattr(
+                deps,
+                "_place_to_book_resolver",
+                SimpleNamespace(_session_service=fake_resolver_store),
+            )
+
+            after = sweeper._resolve_services()
+            assert fake_executor_session_service in after
+            assert fake_resolver_store in after, (
+                f"the sweeper must pick up the resolver's store once it's "
+                f"lazily created, so the retention sweep covers it too "
+                f"(otherwise it leaks past the sweeper forever): {after!r}"
+            )

--- a/tests/unit/test_ratelimit.py
+++ b/tests/unit/test_ratelimit.py
@@ -6,6 +6,7 @@ they run fast and deterministically. Time is injected so the sliding window is
 tested without sleeping.
 """
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -182,3 +183,56 @@ class TestLimitInflight:
         assert inflight.active == 0
         with pytest.raises(StopAsyncIteration):
             await gen.__anext__()
+
+
+# ---------------------------------------------------------------------------
+# MYS-403 gap 3 (disconnect half): limit_inflight() releasing its slot when
+# the holder is cancelled mid-stream, not just on normal completion.
+# ---------------------------------------------------------------------------
+#
+# TestLimitInflight above (and test_api.py::TestInflightLimiterOverRealStream,
+# which drives a real ASGI round-trip) both cover the generator finishing on
+# its own. Neither proves the OTHER half of the dependency's own docstring
+# contract: "holds a slot for the duration of the request ... releases it
+# when the response completes" -- a request that never completes because the
+# client walked away must still free the slot. A real client disconnect
+# surfaces to a FastAPI generator dependency as its enclosing task being
+# cancelled while the generator is parked at its `yield`; Starlette then
+# unwinds the dependency via `aclose()`, throwing `GeneratorExit` in at that
+# yield point -- exactly what `hold_the_slot` below does explicitly, so this
+# exercises the real mechanism `limit_inflight`'s `finally: limiter.release()`
+# has to survive, without depending on ASGI-transport-specific disconnect
+# behavior (which proved unreliable to simulate in this sandbox -- see the
+# note in test_api.py).
+class TestLimitInflightCancellation:
+    async def test_release_runs_when_the_holder_is_cancelled_mid_stream(
+        self, fake_state
+    ):
+        inflight = InFlightLimiter(1)
+        fake_state(SlidingWindowRateLimiter(0, 60), inflight)
+
+        started = asyncio.Event()
+
+        async def hold_the_slot():
+            gen = limit_inflight()
+            await gen.__anext__()  # acquire + past the yield
+            started.set()
+            try:
+                await asyncio.sleep(60)  # stands in for "streaming forever"
+            finally:
+                # What Starlette does to unwind a generator dependency when
+                # the request task is cancelled (client disconnect).
+                await gen.aclose()
+
+        task = asyncio.ensure_future(hold_the_slot())
+        await started.wait()
+        assert inflight.active == 1, "the slot must be held while the stream is open"
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert inflight.active == 0, (
+            "a cancelled (disconnected) request must still release its "
+            "inflight slot -- otherwise capacity is wedged until a restart"
+        )

--- a/tests/unit/test_ratelimit.py
+++ b/tests/unit/test_ratelimit.py
@@ -195,15 +195,26 @@ class TestLimitInflight:
 # its own. Neither proves the OTHER half of the dependency's own docstring
 # contract: "holds a slot for the duration of the request ... releases it
 # when the response completes" -- a request that never completes because the
-# client walked away must still free the slot. A real client disconnect
-# surfaces to a FastAPI generator dependency as its enclosing task being
-# cancelled while the generator is parked at its `yield`; Starlette then
-# unwinds the dependency via `aclose()`, throwing `GeneratorExit` in at that
-# yield point -- exactly what `hold_the_slot` below does explicitly, so this
-# exercises the real mechanism `limit_inflight`'s `finally: limiter.release()`
-# has to survive, without depending on ASGI-transport-specific disconnect
-# behavior (which proved unreliable to simulate in this sandbox -- see the
-# note in test_api.py).
+# client walked away must still free the slot.
+#
+# Two tests below, at two different levels:
+#
+# 1. test_release_runs_when_the_holder_is_cancelled_mid_stream drives the
+#    dependency generator directly (fast, isolated, no app/ASGI machinery) --
+#    it proves OUR cleanup code (`finally: limiter.release()`) survives being
+#    unwound via `aclose()`, i.e. that our code is not the failure mode.
+#
+# 2. test_release_runs_on_a_real_http_disconnect_over_raw_asgi (Codex P2,
+#    MYS-403 review) proves Starlette's OWN machinery actually reaches that
+#    unwind on a genuine disconnect -- test 1 alone would stay green even if
+#    a real disconnect never called `aclose()` at all. httpx's ASGITransport
+#    could not be used for this (confirmed empirically: an early
+#    `client.stream()` context exit does not surface to the app as an ASGI
+#    `http.disconnect` in this sandbox -- see the note in
+#    test_api.py::TestInflightLimiterOverRealStream) -- but a *raw* ASGI
+#    harness (a hand-built scope/receive/send trio calling the real FastAPI
+#    app directly, bypassing httpx entirely) can and does simulate a genuine
+#    `http.disconnect`, and that's what test 2 drives.
 class TestLimitInflightCancellation:
     async def test_release_runs_when_the_holder_is_cancelled_mid_stream(
         self, fake_state
@@ -235,4 +246,94 @@ class TestLimitInflightCancellation:
         assert inflight.active == 0, (
             "a cancelled (disconnected) request must still release its "
             "inflight slot -- otherwise capacity is wedged until a restart"
+        )
+
+    async def test_release_runs_on_a_real_http_disconnect_over_raw_asgi(self):
+        """Drives the real FastAPI app via a hand-built ASGI scope/receive/
+        send trio -- no httpx, no TestClient -- so the disconnect goes
+        through sse_starlette's actual ``_listen_for_disconnect`` ->
+        task-group-cancellation path, not a simulated ``aclose()`` call.
+        This is the integration behavior the test above only assumes.
+        """
+        from unittest.mock import MagicMock
+
+        from api.app import create_app
+        from api.dependencies import AppState, get_gateway_user_id, verify_gateway_secret
+        from core.events import Phase, ProgressEvent
+
+        inflight = InFlightLimiter(1)
+        app_state = AppState(
+            config=MagicMock(),
+            executor=MagicMock(),
+            rate_limiter=SlidingWindowRateLimiter(0, 60),
+            inflight_limiter=inflight,
+        )
+
+        started = asyncio.Event()
+
+        async def mock_discover(**kwargs):
+            yield ProgressEvent(phase=Phase.BOOK_SEARCH, step="Searching")
+            started.set()
+            await asyncio.sleep(60)  # stands in for "streaming forever"
+            # pragma: no cover -- unreachable once disconnect cancels this
+
+        app_state.executor.discover = mock_discover
+
+        app = create_app()
+        app.dependency_overrides[verify_gateway_secret] = lambda: None
+        app.dependency_overrides[get_gateway_user_id] = lambda: "test_user"
+        deps._app_state = app_state
+
+        body = b'{"book_title": "1984", "author": "George Orwell"}'
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/api/v1/itinerary/discover",
+            "raw_path": b"/api/v1/itinerary/discover",
+            "query_string": b"",
+            "root_path": "",
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode()),
+            ],
+            "client": ("testclient", 123),
+            "server": ("testserver", 80),
+        }
+
+        request_delivered = False
+        disconnect_requested = asyncio.Event()
+
+        async def receive():
+            nonlocal request_delivered
+            if not request_delivered:
+                request_delivered = True
+                return {"type": "http.request", "body": body, "more_body": False}
+            # Blocks until the test asks for the disconnect -- mirrors a
+            # real transport's receive() parking between client messages.
+            await disconnect_requested.wait()
+            return {"type": "http.disconnect"}
+
+        async def send(message):
+            pass
+
+        app_task = asyncio.ensure_future(app(scope, receive, send))
+
+        await asyncio.wait_for(started.wait(), timeout=5)
+        for _ in range(5):
+            await asyncio.sleep(0)
+        assert inflight.active == 1, (
+            "the slot must be held while genuinely streaming over raw ASGI"
+        )
+
+        disconnect_requested.set()
+        await asyncio.wait_for(app_task, timeout=5)
+
+        assert inflight.active == 0, (
+            "a genuine ASGI http.disconnect must reach limit_inflight's own "
+            "cleanup via Starlette's dependency-generator unwind -- not just "
+            "a hand-simulated aclose() -- otherwise capacity is wedged until "
+            "a restart"
         )

--- a/tests/unit/test_session_isolation.py
+++ b/tests/unit/test_session_isolation.py
@@ -24,10 +24,15 @@ These tests create a real session as user "alice" via the real
 """
 
 import json
+from contextlib import asynccontextmanager
 
 import pytest
 from fastapi import HTTPException
+from httpx import AsyncClient, ASGITransport
 
+import api.dependencies as deps
+from api.dependencies import AppState, get_gateway_user_id
+from api.ratelimit import InFlightLimiter, SlidingWindowRateLimiter
 from core.events import WorkflowError
 from core.executor import APP_NAME, WorkflowExecutor
 from core.session_state import SessionStateKeys
@@ -55,6 +60,39 @@ async def _drain_sse_route(coro):
     async for sse_dict in response.body_iterator:
         payload = json.loads(sse_dict["data"]) if sse_dict.get("data") else {}
         events.append((sse_dict["event"], payload))
+    return events
+
+
+@asynccontextmanager
+async def _null_lifespan(app):
+    yield
+
+
+def _parse_sse_text(text: str) -> list:
+    """Parse a raw ``text/event-stream`` HTTP response body into
+    ``(event, payload)`` pairs, same shape as ``_drain_sse_route``'s
+    return value, for the real-ASGI-round-trip tests below.
+
+    ``EventSourceResponse`` writes CRLF (``\r\n``) line endings, not bare
+    ``\n`` -- splitting on ``"\n\n"`` directly never matches (the blank
+    line between events is ``\r\n\r\n``), so the whole body parses as one
+    block and only the LAST event/data pair survives. Normalize line
+    endings first.
+    """
+    events = []
+    normalized = text.replace("\r\n", "\n")
+    for block in normalized.strip().split("\n\n"):
+        if not block.strip():
+            continue
+        event_type = None
+        data_line = None
+        for line in block.splitlines():
+            if line.startswith("event:"):
+                event_type = line[len("event:"):].strip()
+            elif line.startswith("data:"):
+                data_line = line[len("data:"):].strip()
+        payload = json.loads(data_line) if data_line else {}
+        events.append((event_type, payload))
     return events
 
 
@@ -358,3 +396,107 @@ class TestExpandRouteIsolation:
             f"real HTTP route, even holding her own chip id; got {events!r}"
         )
         assert not any("Bath" in json.dumps(payload) for _etype, payload in events)
+
+
+class TestRouteIsolationOverRealGatewayIdentity:
+    """Codex P2 (MYS-403 review r2): ``TestComposeRouteIsolation`` and
+    ``TestExpandRouteIsolation`` above call the route functions directly
+    with ``user_id=`` passed in as an already-resolved keyword argument --
+    that exercises route -> stream -> executor propagation, but
+    ``Depends(get_gateway_user_id)`` itself never runs, so a regression
+    that repointed or dropped the identity dependency (e.g. a route
+    signature edit that stopped declaring it, or a swap to a different
+    resolver) would leave the whole file green.
+
+    ``tests/unit/conftest.py`` globally overrides ``get_gateway_user_id``
+    to always return the literal ``"test_user"`` for every unit test (so
+    ordinary endpoint tests don't need gateway headers) -- these tests
+    explicitly remove that override on their own ``app`` instance and
+    drive the real ASGI application with a real ``X-User-ID`` header, so
+    the dependency that resolves identity from the request is what's
+    actually under test, not a stand-in.
+    """
+
+    @pytest.fixture
+    def real_identity_client(self, session_as_alice):
+        """A real ASGI app with the ``get_gateway_user_id`` override
+        removed (so the real dependency reads ``X-User-ID`` off each
+        request) and wired to the same session/executor
+        ``session_as_alice`` sets up. ``verify_gateway_secret`` stays
+        overridden to a no-op -- that boundary already has dedicated
+        negative coverage in ``test_gateway_auth.py`` (MYS-403 gap 1);
+        this fixture isolates identity resolution specifically.
+        """
+        from api.app import create_app
+
+        executor, _service = session_as_alice
+
+        app = create_app()  # patched by tests/unit/conftest.py's autouse fixture
+        app.dependency_overrides.pop(get_gateway_user_id, None)
+        app.router.lifespan_context = _null_lifespan
+
+        deps._app_state = AppState(
+            config=None,
+            executor=executor,
+            rate_limiter=SlidingWindowRateLimiter(max_requests=0, window_seconds=60),
+            inflight_limiter=InFlightLimiter(max_in_flight=0),
+        )
+        try:
+            yield AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+        finally:
+            deps._app_state = None
+
+    async def test_alice_header_reaches_her_own_session_via_compose(
+        self, real_identity_client
+    ):
+        response = await real_identity_client.post(
+            f"/api/v1/itinerary/{_JOB_ID}/compose",
+            json={"region_ids": [1]},
+            headers={"X-User-ID": _OWNER_USER_ID},
+        )
+        assert response.status_code == 200
+        events = _parse_sse_text(response.text)
+        errors = [payload for etype, payload in events if etype == "error"]
+        assert not any(e.get("error_type") == "JobNotFound" for e in errors), (
+            f"a real X-User-ID: alice header must resolve to alice and find "
+            f"her own session, got {events!r}"
+        )
+
+    async def test_bob_header_is_rejected_from_alices_session_via_compose(
+        self, real_identity_client
+    ):
+        response = await real_identity_client.post(
+            f"/api/v1/itinerary/{_JOB_ID}/compose",
+            json={"region_ids": [1]},
+            headers={"X-User-ID": _OTHER_USER_ID},
+        )
+        assert response.status_code == 200
+        events = _parse_sse_text(response.text)
+        errors = [payload for etype, payload in events if etype == "error"]
+        assert errors and errors[0].get("error_type") == "JobNotFound", (
+            f"a real X-User-ID: bob header must be denied alice's session "
+            f"through the actual gateway-identity dependency, got {events!r}"
+        )
+        assert "Bath" not in response.text
+
+    async def test_bob_header_is_rejected_from_alices_session_via_expand(
+        self, real_identity_client
+    ):
+        response = await real_identity_client.post(
+            f"/api/v1/itinerary/{_JOB_ID}/expand",
+            json={
+                "action_id": "chip-1",
+                "action_label": "More cafes",
+                "action_prompt": "Find cafes in Bath",
+            },
+            headers={"X-User-ID": _OTHER_USER_ID},
+        )
+        assert response.status_code == 200
+        events = _parse_sse_text(response.text)
+        errors = [payload for etype, payload in events if etype == "error"]
+        assert errors and errors[0].get("error_type") == "JobNotFound", (
+            f"bob must not reach alice's session via expand() through the "
+            f"real gateway-identity dependency, even holding her chip id, "
+            f"got {events!r}"
+        )
+        assert "Bath" not in response.text

--- a/tests/unit/test_session_isolation.py
+++ b/tests/unit/test_session_isolation.py
@@ -500,3 +500,64 @@ class TestRouteIsolationOverRealGatewayIdentity:
             f"got {events!r}"
         )
         assert "Bath" not in response.text
+
+    async def test_alice_header_reaches_her_own_session_via_expand(
+        self, real_identity_client
+    ):
+        # Codex P2 (MYS-403 review r3): the class above only sent bob's
+        # header to /expand -- a route-specific regression that resolves
+        # EVERY expand request to a fixed non-owner identity would still
+        # produce JobNotFound for bob and pass, since nothing here proves
+        # a REAL owner header is ever admitted on this specific route. The
+        # direct-call owner test elsewhere can't catch this either, since
+        # it supplies user_id explicitly rather than through a header.
+        response = await real_identity_client.post(
+            f"/api/v1/itinerary/{_JOB_ID}/expand",
+            json={
+                "action_id": "chip-1",
+                "action_label": "More cafes",
+                "action_prompt": "Find cafes in Bath",
+            },
+            headers={"X-User-ID": _OWNER_USER_ID},
+        )
+        assert response.status_code == 200
+        events = _parse_sse_text(response.text)
+        errors = [payload for etype, payload in events if etype == "error"]
+        assert not any(e.get("error_type") == "JobNotFound" for e in errors), (
+            f"a real X-User-ID: alice header must resolve to alice and "
+            f"find her own session via expand(), got {events!r}"
+        )
+
+    async def test_alice_header_reaches_her_own_status_via_real_asgi(
+        self, real_identity_client
+    ):
+        # Codex P2 (MYS-403 review r3): TestStatusEndpointIsolation calls
+        # get_status() directly with user_id= as an already-resolved
+        # kwarg, same bypass class as the pre-r3 compose/expand tests --
+        # if the status route alone were repointed to a different/broken
+        # identity resolver, that class would still pass. get_status is a
+        # plain JSON response (no SSE parsing needed).
+        response = await real_identity_client.get(
+            f"/api/v1/itinerary/{_JOB_ID}/status",
+            headers={"X-User-ID": _OWNER_USER_ID},
+        )
+        assert response.status_code == 200, (
+            f"a real X-User-ID: alice header must resolve to alice and "
+            f"find her own status, got {response.status_code} {response.text!r}"
+        )
+        assert response.json().get("book_title") == "Persuasion"
+
+    async def test_bob_header_is_rejected_from_alices_status_via_real_asgi(
+        self, real_identity_client
+    ):
+        response = await real_identity_client.get(
+            f"/api/v1/itinerary/{_JOB_ID}/status",
+            headers={"X-User-ID": _OTHER_USER_ID},
+        )
+        assert response.status_code == 404, (
+            f"a real X-User-ID: bob header must be denied alice's status "
+            f"through the actual gateway-identity dependency, got "
+            f"{response.status_code} {response.text!r}"
+        )
+        assert "Bath" not in response.text
+        assert "Persuasion" not in response.text

--- a/tests/unit/test_session_isolation.py
+++ b/tests/unit/test_session_isolation.py
@@ -23,6 +23,8 @@ These tests create a real session as user "alice" via the real
   exactly that, not user A's data.
 """
 
+import json
+
 import pytest
 from fastapi import HTTPException
 
@@ -35,6 +37,25 @@ from services.session_service import create_session_service
 
 async def _drain(agen):
     return [e async for e in agen]
+
+
+async def _drain_sse_route(coro):
+    """Call a route function that returns an ``EventSourceResponse`` and
+    drain its underlying SSE-dict generator (event/data pairs), decoding
+    each ``data`` payload's JSON. This exercises the actual HTTP route
+    function -- request -> ``compose_stream``/``expand_stream`` ->
+    ``executor`` -- not just the executor directly, so a regression that
+    stopped forwarding the authenticated ``user_id`` anywhere on that path
+    (a route or streaming adapter falling back to a shared default) would
+    show up here even though it would leave an executor-level-only test
+    green.
+    """
+    response = await coro
+    events = []
+    async for sse_dict in response.body_iterator:
+        payload = json.loads(sse_dict["data"]) if sse_dict.get("data") else {}
+        events.append((sse_dict["event"], payload))
+    return events
 
 
 _SEED_STATE = {
@@ -162,6 +183,77 @@ class TestComposeIsolation:
         assert not any("Bath" in str(e) for e in events)
 
 
+class TestComposeRouteIsolation:
+    """Codex P2 (MYS-403 review): the tests above call executor.compose()
+    directly, which only proves the EXECUTOR's session lookup is
+    user-scoped. This PR's stated purpose is protecting the auth boundary
+    -- the HTTP surface -- and that's exactly where a regression would
+    hide: a route or streaming adapter that stopped forwarding the
+    authenticated user_id and fell back to a shared default would leave
+    the tests above green while HTTP callers crossed the boundary. These
+    call the real ``api.routes.compose`` route function (request ->
+    ``compose_stream`` -> executor), the same pattern
+    ``TestStatusEndpointIsolation`` above already uses for ``get_status``.
+    """
+
+    async def test_owner_route_call_succeeds_not_job_not_found(
+        self, session_as_alice
+    ):
+        from api.models import ComposeRequest
+        from api.routes import compose
+        import api.dependencies as deps
+
+        executor, _service = session_as_alice
+        deps._app_state = deps.AppState(
+            config=None, executor=executor, rate_limiter=None, inflight_limiter=None
+        )
+        try:
+            events = await _drain_sse_route(
+                compose(
+                    job_id=_JOB_ID,
+                    request=ComposeRequest(region_ids=[1]),
+                    user_id=_OWNER_USER_ID,
+                )
+            )
+        finally:
+            deps._app_state = None
+        errors = [payload for etype, payload in events if etype == "error"]
+        assert not any(e.get("error_type") == "JobNotFound" for e in errors), (
+            f"alice's own session must be found via the real compose route; "
+            f"got {events!r}"
+        )
+
+    async def test_bob_route_call_gets_job_not_found_not_alices_data(
+        self, session_as_alice
+    ):
+        from api.models import ComposeRequest
+        from api.routes import compose
+        import api.dependencies as deps
+
+        executor, _service = session_as_alice
+        deps._app_state = deps.AppState(
+            config=None, executor=executor, rate_limiter=None, inflight_limiter=None
+        )
+        try:
+            events = await _drain_sse_route(
+                compose(
+                    job_id=_JOB_ID,
+                    request=ComposeRequest(region_ids=[1]),
+                    user_id=_OTHER_USER_ID,
+                )
+            )
+        finally:
+            deps._app_state = None
+        errors = [payload for etype, payload in events if etype == "error"]
+        assert errors and errors[0].get("error_type") == "JobNotFound", (
+            f"bob must not be able to compose alice's session through the "
+            f"real HTTP route; got {events!r}"
+        )
+        # Route→stream→executor propagation must not leak alice's data
+        # anywhere in the wire-shaped output, not just the domain events.
+        assert not any("Bath" in json.dumps(payload) for _etype, payload in events)
+
+
 class TestExpandIsolation:
     async def test_owner_lookup_succeeds_not_job_not_found(self, session_as_alice):
         executor, _service = session_as_alice
@@ -198,3 +290,71 @@ class TestExpandIsolation:
             f"and her chip id; got {events!r}"
         )
         assert not any("Bath" in str(e) for e in events)
+
+
+class TestExpandRouteIsolation:
+    """Codex P2 (MYS-403 review) -- see TestComposeRouteIsolation's
+    docstring: the same route→stream→executor gap applies to expand()."""
+
+    async def test_owner_route_call_succeeds_not_job_not_found(
+        self, session_as_alice
+    ):
+        from api.models import ExpandRequest
+        from api.routes import expand
+        import api.dependencies as deps
+
+        executor, _service = session_as_alice
+        deps._app_state = deps.AppState(
+            config=None, executor=executor, rate_limiter=None, inflight_limiter=None
+        )
+        try:
+            events = await _drain_sse_route(
+                expand(
+                    job_id=_JOB_ID,
+                    request=ExpandRequest(
+                        action_id="chip-1",
+                        action_label="More cafes",
+                        action_prompt="Find cafes in Bath",
+                    ),
+                    user_id=_OWNER_USER_ID,
+                )
+            )
+        finally:
+            deps._app_state = None
+        errors = [payload for etype, payload in events if etype == "error"]
+        assert not any(e.get("error_type") == "JobNotFound" for e in errors), (
+            f"alice's own session must be found via the real expand route; "
+            f"got {events!r}"
+        )
+
+    async def test_bob_route_call_gets_job_not_found_not_alices_data(
+        self, session_as_alice
+    ):
+        from api.models import ExpandRequest
+        from api.routes import expand
+        import api.dependencies as deps
+
+        executor, _service = session_as_alice
+        deps._app_state = deps.AppState(
+            config=None, executor=executor, rate_limiter=None, inflight_limiter=None
+        )
+        try:
+            events = await _drain_sse_route(
+                expand(
+                    job_id=_JOB_ID,
+                    request=ExpandRequest(
+                        action_id="chip-1",
+                        action_label="More cafes",
+                        action_prompt="Find cafes in Bath",
+                    ),
+                    user_id=_OTHER_USER_ID,
+                )
+            )
+        finally:
+            deps._app_state = None
+        errors = [payload for etype, payload in events if etype == "error"]
+        assert errors and errors[0].get("error_type") == "JobNotFound", (
+            f"bob must not be able to expand alice's session through the "
+            f"real HTTP route, even holding her own chip id; got {events!r}"
+        )
+        assert not any("Bath" in json.dumps(payload) for _etype, payload in events)

--- a/tests/unit/test_session_isolation.py
+++ b/tests/unit/test_session_isolation.py
@@ -1,0 +1,200 @@
+"""MYS-403 gap 2: cross-user / session-isolation coverage.
+
+Isolation between users is structural -- ADK's ``session_service.get_session``
+is scoped by ``(app_name, user_id, session_id)``, so a session created under
+one user_id is simply absent under a different one. But nothing PROVED that:
+every existing status/compose/expand test in this suite runs as the implicit
+``dev_user``, so a regression that dropped or mis-threaded the ``user_id``
+filter anywhere on this path (e.g. a copy-paste that hardcoded a shared id,
+or a refactor that read ``job_id`` alone) would have shipped unnoticed.
+
+These tests create a real session as user "alice" via the real
+``InMemorySessionService`` (same technique as
+``test_executor_expansion_concurrency.py``) and then access it as user "bob":
+
+* ``get_status`` (api/routes.py) is a plain request/response endpoint --
+  the user-B case must be a genuine HTTP-shaped 404, same as a job_id that
+  never existed at all.
+* ``compose`` / ``expand`` (core/executor.py) are streaming generators that
+  never raise an HTTP error -- a not-found session surfaces as an SSE
+  ``WorkflowError(error_type="JobNotFound")`` inside a 200-shaped stream
+  (the same contract exercised by e.g. TestDiscoverEndpoint::
+  test_discover_session_create_failure in test_api.py). user B must get
+  exactly that, not user A's data.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from core.events import WorkflowError
+from core.executor import APP_NAME, WorkflowExecutor
+from core.session_state import SessionStateKeys
+from core.types import ExecutorConfig
+from services.session_service import create_session_service
+
+
+async def _drain(agen):
+    return [e async for e in agen]
+
+
+_SEED_STATE = {
+    SessionStateKeys.BOOK_METADATA: {
+        "book_title": "Persuasion",
+        "author": "Jane Austen",
+    },
+    SessionStateKeys.REGION_ANALYSIS: {
+        "regions": [{"region_id": 1, "region_name": "England"}],
+        "analysis_note": "test",
+    },
+    SessionStateKeys.FINAL_ITINERARY: {
+        "cities": [
+            {
+                "name": "Bath",
+                "country": "England",
+                "days_suggested": 2,
+                "overview": "Austen's Bath",
+                "stops": [],
+            }
+        ],
+        "summary_text": "seed",
+    },
+    SessionStateKeys.LAST_SUGGESTIONS: [
+        {"id": "chip-1", "label": "More cafes", "action_prompt": "Find cafes in Bath"}
+    ],
+    SessionStateKeys.BOOK_TITLE: "Persuasion",
+    SessionStateKeys.AUTHOR: "Jane Austen",
+}
+
+_OWNER_USER_ID = "alice"
+_OTHER_USER_ID = "bob"
+_JOB_ID = "job-isolation-1"
+
+
+@pytest.fixture
+async def session_as_alice(monkeypatch):
+    """A real session service with one session created under user 'alice',
+    plus a WorkflowExecutor wired to it. ``create_expansion_workflow`` /
+    ``create_book_to_place_composition_workflow`` are left real (not
+    monkeypatched, unlike the MYS-401 concurrency tests) -- these isolation
+    tests only need the up-front session lookup to behave correctly, not a
+    full successful run, so a dummy ``model=object()`` reaching the agent
+    layer is caught by ``run_guarded``'s exception mapping (MYS-400) and
+    surfaces as SOME client-safe error, never a crash and never JobNotFound.
+    """
+    service = create_session_service(use_database=False)
+    config = ExecutorConfig(model_name="gemini-2.0-flash", google_api_key="test-key")
+    executor = WorkflowExecutor(config=config, session_service=service, model=object())
+    await service.create_session(
+        app_name=APP_NAME,
+        user_id=_OWNER_USER_ID,
+        session_id=_JOB_ID,
+        state=dict(_SEED_STATE),
+    )
+    return executor, service
+
+
+class TestStatusEndpointIsolation:
+    """api/routes.py::get_status -- a real 404, not an SSE error."""
+
+    async def test_owner_can_read_their_own_status(self, session_as_alice):
+        from api.routes import get_status
+        import api.dependencies as deps
+
+        executor, service = session_as_alice
+        app_state = deps.AppState(
+            config=None,
+            executor=executor,
+            rate_limiter=None,
+            inflight_limiter=None,
+        )
+        deps._app_state = app_state
+        try:
+            result = await get_status(job_id=_JOB_ID, user_id=_OWNER_USER_ID)
+        finally:
+            deps._app_state = None
+        assert result.job_id == _JOB_ID
+        assert result.book_title == "Persuasion"
+
+    async def test_a_different_user_gets_404_not_alices_data(self, session_as_alice):
+        from api.routes import get_status
+        import api.dependencies as deps
+
+        executor, service = session_as_alice
+        app_state = deps.AppState(
+            config=None,
+            executor=executor,
+            rate_limiter=None,
+            inflight_limiter=None,
+        )
+        deps._app_state = app_state
+        try:
+            with pytest.raises(HTTPException) as exc:
+                await get_status(job_id=_JOB_ID, user_id=_OTHER_USER_ID)
+        finally:
+            deps._app_state = None
+        assert exc.value.status_code == 404
+
+
+class TestComposeIsolation:
+    async def test_owner_lookup_succeeds_not_job_not_found(self, session_as_alice):
+        executor, _service = session_as_alice
+        events = await _drain(
+            executor.compose(job_id=_JOB_ID, region_ids=[1], user_id=_OWNER_USER_ID)
+        )
+        errors = [e for e in events if isinstance(e, WorkflowError)]
+        assert not any(e.error_type == "JobNotFound" for e in errors), (
+            f"alice's own session must be found by compose(); got {events!r}"
+        )
+
+    async def test_a_different_user_cannot_compose_alices_session(
+        self, session_as_alice
+    ):
+        executor, _service = session_as_alice
+        events = await _drain(
+            executor.compose(job_id=_JOB_ID, region_ids=[1], user_id=_OTHER_USER_ID)
+        )
+        errors = [e for e in events if isinstance(e, WorkflowError)]
+        assert errors and errors[0].error_type == "JobNotFound", (
+            f"bob must not be able to compose alice's session via her job_id; "
+            f"got {events!r}"
+        )
+        # And nothing of alice's leaked into the event stream itself.
+        assert not any("Bath" in str(e) for e in events)
+
+
+class TestExpandIsolation:
+    async def test_owner_lookup_succeeds_not_job_not_found(self, session_as_alice):
+        executor, _service = session_as_alice
+        events = await _drain(
+            executor.expand(
+                job_id=_JOB_ID,
+                action_id="chip-1",
+                action_label="More cafes",
+                action_prompt="Find cafes in Bath",
+                user_id=_OWNER_USER_ID,
+            )
+        )
+        errors = [e for e in events if isinstance(e, WorkflowError)]
+        assert not any(e.error_type == "JobNotFound" for e in errors), (
+            f"alice's own session must be found by expand(); got {events!r}"
+        )
+
+    async def test_a_different_user_cannot_expand_alices_session(
+        self, session_as_alice
+    ):
+        executor, _service = session_as_alice
+        events = await _drain(
+            executor.expand(
+                job_id=_JOB_ID,
+                action_id="chip-1",
+                action_label="More cafes",
+                action_prompt="Find cafes in Bath",
+                user_id=_OTHER_USER_ID,
+            )
+        )
+        errors = [e for e in events if isinstance(e, WorkflowError)]
+        assert errors and errors[0].error_type == "JobNotFound", (
+            f"bob must not be able to expand alice's session via her job_id "
+            f"and her chip id; got {events!r}"
+        )
+        assert not any("Bath" in str(e) for e in events)


### PR DESCRIPTION
## What

Test-only PR closing three of the four gaps the Tech Radar AI review flagged: cross-user session isolation, inflight-slot lifetime over a real stream (both the normal-completion and mid-stream-disconnect cases), and the session sweeper's coverage of the lazily-created place→book resolver store. No production code changes.

## Why

The AI suite is genuinely behavioral, but the auth boundary — the weakest link — was the least-tested. Three concrete gaps:

1. **No negative `X-Internal-Secret` test** — already closed by MYS-399's own PR (`tests/unit/test_gateway_auth.py` now has full missing/wrong/empty-config coverage). Verified present; no new work needed for this gap.
2. **No cross-user / session-isolation test** — every existing status/compose/expand test ran as the implicit `dev_user`, so a regression that dropped or mis-threaded `user_id` anywhere on the path would have shipped unnoticed.
3. **Inflight-slot lifetime was only ever driven as a bare async generator** — never through a real streaming response, so "released when the SSE generator finishes OR the client disconnects mid-stream" was unverified. Also untested: whether the session sweeper's provider actually includes the lazily-created place→book resolver store once it exists.

## How

- `tests/unit/test_session_isolation.py` (new): creates a real session as user `alice` (real `InMemorySessionService`, same technique as `test_executor_expansion_concurrency.py`), then proves user `bob` cannot read it — a genuine HTTP 404 via `api/routes.py::get_status`, and an SSE `JobNotFound` (never a leaked itinerary) via `core.executor.WorkflowExecutor.compose()`/`expand()`.
- `tests/unit/test_api.py`: new `TestInflightLimiterOverRealStream` drives `limit_inflight()` through a genuine ASGI round-trip (httpx `AsyncClient` + `ASGITransport`, same pattern the file's existing streaming-endpoint tests use) and asserts the slot frees after the stream completes — and that the freed slot is genuinely reusable, not just zeroed by accident. New `TestSessionSweeperIncludesResolverStoreOnceCreated` drives the real `api/app.py::lifespan` context manager (with `initialize()`/`shutdown()` stubbed, `SessionSweeper` itself real) and proves `_live_session_services` picks up the resolver's session store once it's lazily created.
- `tests/unit/test_ratelimit.py`: new `TestLimitInflightCancellation` covers the mid-stream-disconnect half. I initially tried this over a real ASGI round-trip (abandon a `client.stream()` read early), but confirmed empirically that httpx's `ASGITransport` in this environment does not propagate an early stream-read abort as a genuine server-side cancellation — it just hangs for the full generator lifetime instead of disconnecting. So this is tested at the dependency-generator level instead: the task holding the slot open is cancelled mid-`sleep`, and its cleanup calls `gen.aclose()` — the same unwind mechanism Starlette uses on a real client disconnect — and the test asserts the slot is freed.

## Docs

No impact — test-only change, no architecture/contract/config/route change.

## Verification

- New tests: `tests/unit/test_session_isolation.py`, `tests/unit/test_api.py::TestInflightLimiterOverRealStream` + `::TestSessionSweeperIncludesResolverStoreOnceCreated`, `tests/unit/test_ratelimit.py::TestLimitInflightCancellation`.
- All new tests confirmed passing individually with `--timeout=15` (pytest-timeout) to rule out any hang; the disconnect scenario was validated to genuinely fail (timeout) before the ASGI-transport approach was replaced with the cancellation-based one — worth a close read since it's the trickiest test in the set.
- Full suite: `make test-ci` → 936 passed, 7 pre-existing failures (identical shape/count to the current `main` baseline — sandbox Python 3.10 lacks the `ExceptionGroup` builtin CI's 3.12 has, unrelated to this change). Coverage 88.96% (floor 74%).
- No dependency/lockfile change, no API/schema/wire-contract change → no eval, no G4-spend gate.