### PR TITLE
feat: GET /api/v1/version reports the deployed commit SHA (MYS-687)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -5,6 +5,8 @@ Maps HTTP endpoints to streaming generators and status queries.
 All business logic lives in core.executor — routes are thin wiring.
 """
 
+import os
+
 from fastapi import APIRouter, Depends, HTTPException
 from sse_starlette.sse import EventSourceResponse
 
@@ -79,6 +81,14 @@ async def health_check() -> HealthResponse:
         )
     except RuntimeError:
         return HealthResponse(status="unhealthy", version="0.1.0")
+
+
+@system_router.get("/version")
+async def version() -> dict:
+    """Deployed commit SHA — reuses SENTRY_RELEASE (already stamped by
+    deploy.sh at deploy time; same value the Sentry SDK tags releases with),
+    so "what's live" is one request instead of an SSH session."""
+    return {"service": "storyland-ai", "git_sha": os.environ.get("SENTRY_RELEASE") or "unknown"}
 
 
 @router.post(

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -653,6 +653,22 @@ class TestHealthEndpoint:
         assert data["model_name"] == "gemini-2.0-flash-lite"
 
 
+class TestVersionEndpoint:
+    @pytest.mark.asyncio
+    async def test_version_reports_sentry_release_env_var(self, test_client, monkeypatch):
+        monkeypatch.setenv("SENTRY_RELEASE", "abc1234")
+        response = await test_client.get("/api/v1/version")
+        assert response.status_code == 200
+        assert response.json() == {"service": "storyland-ai", "git_sha": "abc1234"}
+
+    @pytest.mark.asyncio
+    async def test_version_falls_back_to_unknown_when_unset(self, test_client, monkeypatch):
+        monkeypatch.delenv("SENTRY_RELEASE", raising=False)
+        response = await test_client.get("/api/v1/version")
+        assert response.status_code == 200
+        assert response.json() == {"service": "storyland-ai", "git_sha": "unknown"}
+
+
 class TestStatusEndpoint:
     """Tests for GET /api/v1/itinerary/{job_id}/status (derived status)."""
 


### PR DESCRIPTION
## Why
Confirming "is the latest release actually on prod" currently means SSH + `docker inspect` + timestamp cross-referencing. Olga asked directly for a one-request way to check (MYS-687).

## What
New `GET /api/v1/version` reusing the existing `SENTRY_RELEASE` env var (already stamped by `deploy.sh` at deploy time for the Sentry SDK) — a second consumer of the same value, no new env var.

## Docs
No `ARCHITECTURE.md` impact — additive endpoint, mirrors the existing `/health` shape, no new architecture/contract/route pattern.

## Verification
`TestVersionEndpoint` in `tests/unit/test_api.py` — configured-SHA case and empty-fallback case. Full suite: 966/966 passing (964 pre-existing + 2 new).