### PR TITLE
ci: port the sticky CI-summary comment from fe (MYS-705)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -25,6 +25,7 @@ workflow files** plus GitHub-managed **Dependabot Updates**.
 | **Re-record VCR Cassettes** | `re-record-cassettes.yml` | dispatch | Manual utility to regenerate VCR cassettes (MYS-440 re-record split). No automatic trigger; run when live responses change. | **Keep** (manual tool) |
 | **Sync rotated env keys to box** | `sync-env-keys.yml` | dispatch | Manual utility to push rotated env keys to the prod box (MYS-440 key rotation). | **Keep** (manual tool) |
 | **Dependabot Updates** | *(GitHub-managed, `.github/dependabot.yml`)* | Dependabot schedule | Automated dependency-update PRs. Not a YAML in `.github/workflows/`. | **Keep** |
+| **CI summary comment** | `ci-summary.yml` | `workflow_run` completed on this repo's PR-reporting workflows + dispatch | Upserts ONE sticky comment per PR summarising every workflow's conclusion for the PR's current head SHA. Exists because agents cannot read CI at all — the Checks API 403s (no `checks` scope on the connector app, and our own PAT 403s too) and the Actions API is refused by the agent sandbox's outbound proxy (MYS-672). Runs inside Actions, so it has the access agents lack, and writes into a channel they can read. **Informational — never add to the required-checks list; it reports CI, it does not gate it.** Takes the newest run per workflow name (a re-run leaves stale failures on the same SHA) and reports "no runs" as explicitly NOT green. | **Keep** |
 
 ## Health notes (2026-07-25)
 - `main` **green**; security lane (Gitleaks, pip-audit, Dependabot) all passing.

--- a/.github/workflows/ci-summary.yml
+++ b/.github/workflows/ci-summary.yml
@@ -1,0 +1,147 @@
+name: CI summary comment
+
+# WHY THIS EXISTS (MYS-672)
+#
+# The agent fleet cannot read CI. Two independent walls:
+#   1. The Checks API 403s for the GitHub MCP connector app AND for our own
+#      fine-grained PAT — /commits/<sha>/check-runs is simply out of reach.
+#   2. The Actions API would answer, but the agent sandbox's outbound proxy
+#      refuses api.github.com ("403 from proxy after CONNECT"); --noproxy
+#      does not help. Verified by the Engineering Lead 2026-07-28.
+#
+# So we stop making agents PULL and let CI PUSH. This job runs inside Actions
+# — full API access, no proxy — and writes the result into a PR comment, a
+# channel the fleet already reads through the MCP (pull_request_read
+# get_comments is NOT blocked). Fresh by construction: it updates whenever a
+# run finishes, so there is no staleness window and no snapshot to reconcile.
+#
+# INFORMATIONAL ONLY. Never add this to the required-checks list: it reports
+# CI, it does not gate it. Branch protection already blocks a red merge.
+
+on:
+  workflow_run:
+    # Every workflow that reports on a PR here. Add new ones to this list —
+    # a missing name means its result silently never reaches the summary.
+    workflows:
+      - "Unit Tests"
+      - "Integration Tests"
+      - "Gitleaks"
+      - "pip-audit"
+      - "PR body sections"
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to summarise (manual verification)"
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  pull-requests: write
+
+jobs:
+  summarise:
+    name: Post CI summary to the PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const MARKER = '<!-- ci-summary:do-not-remove -->';
+            const GREEN = new Set(['success', 'skipped']);
+
+            // --- Resolve (pr, head_sha) from either trigger -------------------
+            let prNumber, headSha;
+            if (context.eventName === 'workflow_dispatch') {
+              prNumber = Number(context.payload.inputs.pr);
+              const { data: pr } = await github.rest.pulls.get({
+                ...context.repo, pull_number: prNumber,
+              });
+              headSha = pr.head.sha;
+            } else {
+              const run = context.payload.workflow_run;
+              headSha = run.head_sha;
+              // workflow_run.pull_requests is populated for same-repo PRs, but
+              // is empty for forks and occasionally lags. Fall back to a search
+              // by head SHA rather than silently skipping the comment.
+              prNumber = run.pull_requests?.[0]?.number;
+              if (!prNumber) {
+                const { data: prs } = await github.rest.pulls.list({
+                  ...context.repo, state: 'open', per_page: 100,
+                });
+                prNumber = prs.find((p) => p.head.sha === headSha)?.number;
+              }
+              if (!prNumber) {
+                core.info(`No open PR for ${headSha} — nothing to comment on.`);
+                return;
+              }
+            }
+
+            // --- Newest run per workflow NAME --------------------------------
+            // Load-bearing, not tidiness: a re-run — or an edited PR body
+            // re-firing the body-sections guard — leaves the OLD failure and
+            // the NEW success both attached to the same SHA. Reporting the
+            // first match shows a red that no longer exists, and one phantom
+            // red is all it takes for a reader to stop trusting this comment.
+            const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
+              ...context.repo, head_sha: headSha, per_page: 100,
+            });
+            const latest = new Map();
+            for (const r of [...runs.workflow_runs].sort(
+              (a, b) => new Date(a.created_at) - new Date(b.created_at)
+            )) {
+              if (r.name === context.workflow) continue; // never report on ourselves
+              latest.set(r.name, r);
+            }
+
+            // --- Build the comment -------------------------------------------
+            const rows = [...latest.entries()].sort(([a], [b]) => a.localeCompare(b));
+            const bad = rows.filter(([, r]) => !GREEN.has(r.conclusion));
+            const pending = rows.filter(([, r]) => r.conclusion === null);
+
+            let verdict;
+            if (rows.length === 0) verdict = '**NO RUNS** — CI has not reported for this commit. This is NOT green.';
+            else if (pending.length) verdict = `⏳ **${pending.length} still running** — not green yet.`;
+            else if (bad.length) verdict = `🔴 **RED** — ${bad.length} of ${rows.length} failing.`;
+            else verdict = `🟢 **GREEN** — ${rows.length}/${rows.length} passing.`;
+
+            const table = rows.length
+              ? ['| result | workflow | run |', '| -- | -- | -- |',
+                 ...rows.map(([name, r]) => {
+                   const c = r.conclusion ?? 'running';
+                   const icon = GREEN.has(c) ? '✅' : c === 'running' ? '⏳' : '❌';
+                   return `| ${icon} ${c} | ${name} | [log](${r.html_url}) |`;
+                 })].join('\n')
+              : '_No workflow runs recorded for this commit._';
+
+            const body = [
+              MARKER,
+              `### CI on \`${headSha.slice(0, 8)}\``,
+              '',
+              verdict,
+              '',
+              table,
+              '',
+              `<sub>Posted by CI because the fleet cannot read check status directly ` +
+              `([MYS-672](https://linear.app/mystoryland/issue/MYS-672)). **This comment is only true for ` +
+              `\`${headSha.slice(0, 8)}\`** — if that is not the PR's current head, a newer commit has ` +
+              `landed and this is stale. Informational; branch protection is what actually gates the merge.</sub>`,
+            ].join('\n');
+
+            // --- Upsert one sticky comment, never a thread of them ------------
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo, issue_number: prNumber, per_page: 100,
+            });
+            const existing = comments.find((c) => c.body?.includes(MARKER));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo, comment_id: existing.id, body,
+              });
+              core.info(`Updated CI summary on #${prNumber} (${headSha.slice(0, 8)}).`);
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: prNumber, body,
+              });
+              core.info(`Created CI summary on #${prNumber} (${headSha.slice(0, 8)}).`);
+            }


### PR DESCRIPTION
## What

Ports the proven `.github/workflows/ci-summary.yml` from `storyland-web@main` into this repo, plus its row in the workflow catalog. One sticky comment per PR, updated in place, summarising every workflow's conclusion for the PR's current head SHA.

## Why

Agents cannot read CI in this repo at all. Two independent walls (MYS-672): the Checks API `403`s — the GitHub MCP connector app has no `checks` scope, and our own fine-grained PAT `403`s on `/commits/<sha>/check-runs` too — and the Actions API, which *would* answer, is refused by the agent sandbox's outbound proxy (`403 from proxy after CONNECT`; `--noproxy` does not help).

The only fallback today is the runner's `state/ci-status.json` snapshot. It works, but it is a *snapshot*: every read costs a mandatory staleness check against the live head, and it is stale the moment anyone pushes. That cost showed up concretely on 2026-07-29 — establishing that be#125 (Urgent) was red took a SHA comparison against a six-hour-old file, and only worked because nobody had pushed in between.

`fe#301` fixed this for `storyland-web` by letting CI **push** instead of making agents **pull**. It is proven: fe#302 and fe#303, both opened after that merge with no manual dispatch, carry sticky comments whose stated SHA matches their live head. This is the same file, ported.

## How

Copied verbatim from `storyland-web@main`. **The only edit is the `workflows:` list**, grounded against this repo's actual workflows rather than fe's.

**Enumerated for this repo** (empirically, from `GET /actions/runs?event=pull_request` — which workflows *have* reported on a PR, not which ones an `on:` block suggests might):

- **Listed:** `Unit Tests`, `Integration Tests`, `Gitleaks`, `pip-audit`, `PR body sections`
- **Excluded:** `CI/CD Pipeline`, `Deploy AI (prod)`, `Sync rotated env keys to box` (deploy/ops), `Integration Tests (Live API)`, `Evaluation (manual dispatch)`, `Re-record VCR Cassettes` (manual dispatch), `Claude Code`, `Dependabot Updates`.

⚠️ **Watch the four characters.** `Integration Tests` and `Integration Tests (Live API)` differ only by the suffix, and `workflow_run.workflows` matches on exact name. Listing the wrong one would silently watch a workflow that never runs on PRs — and the Live-API one **spends**, so it must never be implied to be a PR gate. The listed five cross-check against the "CI 5/5 green" this repo's PRs have been reporting.

- Resolves the PR from `workflow_run.pull_requests`, falling back to a search by head SHA (that field is empty for forks and occasionally lags).
- Keeps **the newest run per workflow name**. Load-bearing, not tidiness: a re-run — or an edited PR body re-firing the body-sections guard — leaves the old failure *and* the new success on the same SHA, and reporting the first match shows a red that no longer exists. One phantom red and the comment stops being trusted.
- Upserts a single comment keyed on an HTML marker, so repeats never thread.
- Distinguishes green / red / still-running / **no runs at all** — the last reported explicitly as *not* green, since an empty run list means CI has not reported and collapsing that into green is the inference that lets an unverified commit through.
- Skips itself when building the table.
- `permissions: {actions: read, pull-requests: write}`. Informational: it gates nothing and must never join the required-checks list.

## Docs

`.github/workflows/README.md` — new catalog row for `ci-summary.yml` in the same PR (docs-track-code, engineering-standards §6), stating what it is, why it exists, and that it must never become a required check.

## Verification

- Every workflow name in the `workflows:` list was cross-checked verbatim against `gh api .../actions/workflows` for **this** repo — all exist, exact match.
- The inline `github-script` body was extracted and syntax-checked with `node --check` inside the same async wrapper `actions/github-script` uses.
- Diffed against `storyland-web@main`'s proven copy: **the only differing lines are the `workflows:` list**.
- **Not executed yet, and the PR being green does not prove it works.** `workflow_run` always runs the workflow definition from the default branch, so this cannot run against its own PR. Acceptance test is post-merge: `workflow_dispatch` it against any open PR in this repo (or wait for the next one) and confirm the comment matches the Checks tab.

Reviewer should focus on: whether the `workflows:` list is complete for this repo. **A missing name is silently absent from the summary**, which then renders a confident green table that is green because it never looked — the MYS-492 class, and worse here than no comment at all, since the whole point of the instrument is to be trusted without a second source.
