### PR TITLE
PR2: ai — books-set-in corpus generator, one-city mode (MYS-431)

### DIFF
--- a/tests/unit/fixtures/barcelona_backend_response.json
+++ b/tests/unit/fixtures/barcelona_backend_response.json
@@ -1,0 +1,144 @@
+{
+  "place": "Barcelona",
+  "query": "barcelona",
+  "found": true,
+  "message": null,
+  "books": [
+    {
+      "title": "The Shadow of the Wind",
+      "author": "Carlos Ruiz Zafon",
+      "description": "Barcelona, 1945: a city slowly heals in the aftermath of the Spanish Civil War, and Daniel finds solace in a mysterious book by Julian Carax.",
+      "image_url": "https://books.google.com/books/content?id=aLNPEAAAQBAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
+      "published_date": "2004-04-12",
+      "why_it_fits": "It is arguably the definitive Barcelona novel, capturing the city’s gothic, rainy, and mysterious soul.",
+      "match_type": "literal",
+      "maps_to": "The Gothic Quarter",
+      "grounding": {
+        "google_books_id": "aLNPEAAAQBAJ",
+        "source": "google_books",
+        "verified": true,
+        "catalog_id": "aLNPEAAAQBAJ",
+        "catalog_source": "google_books"
+      }
+    },
+    {
+      "title": "Cathedral of the Sea",
+      "author": "Ildefonso Falcones",
+      "description": "A young serf's rise amid the building of a cathedral in 14th-century Barcelona.",
+      "image_url": "https://books.google.com/books/content?id=60LxPgAACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
+      "published_date": "2009",
+      "why_it_fits": "Walking into the actual Santa Maria del Mar basilica after reading this provides a profound, tangible link to the city's medieval origins.",
+      "match_type": "literal",
+      "maps_to": "La Ribera neighborhood",
+      "grounding": {
+        "google_books_id": "60LxPgAACAAJ",
+        "source": "google_books",
+        "verified": true,
+        "catalog_id": "60LxPgAACAAJ",
+        "catalog_source": "google_books"
+      }
+    },
+    {
+      "title": "In Diamond Square",
+      "author": "Merce Rodoreda",
+      "description": "A shop-girl's life in Gracia through the Spanish Civil War.",
+      "image_url": "https://books.google.com/books/content?id=46tFLwEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
+      "published_date": "2013",
+      "why_it_fits": "It provides a deeply moving and authentic look at how the city’s turbulent 20th-century history affected ordinary citizens.",
+      "match_type": "literal",
+      "maps_to": "Gràcia neighborhood",
+      "grounding": {
+        "google_books_id": "46tFLwEACAAJ",
+        "source": "google_books",
+        "verified": true,
+        "catalog_id": "46tFLwEACAAJ",
+        "catalog_source": "google_books"
+      }
+    },
+    {
+      "title": "Homage to Catalonia",
+      "author": "George Orwell",
+      "description": "Orwell's personal account of fighting for the Republican army during the Spanish Civil War.",
+      "image_url": "https://books.google.com/books/content?id=KgKVzQEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
+      "published_date": "2020-06-06",
+      "why_it_fits": "It offers an essential, raw historical perspective on the political passions that have shaped modern Barcelona.",
+      "match_type": "literal",
+      "maps_to": "Barcelona",
+      "grounding": {
+        "google_books_id": "KgKVzQEACAAJ",
+        "source": "google_books",
+        "verified": true,
+        "catalog_id": "KgKVzQEACAAJ",
+        "catalog_source": "google_books"
+      }
+    },
+    {
+      "title": "The Angst-ridden Executive",
+      "author": "Manuel Vazquez Montalban",
+      "description": "Private investigator Pepe Carvalho investigates a murder in post-Franco Barcelona.",
+      "image_url": "https://books.google.com/books/content?id=fcNvDwAAQBAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
+      "published_date": "2012",
+      "why_it_fits": "It serves as a gritty, \"insider\" tour of the city’s neighborhoods and culinary culture during the post-Franco era.",
+      "match_type": "literal",
+      "maps_to": "Plaça Reial",
+      "grounding": {
+        "google_books_id": "fcNvDwAAQBAJ",
+        "source": "google_books",
+        "verified": true,
+        "catalog_id": "fcNvDwAAQBAJ",
+        "catalog_source": "google_books"
+      }
+    },
+    {
+      "title": "Iberia",
+      "author": "James A. Michener",
+      "description": "Michener's nonfiction tribute to Spain.",
+      "image_url": "https://books.google.com/books/content?id=pzKJDAAAQBAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
+      "published_date": "2015-03-10",
+      "why_it_fits": "It prepares you for the broader cultural and historical context of Spain, helping you appreciate Barcelona’s unique position within the nation.",
+      "match_type": "vibe",
+      "maps_to": null,
+      "grounding": {
+        "google_books_id": "pzKJDAAAQBAJ",
+        "source": "google_books",
+        "verified": true,
+        "catalog_id": "pzKJDAAAQBAJ",
+        "catalog_source": "google_books"
+      }
+    },
+    {
+      "title": "The Battle for Spain",
+      "author": "Antony Beevor",
+      "description": "A comprehensive account of the Spanish Civil War.",
+      "image_url": "https://books.google.com/books/content?id=Q-mayoYS6eIC&printsec=frontcover&img=1&zoom=1&source=gbs_api",
+      "published_date": "2006-06-01",
+      "why_it_fits": "Understanding the gravity of this period will give you a much richer and more respectful appreciation for the city's monuments and memorials.",
+      "match_type": "vibe",
+      "maps_to": null,
+      "grounding": {
+        "google_books_id": "Q-mayoYS6eIC",
+        "source": "google_books",
+        "verified": true,
+        "catalog_id": "Q-mayoYS6eIC",
+        "catalog_source": "google_books"
+      }
+    },
+    {
+      "title": "Barcelona",
+      "author": "Robert Hughes",
+      "description": "A history, art, and architecture tour of Barcelona.",
+      "image_url": "https://books.google.com/books/content?id=6chpUGofrdcC&printsec=frontcover&img=1&zoom=1&source=gbs_api",
+      "published_date": "2011-06-15",
+      "why_it_fits": "It is arguably the most \"flavorful\" introduction to the soul of the city, perfectly blending historical depth with a keen eye for its architectural peculiarities.",
+      "match_type": "vibe",
+      "maps_to": null,
+      "grounding": {
+        "google_books_id": "6chpUGofrdcC",
+        "source": "google_books",
+        "verified": true,
+        "catalog_id": "6chpUGofrdcC",
+        "catalog_source": "google_books"
+      }
+    }
+  ]
+}

--- a/tests/unit/test_generate_books_set_in_corpus.py
+++ b/tests/unit/test_generate_books_set_in_corpus.py
@@ -1,0 +1,171 @@
+import json
+import os
+
+import httpx
+import pytest
+
+from generate_books_set_in_corpus import (
+    GeneratorError,
+    build_page,
+    fetch_place_to_book,
+    place_slug,
+    validate_book,
+    validate_place,
+)
+
+FIXTURE_PATH = os.path.join(os.path.dirname(__file__), "fixtures", "barcelona_backend_response.json")
+
+
+def load_fixture():
+    with open(FIXTURE_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+# -- place_slug: must stay in lockstep with the FE's placeSlug() --
+
+def test_place_slug_basic():
+    assert place_slug("Edinburgh") == "edinburgh"
+    assert place_slug("New York City") == "new-york-city"
+    assert place_slug("Saint Petersburg") == "saint-petersburg"
+
+
+def test_place_slug_strips_accents_and_punctuation():
+    assert place_slug("São Paulo") == "sao-paulo"
+    assert place_slug("  Multiple   Spaces ") == "multiple-spaces"
+    assert place_slug("") == ""
+
+
+# -- validate_book / validate_place: mirrors booksSetInPlace.ts, must be build-fatal --
+
+def test_validate_book_rejects_missing_required_fields():
+    with pytest.raises(GeneratorError, match="title"):
+        validate_book({"author": "A", "why": "w", "cover": "c", "matchType": "vibe"}, "where")
+
+
+def test_validate_book_rejects_literal_without_mapsto():
+    with pytest.raises(GeneratorError, match="mapsTo"):
+        validate_book(
+            {"title": "T", "author": "A", "why": "w", "cover": "c", "matchType": "literal"},
+            "where",
+        )
+
+
+def test_validate_book_allows_vibe_without_mapsto():
+    book = validate_book(
+        {"title": "T", "author": "A", "why": "w", "cover": "c", "matchType": "vibe"},
+        "where",
+    )
+    assert book["matchType"] == "vibe"
+
+
+def test_validate_place_rejects_slug_place_mismatch():
+    with pytest.raises(GeneratorError, match="does not match its place"):
+        validate_place(
+            {
+                "slug": "paris",
+                "place": "London",
+                "intro": "intro",
+                "books": [{"title": "T", "author": "A", "why": "w", "cover": "c", "matchType": "vibe"}],
+            }
+        )
+
+
+def test_validate_place_rejects_empty_books():
+    with pytest.raises(GeneratorError, match="books"):
+        validate_place({"slug": "paris", "place": "Paris", "intro": "intro", "books": []})
+
+
+# -- build_page: the real mapping/filtering logic, against real captured data --
+
+def test_build_page_on_real_barcelona_fixture_keeps_all_eight_verified_rows():
+    resp = load_fixture()
+    report = build_page("Barcelona", resp)
+    assert report.verified_book_count == 8
+    assert report.dropped_unverified_count == 0
+    assert report.page["slug"] == "barcelona"
+    assert report.page["place"] == "Barcelona"
+    # 5 literal + 3 vibe, matching the live response
+    literal = [b for b in report.page["books"] if b["matchType"] == "literal"]
+    vibe = [b for b in report.page["books"] if b["matchType"] == "vibe"]
+    assert len(literal) == 5
+    assert len(vibe) == 3
+    # Every literal row carries a mapsTo; no vibe row does (mirrors the fixture).
+    assert all(b.get("mapsTo") for b in literal)
+    assert all(not b.get("mapsTo") for b in vibe)
+    # image_url passed through verbatim from the backend response.
+    assert report.page["books"][0]["image_url"] == resp["books"][0]["image_url"]
+    # The output must itself pass the FE-mirroring validator (red-before-green
+    # for this exact assertion: a bad build_page() would raise here already,
+    # since build_page calls validate_place internally -- this call re-checks
+    # the returned page independently in case that internal call is ever
+    # removed by a future edit).
+    validate_place(report.page)
+
+
+def test_build_page_drops_unverified_rows_never_pads():
+    resp = load_fixture()
+    # Flip one row to unverified -- it must be dropped, not kept or replaced.
+    resp = json.loads(json.dumps(resp))  # deep copy
+    resp["books"][-1]["grounding"]["verified"] = False
+    report = build_page("Barcelona", resp)
+    assert report.verified_book_count == 7
+    assert report.dropped_unverified_count == 1
+    kept_titles = {b["title"] for b in report.page["books"]}
+    assert resp["books"][-1]["title"] not in kept_titles
+
+
+def test_build_page_refuses_a_city_with_zero_verified_rows():
+    resp = load_fixture()
+    resp = json.loads(json.dumps(resp))
+    for b in resp["books"]:
+        b["grounding"]["verified"] = False
+    with pytest.raises(GeneratorError, match="0 of"):
+        build_page("Barcelona", resp)
+
+
+def test_fetch_place_to_book_raises_on_found_false():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"place": "Nowhereville", "query": "nowhereville", "found": False, "message": "no candidates", "books": []})
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport) as client, pytest.raises(GeneratorError, match="not groundable"):
+        fetch_place_to_book("Nowhereville", "https://example.invalid", client)
+
+
+def test_fetch_place_to_book_calls_the_expected_path_and_query():
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["query"] = dict(request.url.params)
+        return httpx.Response(200, json=load_fixture())
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport) as client:
+        body = fetch_place_to_book("Barcelona", "https://example.invalid", client)
+
+    assert seen["path"] == "/api/v1/place-to-book"
+    assert seen["query"] == {"place": "Barcelona"}
+    assert body["found"] is True
+
+
+# -- CLI: --batch must refuse without ever touching the network --
+
+def test_main_batch_flag_refuses_without_network_call(monkeypatch, capsys):
+    from generate_books_set_in_corpus import main
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("network must not be touched when --batch is passed")
+
+    monkeypatch.setattr(httpx, "Client", fail_if_called)
+    exit_code = main(["--batch", "cities.txt"])
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "not implemented in this PR" in captured.err
+
+
+def test_main_requires_city_or_batch():
+    from generate_books_set_in_corpus import main
+
+    with pytest.raises(SystemExit):
+        main([])

--- a/tests/unit/test_generate_books_set_in_corpus.py
+++ b/tests/unit/test_generate_books_set_in_corpus.py
@@ -4,7 +4,7 @@ import os
 import httpx
 import pytest
 
-from generate_books_set_in_corpus import (
+from tools.generate_books_set_in_corpus import (
     GeneratorError,
     build_page,
     fetch_place_to_book,
@@ -152,7 +152,7 @@ def test_fetch_place_to_book_calls_the_expected_path_and_query():
 # -- CLI: --batch must refuse without ever touching the network --
 
 def test_main_batch_flag_refuses_without_network_call(monkeypatch, capsys):
-    from generate_books_set_in_corpus import main
+    from tools.generate_books_set_in_corpus import main
 
     def fail_if_called(*args, **kwargs):
         raise AssertionError("network must not be touched when --batch is passed")
@@ -165,7 +165,7 @@ def test_main_batch_flag_refuses_without_network_call(monkeypatch, capsys):
 
 
 def test_main_requires_city_or_batch():
-    from generate_books_set_in_corpus import main
+    from tools.generate_books_set_in_corpus import main
 
     with pytest.raises(SystemExit):
         main([])

--- a/tests/unit/test_generate_books_set_in_corpus.py
+++ b/tests/unit/test_generate_books_set_in_corpus.py
@@ -169,3 +169,113 @@ def test_main_requires_city_or_batch():
 
     with pytest.raises(SystemExit):
         main([])
+
+
+# ---------------------------------------------------------------------------
+# r2 (fix-list round 1, Engineering Lead)
+# ---------------------------------------------------------------------------
+
+
+def _mixed_response(literal: int, vibe: int) -> dict:
+    """A minimal PlaceToBook-shaped body with a chosen literal/vibe split.
+
+    Built from the real fixture's row shape rather than invented, so a change to
+    the BE contract breaks these tests too instead of letting them drift.
+    """
+    template = load_fixture()["books"][0]
+    books = []
+    for i in range(literal):
+        row = dict(template, title=f"Literal {i}", match_type="literal", maps_to=f"Anchor {i}")
+        books.append(row)
+    for i in range(vibe):
+        row = dict(template, title=f"Kindred {i}", match_type="vibe")
+        row["maps_to"] = None  # exactly what the BE sends for a kindred row
+        books.append(row)
+    return {"place": "Testville", "query": "Testville", "found": True, "message": None, "books": books}
+
+
+# -- item 1: the intro must not claim an anchor the kindred rows do not have --
+
+
+def test_mixed_page_scopes_the_stand_claim_to_the_literal_entries():
+    # The reported defect: 3 of Barcelona's 8 verified rows are vibe with
+    # maps_to=None, and the intro told every reader "each one points to
+    # somewhere you can actually stand".
+    report = build_page("Barcelona", load_fixture())
+    intro = report.page["intro"]
+
+    assert "the literal entries point to somewhere you can actually stand." in intro
+    assert "each one points to" not in intro, (
+        "an unscoped claim is false for every kindred row on a mixed page: "
+        f"{intro}"
+    )
+
+
+def test_all_literal_page_keeps_the_unscoped_claim_because_it_is_true_there():
+    report = build_page("Testville", _mixed_response(literal=4, vibe=0))
+    intro = report.page["intro"]
+
+    assert "so each one points to somewhere you can actually stand." in intro
+    assert "the literal entries" not in intro
+
+
+def test_the_scoped_claim_never_overstates_a_row_that_carries_no_map_anchor():
+    # Ties the sentence to the DATA rather than to a string: every row the
+    # intro claims is standable must actually carry a mapsTo.
+    report = build_page("Testville", _mixed_response(literal=2, vibe=3))
+    books = report.page["books"]
+    anchored = [b for b in books if b.get("mapsTo")]
+    unanchored = [b for b in books if not b.get("mapsTo")]
+
+    assert len(unanchored) == 3, "fixture guard: this page must contain unanchored rows"
+    assert all(b["matchType"] == "literal" for b in anchored)
+    assert all(b["matchType"] == "vibe" for b in unanchored)
+    # ...and because unanchored rows exist, the claim is scoped.
+    assert "the literal entries point to" in report.page["intro"]
+
+
+# -- item 2: the tool's success bar must equal the corpus's publish bar --
+
+
+def test_all_vibe_city_is_refused_because_the_fe_could_never_publish_it():
+    # Previously: printed "6 verified book(s) kept", exited 0, produced a page
+    # storyland-web's isPublishableBooksSetInPlace (MYS-455) will never publish.
+    with pytest.raises(GeneratorError) as exc:
+        build_page("Testville", _mixed_response(literal=0, vibe=6))
+
+    message = str(exc.value)
+    assert "0 are matchType 'literal'" in message
+    assert "isPublishableBooksSetInPlace" in message
+
+
+def test_a_single_literal_row_is_enough_mirroring_the_fe_gate_exactly():
+    # The FE gate is `some(matchType === 'literal')` -- not a ratio. Mirror it,
+    # so this tool never refuses a page the corpus would happily publish.
+    report = build_page("Testville", _mixed_response(literal=1, vibe=5))
+    assert report.verified_book_count == 6
+
+
+# -- item 3: a trailing slash on the documented override must not 404 --
+
+
+def test_backend_url_trailing_slash_is_stripped_before_the_request(monkeypatch, tmp_path):
+    from tools.generate_books_set_in_corpus import main
+
+    seen: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # httpx preserves the doubled slash, so this asserts the real URL path.
+        seen["path"] = request.url.path
+        return httpx.Response(200, json=load_fixture())
+
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.Client  # captured BEFORE patching, or the lambda recurses into itself
+    monkeypatch.setattr(httpx, "Client", lambda *a, **k: real_client(transport=transport))
+
+    out = tmp_path / "out.json"
+    exit_code = main(["--city", "Barcelona", "--out", str(out), "--backend-url", "http://localhost:8090/"])
+
+    assert exit_code == 0
+    assert seen["path"] == "/api/v1/place-to-book", (
+        f"a trailing slash produced {seen['path']!r} -- a directly-hosted ASGI app 404s on the doubled slash"
+    )

--- a/tools/generate_books_set_in_corpus.py
+++ b/tools/generate_books_set_in_corpus.py
@@ -1,0 +1,308 @@
+"""
+books-set-in corpus generator (MYS-431, PR2 of MYS-204).
+
+Offline, one-off batch job that produces per-city book<->place records
+conforming to storyland-web's `booksSetInPlace` schema (`src/data/
+booksSetInPlace.ts`'s `validatePlace`/`validateBook`, mirrored in
+`validate_place`/`validate_book` below).
+
+Design decision, load-bearing: this generator does NOT call Gemini directly
+and does NOT duplicate ai-side grounding. It calls the backend's already-live,
+already-grounded, already-existence-verified `GET /api/v1/place-to-book`
+endpoint (storyland-services `app/place_to_book`), which already runs the
+`place_to_book_agent` researcher/formatter pipeline AND decorates every
+candidate with a real Google Books / Open Library existence check
+(`PlaceBook.grounding.verified`). Re-implementing that pipeline here would
+duplicate a paid Gemini call this app already makes for real users, and would
+violate the standing rule that book-existence verification lives on the BE via
+Google Books, not ai-side (see docs/CLAUDE.md and models/place_to_book.py's own
+docstring). One HTTP call to an already-deployed, already-costed endpoint is
+the whole "generation" step; this script's only real job is validating and
+reshaping that response into the FE's corpus schema.
+
+The bar, restated because it is the whole point (per the ticket): "We'd rather
+show fewer titles than invent one." Only rows with `grounding.verified is
+True` are kept -- an ungrounded/unverified candidate is dropped, never padded
+in. A city that ends up with zero verified rows is refused outright (an
+empty `books[]` is build-fatal on the FE loader anyway; better to fail loudly
+here than ship a thin or empty page).
+
+Usage:
+    python generate_books_set_in_corpus.py --city Barcelona --out out.json
+    python generate_books_set_in_corpus.py --batch cities.txt   # NOT implemented in this PR (see main())
+
+Environment:
+    BACKEND_URL - base URL of storyland-services (default:
+        https://mystoryland.ai). No GOOGLE_API_KEY or any Gemini credential
+        is read by this script -- see the design note above.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import unicodedata
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+DEFAULT_BACKEND_URL = "https://mystoryland.ai"
+PLACE_TO_BOOK_PATH = "/api/v1/place-to-book"
+REQUEST_TIMEOUT_SECONDS = 30.0
+
+# Cycled by book index within a page, matching the existing 11-city seed
+# corpus's rotating placeholder palette (src/data/booksSetInPlace.json) so a
+# generated page visually matches the hand-authored ones until a real cover
+# image is resolved client-side (BookCover lookupOnMissing) or `image_url`
+# (passed through from the BE response below) is used instead.
+COVER_GRADIENT_PALETTE: tuple[str, ...] = (
+    "linear-gradient(135deg,#4a5e6b,#2c3840)",
+    "linear-gradient(135deg,#6b4a5e,#402c38)",
+    "linear-gradient(135deg,#4a6b4f,#2c402f)",
+    "linear-gradient(135deg,#6b6f4a,#40422c)",
+    "linear-gradient(135deg,#3f3550,#262035)",
+    "linear-gradient(135deg,#5e4a4a,#382c2c)",
+    "linear-gradient(135deg,#4a566b,#2c3340)",
+)
+
+
+class GeneratorError(Exception):
+    """Build-fatal error: the generator refuses to write non-conformant output."""
+
+
+def place_slug(name: str) -> str:
+    """Lowercase, hyphenated, ASCII-only slug for a place name.
+
+    MUST stay byte-for-byte in lockstep with storyland-web's
+    `src/data/booksSetInPlace.ts::placeSlug()` -- the FE loader rejects any
+    record whose `slug` isn't exactly `placeSlug(place)` (MYS-204's build-time
+    gate for generated rows). Re-implemented here rather than shared because
+    this is a different repo/language; a test pins both against the same
+    fixture set to keep them from drifting apart.
+    """
+    if not name:
+        return ""
+    normalized = unicodedata.normalize("NFKD", name)
+    # Strip combining marks (accents) the way the FE's regex range does.
+    stripped = "".join(ch for ch in normalized if not unicodedata.combining(ch))
+    lowered = stripped.lower()
+    hyphenated = re.sub(r"[^a-z0-9]+", "-", lowered)
+    return hyphenated.strip("-")
+
+
+def _is_nonempty_str(v: Any) -> bool:
+    return isinstance(v, str) and v.strip() != ""
+
+
+def validate_book(raw: dict[str, Any], where: str) -> dict[str, Any]:
+    """Mirror of booksSetInPlace.ts's validateBook. Raises GeneratorError on
+    any violation -- if this generator's output can't pass this check, it
+    can't pass the FE build either, so fail here first."""
+    if not isinstance(raw, dict):
+        raise GeneratorError(f"{where} is not an object")
+    if not _is_nonempty_str(raw.get("title")):
+        raise GeneratorError(f'{where} has a missing/empty "title"')
+    if not _is_nonempty_str(raw.get("author")):
+        raise GeneratorError(f'{where} has a missing/empty "author"')
+    if not _is_nonempty_str(raw.get("why")):
+        raise GeneratorError(f'{where} has a missing/empty "why"')
+    if not _is_nonempty_str(raw.get("cover")):
+        raise GeneratorError(f'{where} has a missing/empty "cover"')
+    match_type = raw.get("matchType")
+    if match_type not in ("literal", "vibe"):
+        raise GeneratorError(f'{where} has an invalid "matchType" (expected literal|vibe)')
+    maps_to = raw.get("mapsTo")
+    if match_type == "literal" and not _is_nonempty_str(maps_to):
+        raise GeneratorError(
+            f"{where} has matchType 'literal' but missing or empty mapsTo -- "
+            "literal rows require a map anchor"
+        )
+    if maps_to is not None and not _is_nonempty_str(maps_to):
+        raise GeneratorError(f'{where} has an empty "mapsTo"')
+    image_url = raw.get("image_url")
+    if image_url is not None and not _is_nonempty_str(image_url):
+        raise GeneratorError(f'{where} has an empty "image_url"')
+    return raw
+
+
+def validate_place(raw: dict[str, Any]) -> dict[str, Any]:
+    """Mirror of booksSetInPlace.ts's validatePlace (single-record form, since
+    this generator emits one record per run)."""
+    if not isinstance(raw, dict):
+        raise GeneratorError("record is not an object")
+    slug = raw.get("slug")
+    place = raw.get("place")
+    if not _is_nonempty_str(slug):
+        raise GeneratorError('record has a missing/empty "slug"')
+    if not _is_nonempty_str(place):
+        raise GeneratorError('record has a missing/empty "place"')
+    expected_slug = place_slug(place.strip())
+    if slug.strip() != expected_slug:
+        raise GeneratorError(
+            f'record has a slug "{slug}" that does not match its place "{place}" -- '
+            f'expected "{expected_slug}"'
+        )
+    if not _is_nonempty_str(raw.get("intro")):
+        raise GeneratorError('record has a missing/empty "intro"')
+    books = raw.get("books")
+    if not isinstance(books, list) or len(books) == 0:
+        raise GeneratorError('record has an empty or missing "books" array')
+    for i, b in enumerate(books):
+        validate_book(b, f'record "{slug}" book #{i}')
+    return raw
+
+
+@dataclass
+class GenerationReport:
+    """Measured facts about one generator run, for the founder spot-review."""
+
+    city: str
+    verified_book_count: int
+    dropped_unverified_count: int
+    backend_wall_clock_seconds: float
+    page: dict[str, Any] = field(repr=False)
+
+
+def fetch_place_to_book(city: str, backend_url: str, client: httpx.Client) -> dict[str, Any]:
+    """Call the backend's already-live, already-grounded, already-existence-
+    verified place->book endpoint. Raises on a non-200 or a `found: false`
+    response (an ungroundable city -- refuse rather than ship an empty page)."""
+    resp = client.get(
+        f"{backend_url}{PLACE_TO_BOOK_PATH}",
+        params={"place": city},
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+    resp.raise_for_status()
+    body = resp.json()
+    if not body.get("found"):
+        raise GeneratorError(
+            f'"{city}" was not groundable by the backend '
+            f'(found=false, message={body.get("message")!r}) -- dropping rather than padding'
+        )
+    return body
+
+
+def build_page(city: str, backend_response: dict[str, Any]) -> GenerationReport:
+    """Reshape a PlaceToBookResponse-shaped dict into a validated
+    BooksSetInPlacePage-shaped dict, keeping only grounding-verified rows."""
+    raw_books = backend_response.get("books", [])
+    verified = [b for b in raw_books if isinstance(b, dict) and b.get("grounding", {}).get("verified") is True]
+    dropped = len(raw_books) - len(verified)
+
+    if not verified:
+        raise GeneratorError(
+            f'"{city}": 0 of {len(raw_books)} candidate(s) passed the grounding.verified '
+            "bar -- refusing to ship an empty/thin page rather than pad it"
+        )
+
+    place = backend_response.get("place") or city
+    slug = place_slug(place)
+
+    books: list[dict[str, Any]] = []
+    for i, b in enumerate(verified):
+        book: dict[str, Any] = {
+            "title": b["title"],
+            "author": b["author"],
+            "matchType": b["match_type"],
+            "why": b["why_it_fits"],
+            "cover": COVER_GRADIENT_PALETTE[i % len(COVER_GRADIENT_PALETTE)],
+        }
+        if b.get("maps_to"):
+            book["mapsTo"] = b["maps_to"]
+        if b.get("image_url"):
+            book["image_url"] = b["image_url"]
+        books.append(book)
+
+    literal_titles = [b["title"] for b in books if b["matchType"] == "literal"]
+    # Deterministic, no-extra-LLM-call intro: a template, not a second Gemini
+    # pass. Matches the fixed closing sentence every hand-authored seed page
+    # already uses (src/data/booksSetInPlace.json) so a generated page reads
+    # as one voice with the existing 11. A Content role can hand-polish the
+    # opening clause before publish; the schema/grounding contract below is
+    # the build-fatal part, not the prose.
+    if literal_titles:
+        opening = f"{literal_titles[0]} is among the books genuinely set in {place}."
+    else:
+        opening = f"{place} has inspired more books than most guides let on."
+    intro = (
+        f"{opening} The books below are drawn from Storyland's book↔place "
+        "engine and checked against real locations, so each one points to "
+        "somewhere you can actually stand."
+    )
+
+    page = {
+        "slug": slug,
+        "place": place,
+        "intro": intro,
+        "books": books,
+    }
+    validate_place(page)
+
+    return GenerationReport(
+        city=city,
+        verified_book_count=len(books),
+        dropped_unverified_count=dropped,
+        backend_wall_clock_seconds=0.0,  # filled in by the CLI, which times the HTTP call
+        page=page,
+    )
+
+
+def run_one_city(city: str, backend_url: str) -> GenerationReport:
+    import time
+
+    with httpx.Client() as client:
+        t0 = time.monotonic()
+        backend_response = fetch_place_to_book(city, backend_url, client)
+        elapsed = time.monotonic() - t0
+    report = build_page(city, backend_response)
+    report.backend_wall_clock_seconds = elapsed
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--city", help="Single city to generate (e.g. 'Barcelona')")
+    parser.add_argument(
+        "--batch",
+        help="Path to a newline-separated city list for a full batch run",
+    )
+    parser.add_argument("--out", default="books_set_in_generated.json", help="Output JSON path")
+    parser.add_argument("--backend-url", default=DEFAULT_BACKEND_URL)
+    args = parser.parse_args(argv)
+
+    if args.batch:
+        # Deliberately not implemented in this PR. MYS-431's own scope note:
+        # "Run the generator against ONE city first, report the real
+        # per-city token/$ figure, and stop. Do not fire the 40-90-city batch
+        # in the same run." Batch mode is a separate PR once the founder has
+        # reviewed this run's sample + cost figure and the city list is
+        # agreed.
+        print(
+            "Batch mode is intentionally not implemented in this PR (MYS-431 scope: "
+            "one city, report cost, stop). Run --city repeatedly once the founder "
+            "has agreed the city list for the batch PR.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not args.city:
+        parser.error("either --city or --batch is required")
+
+    report = run_one_city(args.city, args.backend_url)
+    with open(args.out, "w", encoding="utf-8") as f:
+        json.dump([report.page], f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+    print(
+        f'"{args.city}": {report.verified_book_count} verified book(s) kept, '
+        f"{report.dropped_unverified_count} unverified dropped, "
+        f"backend call {report.backend_wall_clock_seconds:.2f}s -> {args.out}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/generate_books_set_in_corpus.py
+++ b/tools/generate_books_set_in_corpus.py
@@ -25,7 +25,10 @@ show fewer titles than invent one." Only rows with `grounding.verified is
 True` are kept -- an ungrounded/unverified candidate is dropped, never padded
 in. A city that ends up with zero verified rows is refused outright (an
 empty `books[]` is build-fatal on the FE loader anyway; better to fail loudly
-here than ship a thin or empty page).
+here than ship a thin or empty page). A city whose verified rows are ALL
+kindred (`vibe`) is refused too: storyland-web's `isPublishableBooksSetInPlace`
+(MYS-455) requires at least one `literal` row before a page may be published,
+so "verified" alone is this tool's bar, not the corpus's.
 
 Usage:
     python generate_books_set_in_corpus.py --city Barcelona --out out.json
@@ -80,8 +83,10 @@ def place_slug(name: str) -> str:
     `src/data/booksSetInPlace.ts::placeSlug()` -- the FE loader rejects any
     record whose `slug` isn't exactly `placeSlug(place)` (MYS-204's build-time
     gate for generated rows). Re-implemented here rather than shared because
-    this is a different repo/language; a test pins both against the same
-    fixture set to keep them from drifting apart.
+    this is a different repo/language. There is deliberately no cross-repo pin
+    here -- CI cannot run both sides -- so the real guard is that the FE's
+    `validatePlace` is build-fatal on a slug mismatch. (Corrected in r2: this
+    docstring used to claim a shared-fixture test that does not exist.)
     """
     if not name:
         return ""
@@ -217,20 +222,45 @@ def build_page(city: str, backend_response: dict[str, Any]) -> GenerationReport:
         books.append(book)
 
     literal_titles = [b["title"] for b in books if b["matchType"] == "literal"]
+    vibe_count = len(books) - len(literal_titles)
+
+    # MYS-431 r1 (Eng Lead), item 2: mirror storyland-web's SECOND, stricter
+    # gate. The verified bar above is this tool's bar; `isPublishableBooksSetInPlace`
+    # (booksSetInPlace.ts, MYS-455) is the CORPUS's bar -- a page needs at least
+    # one LITERAL row, because the h1, <title> and ItemList JSON-LD all assert a
+    # "set in <place>" relationship an all-kindred page does not contain. Without
+    # this, a city returning 6 verified-but-all-vibe rows printed "6 verified
+    # book(s) kept", exited 0, and produced a page the FE will never publish --
+    # invisible at --city scale, silent at 90 cities.
+    if not literal_titles:
+        raise GeneratorError(
+            f'"{city}": {len(books)} verified row(s) kept but 0 are matchType '
+            "'literal' -- storyland-web's isPublishableBooksSetInPlace (MYS-455) "
+            "refuses an all-kindred page, so this city is unpublishable: its h1 and "
+            "ItemList would assert a set-in relationship the corpus does not contain"
+        )
+
     # Deterministic, no-extra-LLM-call intro: a template, not a second Gemini
-    # pass. Matches the fixed closing sentence every hand-authored seed page
-    # already uses (src/data/booksSetInPlace.json) so a generated page reads
-    # as one voice with the existing 11. A Content role can hand-polish the
-    # opening clause before publish; the schema/grounding contract below is
-    # the build-fatal part, not the prose.
-    if literal_titles:
-        opening = f"{literal_titles[0]} is among the books genuinely set in {place}."
+    # pass.
+    #
+    # MYS-431 r1 (Eng Lead), item 1: the closing clause must not claim a
+    # property the rows do not have. A `vibe` row legitimately carries no
+    # `mapsTo` at all, so on a mixed page the unscoped "each one points to
+    # somewhere you can actually stand" is FALSE for every kindred row -- the
+    # render-"we-don't-know"-as-a-positive-claim class (MYS-584/MYS-492), and
+    # worse here because these are indexable pages whose whole proposition is
+    # that we checked. `greece` is the one seed page that solved it, by scoping
+    # the clause to "the literal entries"; that form is copied here for any page
+    # carrying kindred rows. An all-literal page keeps the unscoped form, which
+    # is honest for it. (The zero-literal case can no longer reach this code.)
+    opening = f"{literal_titles[0]} is among the books genuinely set in {place}."
+    if vibe_count:
+        claim = "so the literal entries point to somewhere you can actually stand."
     else:
-        opening = f"{place} has inspired more books than most guides let on."
+        claim = "so each one points to somewhere you can actually stand."
     intro = (
         f"{opening} The books below are drawn from Storyland's book↔place "
-        "engine and checked against real locations, so each one points to "
-        "somewhere you can actually stand."
+        f"engine and checked against real locations, {claim}"
     )
 
     page = {
@@ -272,6 +302,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--out", default="books_set_in_generated.json", help="Output JSON path")
     parser.add_argument("--backend-url", default=DEFAULT_BACKEND_URL)
     args = parser.parse_args(argv)
+    # MYS-431 r1 (Eng Lead), item 3 (from Codex): `--backend-url http://host:8090/`
+    # would request `//api/v1/place-to-book`, which a directly-hosted ASGI app
+    # treats as a distinct path and 404s. The default carries no trailing slash,
+    # so this never fired in the Barcelona run -- it only breaks the documented
+    # override, for the person most likely to use it (a local backend).
+    args.backend_url = args.backend_url.rstrip("/")
 
     if args.batch:
         # Deliberately not implemented in this PR. MYS-431's own scope note:


### PR DESCRIPTION
## Why

[MYS-204](https://linear.app/mystoryland/issue/MYS-204) wants the books-set-in SEO corpus grown from 10 to 50-100 cities. Founder approved live Gemini spend for this generator (#approvals, 2026-07-11) on the condition it run against **ONE city first, report the real per-city cost, and stop** — not fire the 40-90-city batch in the same PR.

## What

`tools/generate_books_set_in_corpus.py`, a `--city` CLI that produces one storyland-web `booksSetInPlace`-schema-conformant record.

**Design decision, load-bearing:** this generator does **not** call Gemini directly and does not re-implement ai-side grounding. It calls the backend's already-live `GET /api/v1/place-to-book` endpoint (storyland-services `app/place_to_book`), which already runs the `place_to_book_agent` researcher/formatter pipeline **and** decorates every candidate with a real Google Books/Open Library existence check. This respects the standing rule that book-existence verification lives on the BE, not ai-side (see `models/place_to_book.py`'s own docstring) — reusing the live endpoint means zero new paid-API surface and zero duplicated Gemini spend beyond what this app already spends for real users.

**Two bars, not one (r2):** only rows with `grounding.verified == true` are kept — an ungrounded candidate is dropped, never padded in. A city with zero verified rows is refused. **And** a city whose verified rows are all kindred (`vibe`) is refused too, because storyland-web's `isPublishableBooksSetInPlace` ([MYS-455](https://linear.app/mystoryland/issue/MYS-455)) requires at least one `literal` row before a page may be published. "Verified" is this tool's bar; "publishable" is the corpus's.

`--batch` is an explicit, tested no-op in this PR — it refuses before ever touching the network. Batch mode is a separate PR once the founder reviews this run's sample + cost figure and the city list is agreed.

## The one-city run

Ran against **Barcelona** (not yet in the 10-city seed corpus) on live prod:

- **8/8 candidates passed the verified bar** — 5 literal, 3 vibe. Nothing dropped.
- **Backend call: 11.5s wall-clock** (agent workflow itself: 8.24s per the Langfuse trace).
- **Real measured cost** (Langfuse traceId `c90d32547e64357bfe8f2e5ca19c4c52`, 2026-07-29T16:03:48Z):
  - `place_to_book_researcher` call_llm: 475 in / 1,014 out tokens — $0.00328
  - `place_to_book_formatter` call_llm: 1,463 in / 1,012 out tokens — $0.003768
  - **Total: 3,964 tokens, $0.007047 for the full workflow**
- At that rate, a 90-city batch would run **about $0.63 total** — confirms the founder's original near-zero-spend assessment.

Sample corpus output and the full cost/token breakdown are attached to [MYS-431](https://linear.app/mystoryland/issue/MYS-431) for spot-review, along with the real captured backend response this was built from (also committed as the test fixture, so the review is against ground truth, not a hand-written approximation).

## Docs

No doc impact — new standalone offline tool, no route/contract/schema change (output conforms to an existing FE schema unchanged by this PR).

## Verification

20 tests (`tests/unit/test_generate_books_set_in_corpus.py`), including ones run against the real captured Barcelona backend response (`tests/unit/fixtures/barcelona_backend_response.json`) asserting the exact 5-literal/3-vibe split, `mapsTo`/`image_url` passthrough, and the FE validator contract. `ruff check` clean.

- Full unit suite — **986 passed**, coverage **90.16%** against the `fail_under = 74` ratchet.
- 7 tests in `test_discovery_errors.py` / `test_run_harness.py` fail **in the sandbox only**: `asyncio.TaskGroup`/`ExceptionGroup` cancellation semantics differ between the sandbox's Python **3.10** and CI's **3.12**. Reproduced identically with this PR's change stashed, so they are not from this diff. CI on 3.12 is the authority.
- **Red-before-green, r2:** reverting all three r2 fixes fails exactly 4 of the new tests; restored, 20/20 pass.

### r1 → r2 history

**r1:** the first push was **CI-red at collection** — the test file imported the module top-level, which only resolves when pytest runs from inside `tools/`. `tools` is a package. Fixed; the exact `ModuleNotFoundError` was reproduced locally first. The lesson is the useful part: 0 tests ran while the body claimed "all 14 pass".

**r2 (fix-list round 1, three items):**

1. **The intro claimed an anchor the kindred rows don't have.** The template said *"each one points to somewhere you can actually stand"* while a `vibe` row legitimately carries no `mapsTo` at all — false for 3 of Barcelona's 8 rows, on indexable pages whose whole proposition is that we checked. Now scoped to *"the literal entries point to…"* whenever the page carries any kindred row; an all-literal page keeps the unscoped form, which is true for it.
2. **The tool's success bar wasn't the corpus's publish bar.** An all-vibe city printed `"6 verified book(s) kept"`, exited 0, and produced a page the FE will never publish. Now refused here, where the cause is, mirroring `isPublishableBooksSetInPlace` exactly (`some(matchType === 'literal')` — not a ratio, so a single literal row still passes).
3. **Trailing slash on `--backend-url`** produced `//api/v1/place-to-book`, which a directly-hosted ASGI app 404s. `rstrip("/")` at parse time.

Also corrected `place_slug`'s docstring, which claimed a cross-repo fixture test that does not exist; the real guard is the FE's build-fatal `validatePlace`.

### One correction to the fix-list's supporting evidence

The fix-list's item 1 is right, but its evidence isn't, and the difference matters for what happens next. It said Greece is *"the one seed page that mixes literal and vibe"* and that *"Edinburgh and London do use the unscoped form — but both are all-literal pages."*

I read all 11 seed pages rather than take that. **Edinburgh is 4 literal + 1 vibe, and Dublin is 5 literal + 2 vibe — both mixed, both carrying the unscoped claim, both live and indexable today.** Seven other pages (paris, venice, tokyo, lisbon, new-york-city, saint-petersburg, rome) make no stand-anywhere claim at all; Greece alone scopes it. So the corpus does not already solve this — it contains one page that solved it and two that have the same defect this fix-list is about.

I implemented the Greece form as asked, because it's the most informative honest option. The two live pages are a content defect I can't fix in an ai PR (FE data, and the wording is a copy call) — filed separately rather than left in a PR comment.

— Staff Engineer, 2026-07-29