### PR TITLE
test(ai): dead-field inventory class guard — fail CI when a prompt reads a preference field no UI collects

### DIFF
--- a/docs/ui_collected_preference_fields.json
+++ b/docs/ui_collected_preference_fields.json
@@ -1,0 +1,21 @@
+{
+  "_readme": [
+    "MYS-439 class-level guard inventory (paired with tests/unit/test_dead_field_inventory.py).",
+    "Every preference FIELD NAME literally read off a variable/parameter named `preferences` inside",
+    "the prompt-assembly surface (agents/*.py, core/prompts.py) via preferences[\"field\"] or",
+    "preferences.get(\"field\") must have an entry in `fields` below, naming the FE surface that",
+    "actually collects it -- so QA's weekly dead-control sweep can diff against the same list. The",
+    "test fails CI if a scanned field is missing here, or if an entry here names a field the scan no",
+    "longer finds (stale documentation of a read that was removed).",
+    "",
+    "Empty today (2026-07-27): MYS-436 deleted reader_profile_agent, the only prompt that ever read",
+    "a NAMED preference field. Every remaining prompt builder treats `preferences` as an opaque dict",
+    "passed through whole via json.dumps(preferences) -- core/prompts.py::build_composition_prompt,",
+    "agents/prompts.py::preferences_block. The FE does not collect or send any named preference",
+    "field on the live discover/compose paths either (storyland-web's `preferences` payload is",
+    "optional and unused since MYS-392 retired the mood-chip channel). Add an entry here in the SAME",
+    "PR that adds a named preferences.get(\"field\")/preferences[\"field\"] read to the prompt-assembly",
+    "surface."
+  ],
+  "fields": {}
+}

--- a/tests/unit/test_dead_field_inventory.py
+++ b/tests/unit/test_dead_field_inventory.py
@@ -1,0 +1,186 @@
+"""
+MYS-439 — class-level guard: fail CI when a prompt reads a preference field
+no UI collects.
+
+## Why this exists (class, not instance)
+
+The class this test guards against is: a prompt-assembly module reads a
+NAMED preference field (`preferences["budget"]`, `preferences.get("pace")`)
+that nothing on the frontend actually collects and sends — the model then
+receives (and can act on, or narrate) a field that is always absent. This
+ticket was originally scoped against `reader_profile_agent`'s prompt, which
+named five such fields. MYS-436 deleted that agent outright, so there is no
+live violation today; this test passes cleanly on the current tree.
+
+That does not make the guard pointless (PM ruling, 2026-07-27, MYS-439):
+this is a "second occurrence = write the gate" class-level guard (the
+sibling read-side of MYS-437's send-side wired-control spec), and its value
+is catching the *next* time someone wires a prompt to a field the UI never
+collects — not re-proving today's already-fixed instance. Instance fixed !=
+class closed.
+
+## What counts as an offense
+
+Every prompt-assembly module (`agents/*.py`, `core/prompts.py`) currently
+treats `preferences` as an OPAQUE dict, passed through whole via
+`json.dumps(preferences)` — `core/prompts.py::build_composition_prompt`,
+`agents/prompts.py::preferences_block`. Neither ever reads a field by name.
+An offense is a NEW literal-key read off a variable/parameter named exactly
+`preferences`: `preferences["field"]` or `preferences.get("field", ...)`.
+Reading the whole dict opaquely (`json.dumps(preferences)`,
+`preferences.items()`, `dict(preferences)`) is not an offense — that's the
+safe, already-shipped shape.
+
+## SCOPE (deliberately narrow, not exhaustive)
+
+This is an AST scanner bound to the literal receiver name `preferences`,
+over a fixed set of prompt-assembly files (`agents/` + `core/prompts.py`).
+It does NOT track a differently-named alias (`user_preferences`,
+`prefs = preferences; prefs["budget"]`), attribute-style access on a typed
+object (`preferences.budget`, e.g. if `TravelPreferences` — currently
+unused in production code — were wired back in), or reads outside the
+scanned files. Verified by hand as of this PR that no such alias exists
+today. Mirrors the same "receiver-name-bound, narrow the claim rather than
+over-promise" scope note the fe sibling guard carries
+(`storyland-web/tests/regionCitiesGuard.test.ts`, MYS-681).
+
+## Inventory file
+
+`docs/ui_collected_preference_fields.json`: `fields` maps each read field
+name to the FE surface that collects it. Empty today (see the file's own
+`_readme`). A field found by the scanner but missing from the inventory
+fails CI; a field listed in the inventory but no longer found by the
+scanner also fails (stale documentation of a read that was removed —
+catches the inventory drifting from reality in either direction).
+"""
+
+import ast
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INVENTORY_PATH = REPO_ROOT / "docs" / "ui_collected_preference_fields.json"
+
+# The prompt-assembly surface. NOT core/executor.py, core/session_state.py,
+# core/cache.py, etc: those pass the whole `preferences` dict through
+# opaquely (`.items()` for cache-key hashing, `state["user:preferences"] =
+# preferences`) without ever reading a NAMED field — that's a different
+# (and already-guarded, MYS-401) class, not this ticket's.
+SCAN_ROOTS = [REPO_ROOT / "agents", REPO_ROOT / "core" / "prompts.py"]
+
+
+def _iter_py_files():
+    for root in SCAN_ROOTS:
+        if root.is_file():
+            yield root
+        elif root.is_dir():
+            yield from sorted(root.rglob("*.py"))
+
+
+class _PreferencesFieldVisitor(ast.NodeVisitor):
+    """Collects every literal field name read off a variable/parameter
+    literally named `preferences` via `preferences["x"]` or
+    `preferences.get("x", ...)`.
+    """
+
+    def __init__(self):
+        self.fields: set[str] = set()
+
+    def visit_Subscript(self, node: ast.Subscript) -> None:
+        if isinstance(node.value, ast.Name) and node.value.id == "preferences":
+            key = node.slice
+            if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                self.fields.add(key.value)
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "get"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "preferences"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        ):
+            self.fields.add(node.args[0].value)
+        self.generic_visit(node)
+
+
+def find_named_preference_reads(source: str) -> set:
+    """Return every literal field name read off a `preferences`-named
+    receiver in `source` (see module docstring for exactly which shapes
+    count)."""
+    tree = ast.parse(source)
+    visitor = _PreferencesFieldVisitor()
+    visitor.visit(tree)
+    return visitor.fields
+
+
+def _load_inventory() -> dict:
+    return json.loads(INVENTORY_PATH.read_text())
+
+
+def test_detector_self_check_catches_every_offense_shape_and_ignores_safe_shapes():
+    assert find_named_preference_reads(
+        'def f(preferences):\n    return preferences["budget"]\n'
+    ) == {"budget"}
+    assert find_named_preference_reads(
+        "def f(preferences):\n    return preferences.get('preferred_pace')\n"
+    ) == {"preferred_pace"}
+    assert find_named_preference_reads(
+        "def f(preferences):\n    return preferences.get('budget', 'moderate')\n"
+    ) == {"budget"}
+    assert find_named_preference_reads(
+        "def f(preferences):\n"
+        "    a = preferences['budget']\n"
+        "    b = preferences.get('preferred_pace')\n"
+        "    return a, b\n"
+    ) == {"budget", "preferred_pace"}
+
+    safe_sources = [
+        # the exact opaque-passthrough shapes already shipped in this repo
+        "import json\ndef f(preferences):\n    return json.dumps(preferences)\n",
+        "def f(preferences):\n    return dict(preferences)\n",
+        "def f(preferences):\n    return sorted(preferences.items())\n",
+        # a bare truthiness/emptiness check is not a field read
+        "def f(preferences):\n    if not preferences:\n        return ''\n    return 'x'\n",
+        # a differently-named receiver is out of scope by design (SCOPE note)
+        "def f(user_preferences):\n    return user_preferences.get('budget')\n",
+    ]
+    for src in safe_sources:
+        assert find_named_preference_reads(src) == set(), src
+
+
+def test_inventory_file_is_valid_json_with_a_fields_map():
+    inventory = _load_inventory()
+    assert isinstance(inventory.get("fields"), dict)
+
+
+def test_every_named_preference_field_read_in_the_prompt_assembly_surface_is_inventoried():
+    inventory_fields = set(_load_inventory()["fields"].keys())
+
+    found_by_file = {}
+    for path in _iter_py_files():
+        fields = find_named_preference_reads(path.read_text())
+        if fields:
+            found_by_file[str(path.relative_to(REPO_ROOT))] = sorted(fields)
+
+    all_found = {f for fields in found_by_file.values() for f in fields}
+    undocumented = all_found - inventory_fields
+    assert not undocumented, (
+        f"prompt assembly reads preference field(s) {sorted(undocumented)} "
+        f"not documented in {INVENTORY_PATH.relative_to(REPO_ROOT)} -- add "
+        "an entry naming which FE surface actually collects each field "
+        f"before this can ship (offending file(s): {found_by_file})"
+    )
+
+    stale = inventory_fields - all_found
+    assert not stale, (
+        f"docs/ui_collected_preference_fields.json documents field(s) "
+        f"{sorted(stale)} that the scanner no longer finds anywhere in "
+        f"{[str(r.relative_to(REPO_ROOT)) for r in SCAN_ROOTS]} -- either "
+        "the read was removed (delete the stale entry) or the scanner's "
+        "SCOPE narrowed past a real remaining read (widen it)."
+    )

--- a/tests/unit/test_dead_field_inventory.py
+++ b/tests/unit/test_dead_field_inventory.py
@@ -87,7 +87,17 @@ class _PreferencesFieldVisitor(ast.NodeVisitor):
         self.fields: set[str] = set()
 
     def visit_Subscript(self, node: ast.Subscript) -> None:
-        if isinstance(node.value, ast.Name) and node.value.id == "preferences":
+        # Only a READ is an offense candidate. `preferences["derived"] = value`
+        # (ast.Store) or `del preferences["derived"]` (ast.Del) are the service
+        # WRITING/removing its own key, not reading a field the FE must have
+        # collected -- counting those as reads would demand a nonexistent FE
+        # surface for a key that never came from the frontend at all (Eng Lead
+        # fix-list, MYS-439, Codex P2).
+        if (
+            isinstance(node.value, ast.Name)
+            and node.value.id == "preferences"
+            and isinstance(node.ctx, ast.Load)
+        ):
             key = node.slice
             if isinstance(key, ast.Constant) and isinstance(key.value, str):
                 self.fields.add(key.value)
@@ -140,6 +150,11 @@ def test_detector_self_check_catches_every_offense_shape_and_ignores_safe_shapes
     ) == {"budget", "preferred_pace"}
 
     safe_sources = [
+        # a STORE (assignment) or DEL context is the service writing/removing
+        # its own key, not reading a field the FE sent -- must not be
+        # collected as an offense (Eng Lead fix-list, MYS-439, Codex P2)
+        "def f(preferences):\n    preferences['derived'] = 1\n    return preferences\n",
+        "def f(preferences):\n    del preferences['derived']\n    return preferences\n",
         # the exact opaque-passthrough shapes already shipped in this repo
         "import json\ndef f(preferences):\n    return json.dumps(preferences)\n",
         "def f(preferences):\n    return dict(preferences)\n",
@@ -155,7 +170,21 @@ def test_detector_self_check_catches_every_offense_shape_and_ignores_safe_shapes
 
 def test_inventory_file_is_valid_json_with_a_fields_map():
     inventory = _load_inventory()
-    assert isinstance(inventory.get("fields"), dict)
+    fields = inventory.get("fields")
+    assert isinstance(fields, dict)
+    # The _readme's own promise, and the failure message on the drift test
+    # below, both claim every entry NAMES THE FE SURFACE that collects the
+    # field -- {"budget": null} or {"budget": ""} would pass a bare
+    # isinstance(dict) check while telling QA's dead-control sweep nothing.
+    # That's this repo's own "copy claims something the code doesn't do"
+    # class (MYS-492/MYS-584); enforce the contract the doc states (Eng
+    # Lead fix-list, MYS-439, Codex P2).
+    for field, fe_surface in fields.items():
+        assert isinstance(fe_surface, str) and fe_surface.strip(), (
+            f'inventory entry {field!r} must name a non-empty FE surface '
+            f'string (got {fe_surface!r}) -- an empty/null value documents '
+            'nothing for QA\'s dead-control sweep to diff against'
+        )
 
 
 def test_every_named_preference_field_read_in_the_prompt_assembly_surface_is_inventoried():

--- a/tests/unit/test_dead_field_inventory.py
+++ b/tests/unit/test_dead_field_inventory.py
@@ -26,10 +26,16 @@ treats `preferences` as an OPAQUE dict, passed through whole via
 `json.dumps(preferences)` — `core/prompts.py::build_composition_prompt`,
 `agents/prompts.py::preferences_block`. Neither ever reads a field by name.
 An offense is a NEW literal-key read off a variable/parameter named exactly
-`preferences`: `preferences["field"]` or `preferences.get("field", ...)`.
-Reading the whole dict opaquely (`json.dumps(preferences)`,
-`preferences.items()`, `dict(preferences)`) is not an offense — that's the
-safe, already-shipped shape.
+`preferences`: `preferences["field"]` (`ast.Load` context), `preferences["field"]
++= x` (`ast.AugAssign` -- reads the prior value even though its target
+Subscript carries `ast.Store`, same as a plain write), or
+`preferences.get("field", ...)`. A plain write/delete (`preferences["field"]
+= x`, `del preferences["field"]`) is not an offense -- the service writing
+or removing its own key, not reading one the FE sent. Reading the whole
+dict opaquely (`json.dumps(preferences)`, `preferences.items()`,
+`dict(preferences)`) is likewise not an offense. `.pop()`/`.setdefault()`
+also read a field but are deliberately out of scope (disclosed, not a false
+claim -- see SCOPE).
 
 ## SCOPE (deliberately narrow, not exhaustive)
 
@@ -38,8 +44,11 @@ over a fixed set of prompt-assembly files (`agents/` + `core/prompts.py`).
 It does NOT track a differently-named alias (`user_preferences`,
 `prefs = preferences; prefs["budget"]`), attribute-style access on a typed
 object (`preferences.budget`, e.g. if `TravelPreferences` — currently
-unused in production code — were wired back in), or reads outside the
-scanned files. Verified by hand as of this PR that no such alias exists
+unused in production code — were wired back in), reads outside the
+scanned files, or `.pop()`/`.setdefault()` calls (these read too, but sit
+outside this guard's literal-key-subscript/`.get()` offense definition --
+a closed read-set of `Load` ∪ (`Store` under `AugAssign`) that a source-text
+regex could never enumerate but this AST scanner can, per MYS-685). Verified by hand as of this PR that no such alias exists
 today. Mirrors the same "receiver-name-bound, narrow the claim rather than
 over-promise" scope note the fe sibling guard carries
 (`storyland-web/tests/regionCitiesGuard.test.ts`, MYS-681).
@@ -103,6 +112,36 @@ class _PreferencesFieldVisitor(ast.NodeVisitor):
                 self.fields.add(key.value)
         self.generic_visit(node)
 
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        # `preferences["field"] += x` READS the prior value before writing
+        # the new one -- but its target Subscript carries ast.Store, the
+        # same ctx as a plain `preferences["field"] = x` write, so
+        # visit_Subscript's Load gate (correctly) excludes it. That gate
+        # would make this a false-GREEN: a real read shipping uninventoried
+        # (Eng Lead fix-list, MYS-439 r2, Codex-caught).
+        #
+        # This is the ONLY non-Load context that reads. A Subscript carries
+        # exactly three contexts (Load/Store/Del); of every syntactic
+        # position that yields a non-Load one -- Assign, AnnAssign,
+        # AugAssign, For/AsyncFor, With, comprehension, tuple/starred
+        # unpack, Delete -- only AugAssign evaluates the prior value before
+        # writing. So read-set = Load ∪ (Store under AugAssign), and that
+        # set is closed: deliberately NOT widened to `.pop()`/`.setdefault()`
+        # (Eng Lead, MYS-439 r2) -- those also read, but they sit outside
+        # this guard's documented offense definition (a literal-key read via
+        # `preferences["x"]`/`preferences.get("x")`), so they're disclosed
+        # scope rather than a false claim the docstring makes and breaks.
+        target = node.target
+        if (
+            isinstance(target, ast.Subscript)
+            and isinstance(target.value, ast.Name)
+            and target.value.id == "preferences"
+        ):
+            key = target.slice
+            if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                self.fields.add(key.value)
+        self.generic_visit(node)
+
     def visit_Call(self, node: ast.Call) -> None:
         func = node.func
         if (
@@ -148,13 +187,26 @@ def test_detector_self_check_catches_every_offense_shape_and_ignores_safe_shapes
         "    b = preferences.get('preferred_pace')\n"
         "    return a, b\n"
     ) == {"budget", "preferred_pace"}
+    # AugAssign READS the prior value before writing -- its target Subscript
+    # carries ast.Store, same as a plain write, so this is the one
+    # non-Load context that must still count (Eng Lead fix-list, MYS-439 r2).
+    assert find_named_preference_reads(
+        "def f(preferences):\n    preferences['budget'] += 1\n    return preferences\n"
+    ) == {"budget"}
 
     safe_sources = [
-        # a STORE (assignment) or DEL context is the service writing/removing
-        # its own key, not reading a field the FE sent -- must not be
-        # collected as an offense (Eng Lead fix-list, MYS-439, Codex P2)
+        # a plain STORE (assignment) or DEL context is the service writing/
+        # removing its own key, not reading a field the FE sent -- must not
+        # be collected as an offense (Eng Lead fix-list, MYS-439, Codex P2).
+        # AugAssign is the one Store-context exception (it reads first) --
+        # covered as its own offense assertion above, not here.
         "def f(preferences):\n    preferences['derived'] = 1\n    return preferences\n",
         "def f(preferences):\n    del preferences['derived']\n    return preferences\n",
+        # .pop()/.setdefault() also read, but sit outside this guard's
+        # documented offense definition (subscript-Load / .get() only) --
+        # disclosed scope, deliberately not widened (Eng Lead, MYS-439 r2).
+        "def f(preferences):\n    return preferences.pop('budget', None)\n",
+        "def f(preferences):\n    return preferences.setdefault('budget', 'moderate')\n",
         # the exact opaque-passthrough shapes already shipped in this repo
         "import json\ndef f(preferences):\n    return json.dumps(preferences)\n",
         "def f(preferences):\n    return dict(preferences)\n",


### PR DESCRIPTION
## What
Adds `tests/unit/test_dead_field_inventory.py`: an AST scanner over the prompt-assembly surface (`agents/*.py`, `core/prompts.py`) that collects every literal field name read off a variable/parameter named `preferences` via `preferences["field"]` or `preferences.get("field")`, and fails CI if that name isn't documented in the paired inventory file `docs/ui_collected_preference_fields.json` (which names the FE surface that collects it) — or if the inventory documents a field the scanner no longer finds anywhere (stale-entry drift, checked in both directions).

## Why
MYS-436 deleted `reader_profile_agent`, the only prompt that ever read a named preference field (`budget`, `preferred_pace`, etc.), so there's no live violation today — every remaining prompt builder (`core/prompts.py::build_composition_prompt`, `agents/prompts.py::preferences_block`) treats `preferences` as an opaque dict, passed through whole via `json.dumps(preferences)`. That doesn't make the guard pointless: per the ticket's own PM ruling, this is a class-level recurrence guard ("second occurrence = write the gate"), not a re-proof of an already-fixed instance — its job is catching the *next* prompt wired to a field the UI never collects, which is the actual failure mode MYS-392 hit (the mood-chip's `preferences.moods`, read by nothing).

## How
- `find_named_preference_reads()` walks each scanned file's AST looking for `ast.Subscript`/`ast.Call` nodes whose receiver `Name` is literally `preferences`, collecting string-literal keys. Deliberately AST- not regex-based (this is Python, `ast` is stdlib and immune to the false-positive/line-break issues a regex scanner has to work around).
- Scope is intentionally narrow and documented as such in the module docstring: bound to the literal receiver name `preferences`, over `agents/` + `core/prompts.py` only — no alias/destructuring tracking, no attribute-style access (the unused `TravelPreferences` model). Verified by hand today that no such alias exists in the scanned surface. Mirrors the same narrow-the-claim move made on the fe sibling guard (`storyland-web/tests/regionCitiesGuard.test.ts`, MYS-681, built earlier in this run) rather than over-promising "every read."
- `docs/ui_collected_preference_fields.json`: `fields` map (empty today) + a `_readme` explaining why it's empty and how to add an entry. QA's weekly dead-control sweep can diff against the same file.
- Self-check test pins every offense shape (subscript, `.get()`, `.get()` with a default, multiple reads) and every safe shape already shipped in this repo (`json.dumps(preferences)`, `dict(preferences)`, `.items()`, a differently-named receiver) so the detector itself is covered, not just the production-tree scan.
- **r2 (Eng Lead fix-list, 2 valid Codex P2s):** `visit_Subscript()` didn't check `node.ctx`, so `preferences["derived"] = value` (Store) and `del preferences["derived"]` (Del) were both counted as reads — the service writing/removing its own key, not a field the FE must have collected. Gated on `isinstance(node.ctx, ast.Load)`; added store-context + `del` self-check cases. Separately, `test_inventory_file_is_valid_json_with_a_fields_map()` only checked `fields` was a dict — `{"budget": null}` or `{"budget": ""}` passed while the `_readme` and failure message both promise each entry names the FE surface that collects it; now asserts every value is a non-empty string.

## Docs
`docs/ui_collected_preference_fields.json` *is* the doc for this guard (own `_readme` explains scope, rationale, and how to extend it). No `ARCHITECTURE.md` entry: this is a test-only addition with no architecture, contract, endpoint, env, or route change.

## Verification
- `python3 -m pytest tests/unit/test_dead_field_inventory.py -v` — 3/3 pass.
- Full suite: `python3 -m pytest tests/unit/ --cov --cov-report=term-missing` — 958 passed, 7 pre-existing failures (all `ExceptionGroup`-dependent, `test_discovery_errors.py`/`test_run_harness.py`, Python-3.11-only builtin, confirmed identical on `main` with these two new files absent — untouched by this PR). Coverage 89.90% (floor 74%). `ruff check` clean on the touched file.
- To verify the guard actually catches something: temporarily add `preferences.get("budget")` anywhere in `agents/` or `core/prompts.py` and re-run — the inventory test goes red naming the undocumented field; add a `fields` entry and it goes green again.
- To verify the r2 write/del fix: temporarily remove the `ast.Load` gate and add `preferences["derived"] = 1` anywhere in the scanned surface — pre-fix, the self-check's new store-context case fails (falsely collected as a read); post-fix it passes.
- Environment note: this sandbox's `requirements-dev.lock` pins `rpds-py==2026.6.3`, which requires Python ≥3.11 and has no py3.10 wheel/sdist; the sandbox only has 3.10. Installed the full dep set via `pip install --no-deps -r ` + a compatible standalone `rpds-py==0.30.0`, confirmed `google.genai` imports and the full suite collects/runs correctly afterward — a one-time environment workaround, not a project change (lockfile untouched, not part of this diff).