### PR TITLE
fix(sentry): drop bare-query span/trace-data keys the '?' scrub misses (MYS-551 ai twin)

### DIFF
--- a/api/sentry.py
+++ b/api/sentry.py
@@ -82,6 +82,27 @@ logger = get_logger(__name__)
 # in access lines and any other URL-bearing stdlib log reaching Sentry Logs.
 _URL_QUERY_RE = re.compile(r"\?[^\s\"]*")
 
+# Span/trace attribute keys whose VALUE is a bare query string with no
+# leading '?' (MYS-551, ai twin of the gateway defect): sentry-sdk's HTTPX
+# integration stores span.data['http.query'] = 'q=<user search>'. The
+# '?'-heuristic below can never fire on those values, so the KEY is dropped
+# outright. Matches http.query / url.query / query_string style names.
+_QUERY_KEY_RE = re.compile(r"(^|[._])query($|[._])", re.IGNORECASE)
+
+
+def _scrub_data_record(data):
+    """
+    Scrub one span/trace attribute dict in place (MYS-551): query-named keys
+    are DELETED (their whole value is the query — nothing to strip back to),
+    every other string value loses any '?' tail. Same two rules as the
+    gateway (storyland-services#127) and the frontend (storyland-web#310).
+    """
+    for key, value in list(data.items()):
+        if _QUERY_KEY_RE.search(key):
+            del data[key]
+        elif isinstance(value, str) and "?" in value:
+            data[key] = _URL_QUERY_RE.sub("", value)
+
 
 def _drop_health_probe_logs(log, hint):
     """
@@ -154,9 +175,17 @@ def _scrub_event(event, hint):
                 span["description"] = _URL_QUERY_RE.sub("", description)
             data = span.get("data")
             if isinstance(data, dict):
-                for key, value in list(data.items()):
-                    if isinstance(value, str) and "?" in value:
-                        data[key] = _URL_QUERY_RE.sub("", value)
+                _scrub_data_record(data)
+    # The ROOT span's attributes are serialized separately, as
+    # contexts.trace.data — same record shape, same rules (parity with the
+    # gateway's MYS-551 fix and storyland-web#310 round 2).
+    contexts = event.get("contexts")
+    if isinstance(contexts, dict):
+        trace = contexts.get("trace")
+        if isinstance(trace, dict):
+            trace_data = trace.get("data")
+            if isinstance(trace_data, dict):
+                _scrub_data_record(trace_data)
     return event
 
 

--- a/tests/unit/test_sentry.py
+++ b/tests/unit/test_sentry.py
@@ -236,6 +236,52 @@ class TestHealthProbeLogFilter:
         assert out3["spans"][0]["description"] == "GET http://u/v"
         assert out3["spans"][0]["data"]["url"] == "http://u/v"
 
+    def test_span_bare_query_keys_dropped(self):
+        """MYS-551 (ai twin of the gateway defect): the HTTPX integration
+        stores the query WITHOUT a leading '?' in span.data['http.query'] —
+        the '?' heuristic never fires, so the key must be dropped. Reds
+        against pre-fix main."""
+        event = {
+            "spans": [
+                {
+                    "description": "GET http://u/v",
+                    "data": {
+                        "http.query": "book_title=secret+title",
+                        "url.query": "place=Paris",
+                        "http.request.method": "GET",
+                        "status": 200,
+                    },
+                }
+            ]
+        }
+        out = _scrub_event(event, {})
+        data = out["spans"][0]["data"]
+        assert "http.query" not in data
+        assert "url.query" not in data
+        assert data["http.request.method"] == "GET"
+        assert data["status"] == 200
+
+    def test_root_trace_context_data_scrubbed(self):
+        """MYS-551 companion: the ROOT span's attributes land in
+        contexts.trace.data, not event['spans'] (storyland-web#310 r2
+        parity)."""
+        event = {
+            "contexts": {
+                "trace": {
+                    "data": {
+                        "url.full": "http://u/api/v1/discover?book_title=secret",
+                        "http.query": "book_title=secret",
+                        "keep": "plain",
+                    }
+                }
+            }
+        }
+        out = _scrub_event(event, {})
+        trace_data = out["contexts"]["trace"]["data"]
+        assert trace_data["url.full"] == "http://u/api/v1/discover"
+        assert "http.query" not in trace_data
+        assert trace_data["keep"] == "plain"
+
     def test_round5_parity(self, monkeypatch):
         """storyland-services#92 round 5: dict params + extras scrubbed,
         health crumbs dropped, tracing None when off / kept when opted in."""


### PR DESCRIPTION
## Why

Twin of [MYS-551](https://linear.app/mystoryland/issue/MYS-551) confirmed 2026-08-02 (the Eng Lead's infra#59 review scoped the finding to the gateway and flagged this service as an unchecked surface; checking it found the same `if "?" in value` predicate on span data). `span.data['http.query']` holds the bare query with no leading `?` — the scrub never fires, and with tracing on, user search terms (`book_title=…`, `place=…`) would survive a scrubbed transaction. Gates the `.env.prod` `SENTRY_TRACES_SAMPLE_RATE=1.0` flip (MYS-735).

## What

Same fix as the gateway ([services#127](https://github.com/o-ostrovskiy/storyland-services/pull/127)) and frontend ([web#310](https://github.com/o-ostrovskiy/storyland-web/pull/310)): `_scrub_data_record` deletes query-named keys (`(^|[._])query($|[._])`, case-insensitive) and keeps the `?`-tail scrub for other strings — applied to every span's `data` and the root span's `contexts.trace.data`.

## Docs

Inline docstrings carry the MYS-551 rationale and cross-repo parity references. No standalone docs page covers scrubbing internals.

## Verification

**Red-before-green proven**: both new tests fail against pre-fix `main`, pass after. Suite: 1004 passing; the 4 failing integration tests (`test_cache_real_api`, `test_langfuse_integration` ×3) **fail identically on clean main** — environment-dependent (live API / Langfuse env), untouched by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)