### PR TITLE
fix(ai): set trace-level input/output so Langfuse stops rendering prod traces blank (MYS-788)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -953,12 +953,13 @@ Add an isolated, gateway-internal capability that routes a **place back to books
 
 ## 21. API Abuse + Operational Hardening (grouped; 2026-06-23 → 07-17)
 
-Four smaller decisions, recorded together:
+Five smaller decisions, recorded together:
 
 - **Rate limiting + concurrency cap** (2026-06-23): per-identity request rate limit and in-flight concurrency cap on discovery endpoints (`api/ratelimit.py`); input-size bounds return 422 **before** any Gemini tokens are spent.
 - **Bounded session retention** (2026-06-24): a periodic retention sweep (`services/session_retention.py`) bounds the in-memory/SQLite session store — extends ADR #6, which predates it.
 - **Recommendation-tone guardrail** (2026-06-28): rec explanations are fit-only and never grade the reader (`core/guardrails/tone_guardrail.py`).
 - **Langfuse per-branch scoping** (2026-07-17, MYS-398): generation/agent-stack/span state is scoped **per ParallelAgent branch** (`_branch_key()` in `plugins/langfuse_plugin.py`) — per-request plugin instances (ADR #8) were not enough under the ADR #3 parallel fan-out.
+- **Langfuse trace-level I/O written explicitly** (2026-08-05, MYS-788): the plugin sets input/output on the trace as well as on its root span (`set_trace_io()` in `plugins/langfuse_plugin.py`), because Langfuse's session view and trace list render **trace**-level I/O — setting only the root span's made every production trace display as "This trace has no input or output" despite a complete span tree. Python SDK v4 dropped `update_current_trace()` and deprecates trace I/O in favour of the observations-first model, but `propagate_attributes()` carries correlating attributes only (user/session/tags/metadata), so `set_trace_io()` is the sole remaining writer for those two fields; revisit when those views read observations instead. Trace output is the run's final-response text, picked with the same rule as `core/run_harness.py` (last event where `is_final_response()` is true).
 
 ---
 

--- a/plugins/langfuse_plugin.py
+++ b/plugins/langfuse_plugin.py
@@ -141,6 +141,14 @@ class LangfusePlugin(BasePlugin):
         self._agent_stacks: dict[str, list] = {}  # branch key -> that branch's own LIFO agent stack
         self._spans: dict[str, Any] = {}  # branch key -> open tool span
         self._propagation_cm = None
+        # Last final-response event text, used as the trace's output. A plain
+        # scalar is correct here even under ParallelAgent: unlike the
+        # before_model/after_model pairs above, events are consumed one at a
+        # time off the Runner's single event stream, so there is no
+        # interleaving to scope per branch. "Last event whose
+        # is_final_response() is true" is the same rule core/run_harness.py
+        # already uses to pick a run's answer.
+        self._final_response_text: Optional[str] = None
 
         if not LANGFUSE_AVAILABLE:
             logger.info("langfuse_unavailable", reason="package_not_installed")
@@ -250,6 +258,15 @@ class LangfusePlugin(BasePlugin):
                 },
                 input=str(user_message),
             )
+            # Mirror the root span's input onto the TRACE. Langfuse's session
+            # view and trace list render trace-level I/O, not the root span's,
+            # so without this every production trace displays as "This trace
+            # has no input or output" even though the span tree is complete.
+            # v4's observations-first model deprecates trace I/O in favour of
+            # propagate_attributes(), but propagate_attributes carries only
+            # correlating attributes (user/session/tags) -- set_trace_io is
+            # still the only way to populate the fields those views read.
+            self._current_trace.set_trace_io(input=str(user_message))
             logger.debug("langfuse_trace_created", trace_id=self._current_trace.trace_id, user_id=user_id)
         except Exception as e:
             logger.warning("langfuse_trace_error", error=str(e), error_type=type(e).__name__)
@@ -518,6 +535,26 @@ class LangfusePlugin(BasePlugin):
 
         return None
 
+    async def on_event_callback(
+        self, *, invocation_context: InvocationContext, event: Any
+    ) -> None:
+        """Remember the run's answer so after_run can set it as trace output."""
+        if not self.enabled or not self.client or not self._current_trace:
+            return None
+
+        try:
+            if not event.is_final_response():
+                return None
+            content = getattr(event, "content", None)
+            parts = getattr(content, "parts", None) or []
+            texts = [t for t in (getattr(p, "text", None) for p in parts) if t]
+            if texts:
+                self._final_response_text = "".join(texts)
+        except Exception as e:
+            logger.warning("langfuse_event_error", error=str(e), error_type=type(e).__name__)
+
+        return None
+
     async def after_run_callback(
         self, *, invocation_context: InvocationContext
     ) -> None:
@@ -534,6 +571,15 @@ class LangfusePlugin(BasePlugin):
                     "total_cost_usd": self._total_cost_usd,
                 },
             )
+            # Trace-level output, for the same reason as the input above. Falls
+            # back to the status blob only when the run produced no final-
+            # response text (error paths), so the trace never renders blank.
+            # set_trace_io drops None fields, so this cannot clear the input.
+            self._current_trace.set_trace_io(
+                output=self._final_response_text
+                if self._final_response_text is not None
+                else {"status": "completed"}
+            )
             self._current_trace.end()
             logger.info(
                 "langfuse_invocation_complete",
@@ -545,6 +591,7 @@ class LangfusePlugin(BasePlugin):
         except Exception as e:
             logger.warning("langfuse_finalize_error", error=str(e), error_type=type(e).__name__)
         finally:
+            self._final_response_text = None
             if self._propagation_cm:
                 self._propagation_cm.__exit__(None, None, None)
                 self._propagation_cm = None
@@ -567,6 +614,7 @@ class LangfusePlugin(BasePlugin):
         """Reset token usage statistics."""
         self._token_usage = TokenUsage()
         self._total_cost_usd = 0.0
+        self._final_response_text = None
 
     async def flush(self) -> None:
         """Flush pending Langfuse events."""

--- a/tests/unit/test_langfuse_trace_io.py
+++ b/tests/unit/test_langfuse_trace_io.py
@@ -1,0 +1,208 @@
+"""Unit tests pinning trace-level input/output on LangfusePlugin (MYS-788).
+
+Langfuse's session view and trace list render the TRACE's input/output, not
+the root span's. The plugin set both on the root span only, so every
+production trace displayed as "This trace has no input or output" even though
+the span tree underneath was complete -- see the session that surfaced it:
+us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/sessions/2492a1a4-26b5-45f0-bcde-afb9a76295fc
+
+Python SDK v4 moved trace attributes to propagate_attributes(), but that
+context manager carries only correlating attributes (user_id/session_id/
+tags/metadata) -- set_trace_io() remains the only way to populate the two
+fields those views actually read, which is why the plugin calls a method the
+SDK marks deprecated.
+
+Same fake-based approach as test_langfuse_plugin_concurrency.py: the plugin
+only ever calls methods on self.client / self._current_trace, so neither a
+real Langfuse client nor live credentials are needed.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from plugins.langfuse_plugin import LangfusePlugin
+
+
+class FakeRootSpan:
+    """Root observation that records set_trace_io/update/end separately."""
+
+    def __init__(self):
+        self.trace_io = []       # set_trace_io kwargs, in call order
+        self.updates = []        # update() kwargs (root-span I/O)
+        self.ended = False
+        self.trace_id = "trace-abc"
+
+    def set_trace_io(self, **kwargs):
+        # Mirror the SDK: None-valued fields are dropped, so a later
+        # output-only call can never clear an earlier input.
+        self.trace_io.append({k: v for k, v in kwargs.items() if v is not None})
+        return self
+
+    def start_observation(self, **kwargs):
+        return FakeRootSpan()
+
+    def update(self, **kwargs):
+        self.updates.append(kwargs)
+
+    def end(self):
+        self.ended = True
+
+
+class FakeClient:
+    def __init__(self, root):
+        self._root = root
+
+    def start_observation(self, **kwargs):
+        return self._root
+
+
+def _make_plugin(root=None):
+    plugin = LangfusePlugin(secret_key=None, public_key=None, host=None)
+    plugin.enabled = True
+    root = root or FakeRootSpan()
+    plugin.client = FakeClient(root)
+    plugin._current_trace = root
+    return plugin, root
+
+
+def _invocation_context():
+    # agent=None mirrors every Runner(node=...) root on ADK 2.5, which is why
+    # the plugin falls back to the injected root_name -- see _resolve_root_name.
+    return SimpleNamespace(
+        invocation_id="inv-1",
+        user_id="anon:test",
+        session=SimpleNamespace(id="sess-1"),
+        agent=None,
+    )
+
+
+def _event(text, final=True):
+    """Minimal ADK Event stand-in: on_event_callback reads is_final_response()
+    and content.parts[*].text, nothing else."""
+    parts = [SimpleNamespace(text=t) for t in ([text] if isinstance(text, str) else text)]
+    return SimpleNamespace(
+        is_final_response=lambda: final,
+        content=SimpleNamespace(parts=parts),
+    )
+
+
+class TestTraceInput:
+    async def test_user_message_lands_on_the_trace_not_only_the_span(self, monkeypatch):
+        plugin, root = _make_plugin()
+        monkeypatch.setattr(
+            "plugins.langfuse_plugin.propagate_attributes",
+            lambda **kwargs: SimpleNamespace(
+                __enter__=lambda *a: None, __exit__=lambda *a: None
+            ),
+        )
+        plugin.root_name = "book_to_place_discovery"
+
+        await plugin.on_user_message_callback(
+            invocation_context=_invocation_context(), user_message="Where is 1984 set?"
+        )
+
+        assert root.trace_io, "trace-level input was never set -- session view renders blank"
+        assert "1984" in str(root.trace_io[0]["input"])
+
+
+class TestTraceOutput:
+    async def test_final_response_becomes_the_trace_output(self):
+        plugin, root = _make_plugin()
+
+        await plugin.on_event_callback(
+            invocation_context=_invocation_context(), event=_event("London, Airstrip One.")
+        )
+        await plugin.after_run_callback(invocation_context=_invocation_context())
+
+        outputs = [io["output"] for io in root.trace_io if "output" in io]
+        assert outputs == ["London, Airstrip One."]
+
+    async def test_multipart_final_response_is_joined(self):
+        plugin, root = _make_plugin()
+
+        await plugin.on_event_callback(
+            invocation_context=_invocation_context(),
+            event=_event(["London, ", "Airstrip One."]),
+        )
+        await plugin.after_run_callback(invocation_context=_invocation_context())
+
+        assert root.trace_io[-1]["output"] == "London, Airstrip One."
+
+    async def test_last_final_response_wins(self):
+        plugin, root = _make_plugin()
+
+        for text in ("first pass", "second pass"):
+            await plugin.on_event_callback(
+                invocation_context=_invocation_context(), event=_event(text)
+            )
+        await plugin.after_run_callback(invocation_context=_invocation_context())
+
+        assert root.trace_io[-1]["output"] == "second pass"
+
+    async def test_non_final_events_are_ignored(self):
+        plugin, root = _make_plugin()
+
+        await plugin.on_event_callback(
+            invocation_context=_invocation_context(),
+            event=_event("intermediate chatter", final=False),
+        )
+        await plugin.after_run_callback(invocation_context=_invocation_context())
+
+        # No final response -> status blob, never a blank trace.
+        assert root.trace_io[-1]["output"] == {"status": "completed"}
+
+    async def test_error_path_with_no_events_still_sets_an_output(self):
+        plugin, root = _make_plugin()
+
+        await plugin.after_run_callback(invocation_context=_invocation_context())
+
+        assert root.trace_io[-1]["output"] == {"status": "completed"}
+        assert root.ended is True
+
+
+class TestStateHygiene:
+    async def test_final_response_does_not_leak_into_the_next_run(self):
+        plugin, root = _make_plugin()
+
+        await plugin.on_event_callback(
+            invocation_context=_invocation_context(), event=_event("run one answer")
+        )
+        await plugin.after_run_callback(invocation_context=_invocation_context())
+
+        # Second invocation on the same plugin instance produces no final
+        # response: it must NOT re-report run one's answer.
+        plugin._current_trace = root
+        await plugin.after_run_callback(invocation_context=_invocation_context())
+
+        assert root.trace_io[-1]["output"] == {"status": "completed"}
+
+    async def test_reset_stats_clears_the_captured_response(self):
+        plugin, _ = _make_plugin()
+
+        await plugin.on_event_callback(
+            invocation_context=_invocation_context(), event=_event("answer")
+        )
+        plugin.reset_stats()
+
+        assert plugin._final_response_text is None
+
+    async def test_malformed_event_does_not_raise(self):
+        plugin, root = _make_plugin()
+
+        # content=None is what ADK emits for tool-only / control events.
+        bad = SimpleNamespace(is_final_response=lambda: True, content=None)
+        await plugin.on_event_callback(invocation_context=_invocation_context(), event=bad)
+
+        assert plugin._final_response_text is None
+
+    async def test_disabled_plugin_sets_nothing(self):
+        plugin, root = _make_plugin()
+        plugin.enabled = False
+
+        await plugin.on_event_callback(
+            invocation_context=_invocation_context(), event=_event("answer")
+        )
+        await plugin.after_run_callback(invocation_context=_invocation_context())
+
+        assert root.trace_io == []


### PR DESCRIPTION
## Why

Every production trace renders as **"This trace has no input or output"** in Langfuse's session view, with empty Input/Output columns in the trace list — even though the span tree underneath is complete (48 observations, generations with I/O, tokens, cost).

Surfaced on [this session](https://us.cloud.langfuse.com/project/cml1naeqj01adad07nx6cwg0u/sessions/2492a1a4-26b5-45f0-bcde-afb9a76295fc).

**Ingestion was never broken.** The plugin sets input/output on the root **span** observation only — `start_observation(input=...)` and `.update(output={"status": "completed"})`. Nothing writes to the **trace**, and those views render trace-level I/O. Confirmed via the API: 0 of 32 prod traces from Jul 27 → Aug 5 carry trace-level input; eval runs (`default` env) do (25/25 Jul 20, 15/15 Jul 26, 18/18 Aug 2) because that path wraps the run in `@observe`.

## What

- Mirror the user message onto the trace in `on_user_message_callback`
- New `on_event_callback` captures the run's final-response text, reusing `core/run_harness.py`'s rule — last event where `is_final_response()` is true
- `after_run_callback` sets that as trace output, falling back to the status blob when a run produced no final response, so error paths never render blank either

### On the deprecated call

Python SDK v4 (we're on 4.14.0) removed `update_current_trace()`. `set_trace_io()` is deprecated in favour of the observations-first model, but `propagate_attributes()` — already used here for trace_name/user/session — carries correlating attributes only, **not** input/output. `set_trace_io()` is the only remaining way to populate the two fields these views read. Removal is tracked as follow-up on MYS-788.

### Concurrency note

`_final_response_text` is a plain scalar, not per-branch like `_generations`/`_models` (MYS-398). That's safe: events are consumed one at a time off the Runner's single event stream, so there's no interleaving to isolate.

## Docs

`docs/ARCHITECTURE.md` ADR #21 gains a fifth entry — **Langfuse trace-level I/O written explicitly** — recording why the plugin writes trace I/O separately from the root span, why it calls an SDK-deprecated method, and the condition under which that call should be removed (when Langfuse's session/trace views read observations instead).

## Verification

- 10 new unit tests in `tests/unit/test_langfuse_trace_io.py` — input mirroring, multipart joins, last-final-wins, non-final ignored, error-path fallback, no leak across runs, malformed events, disabled plugin
- Full unit suite: **1005 passed**
- **Live against prod Langfuse**: ran the real plugin callbacks with a live client; trace `bba3e6a155d2a71e89422252c2957c72` reads back `input: "Where is 1984 set?"` / `output: "Winston walks through Victory Square."`, and the session view renders both panels instead of the blank-state message

Hotfix — off-train, per the deploy path in MYS-678.

Closes MYS-788

🤖 Generated with [Claude Code](https://claude.com/claude-code)